### PR TITLE
Fix KeyColor equality function

### DIFF
--- a/common/changes/@bentley/imodeljs-common/fix-key-color-equals_2020-10-29-15-24.json
+++ b/common/changes/@bentley/imodeljs-common/fix-key-color-equals_2020-10-29-15-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Fix KeyColor equality comparison.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/core/common/src/Gradient.ts
+++ b/core/common/src/Gradient.ts
@@ -62,7 +62,7 @@ export namespace Gradient {
 
   /** Compare two KeyColor objects for equality. Returns true if equal. */
   export function keyColorEquals(a: KeyColor, b: KeyColor): boolean {
-    return (a.value === b.value) || a.color.equals(b.color);
+    return (a.value === b.value) && a.color.equals(b.color);
   }
 
   /** Multi-color area fill defined by a range of colors that vary by position */


### PR DESCRIPTION
Equality function for two KeyColor objects needs to use && instead of ||.