### PR TITLE
Samw/improve concurrency control api

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -810,7 +810,11 @@ export class ConcurrencyControl {
     abandonRequest(): void;
     abandonResources(requestContext: AuthorizedClientRequestContext): Promise<void>;
     areAvailable(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean>;
+    // @internal @deprecated (undocumented)
     areCodesAvailable(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean>;
+    // @internal (undocumented)
+    areCodesAvailable0(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean>;
+    // @internal @deprecated (undocumented)
     areCodesAvailable2(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<boolean>;
     areLocksAvailable(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean>;
     buildConcurrencyControlRequestForDb(): void;
@@ -824,32 +828,43 @@ export class ConcurrencyControl {
     buildRequestForRelationship(_instance: RelationshipProps, _opcode: DbOpcode): void;
     // @alpha
     get channel(): ConcurrencyControl.Channel;
-    get codes(): ConcurrencyControl.Codes;
-    // @internal (undocumented)
+    get codes(): ConcurrencyControl.CodesManager;
     endBulkMode(rqctx: AuthorizedClientRequestContext): Promise<void>;
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     getHeldElementLock(elementId: Id64String): LockLevel;
-    // (undocumented)
+    // @internal @deprecated (undocumented)
     getHeldLock(type: LockType, objectId: Id64String): LockLevel;
-    // (undocumented)
+    // @internal (undocumented)
+    getHeldLock0(type: LockType, objectId: Id64String): LockLevel;
+    // @internal @deprecated (undocumented)
     getHeldModelLock(modelId: Id64String): LockLevel;
     // @internal (undocumented)
     getPolicy(): ConcurrencyControl.PessimisticPolicy | ConcurrencyControl.OptimisticPolicy;
-    // @alpha
+    // @internal @deprecated (undocumented)
     get hasCodeSpecsLock(): boolean;
     get hasPendingRequests(): boolean;
-    // @alpha
+    // @internal @deprecated (undocumented)
     hasReservedCode(code: CodeProps): boolean;
-    // @alpha
+    // (undocumented)
+    hasReservedCode0(code: CodeProps): boolean;
+    // @internal @deprecated (undocumented)
     get hasSchemaLock(): boolean;
-    // @alpha
+    // @internal @deprecated (undocumented)
     holdsLock(lock: ConcurrencyControl.LockProps): boolean;
     // @internal (undocumented)
-    get iModel(): BriefcaseDb;
+    holdsLock0(lock: ConcurrencyControl.LockProps): boolean;
     // @internal (undocumented)
+    get iModel(): BriefcaseDb;
     get isBulkMode(): boolean;
+    // @internal @deprecated (undocumented)
     lockCodeSpecs(requestContext: AuthorizedClientRequestContext): Promise<Lock[]>;
+    // @internal (undocumented)
+    lockCodeSpecs0(requestContext: AuthorizedClientRequestContext): Promise<Lock[]>;
+    get locks(): ConcurrencyControl.LocksManager;
+    // @internal @deprecated (undocumented)
     lockSchema(requestContext: AuthorizedClientRequestContext): Promise<Lock[]>;
+    // @internal (undocumented)
+    lockSchema0(requestContext: AuthorizedClientRequestContext): Promise<Lock[]>;
     // @internal (undocumented)
     get modelsAffectedByWrites(): Id64String[];
     // @internal (undocumented)
@@ -882,28 +897,21 @@ export class ConcurrencyControl {
     onSavedChanges(): void;
     // @internal (undocumented)
     onUndoRedo(): void;
-    // (undocumented)
-    openOrCreateCache(requestContext: AuthorizedClientRequestContext): Promise<void>;
     // @internal (undocumented)
     get pendingRequest(): ConcurrencyControl.Request;
-    // @internal
+    // @internal @deprecated (undocumented)
     queryCodeStates(requestContext: AuthorizedClientRequestContext, specId: Id64String, scopeId: string, value?: string): Promise<HubCode[]>;
     request(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<void>;
     requestResources(ctx: AuthorizedClientRequestContext, elements: ConcurrencyControl.ElementAndOpcode[], models?: ConcurrencyControl.ModelAndOpcode[], relationships?: ConcurrencyControl.RelationshipAndOpcode[]): Promise<void>;
-    // @internal (undocumented)
     requestResourcesForDelete(ctx: AuthorizedClientRequestContext, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void>;
-    // @internal (undocumented)
     requestResourcesForInsert(ctx: AuthorizedClientRequestContext, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void>;
     // @internal (undocumented)
     requestResourcesForOpcode(ctx: AuthorizedClientRequestContext, opcode: DbOpcode, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void>;
-    // @alpha
     requestResourcesForUpdate(ctx: AuthorizedClientRequestContext, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void>;
-    // @internal
+    // @internal @deprecated (undocumented)
     reserveCodes(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<HubCode[]>;
     setPolicy(policy: ConcurrencyControl.PessimisticPolicy | ConcurrencyControl.OptimisticPolicy): void;
-    // @internal (undocumented)
     startBulkMode(): void;
-    // (undocumented)
     syncCache(requestContext: AuthorizedClientRequestContext): Promise<void>;
 }
 
@@ -943,8 +951,11 @@ export namespace ConcurrencyControl {
         // (undocumented)
         readonly ownerInfo: any;
     }
-    export class Codes {
+    export class CodesManager {
+        // @internal
         constructor(_iModel: BriefcaseDb);
+        areAvailable(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<boolean>;
+        isReserved(code: CodeProps): boolean;
         query(requestContext: AuthorizedClientRequestContext, specId: Id64String, scopeId: string, value?: string): Promise<HubCode[]>;
         reserve(requestContext: AuthorizedClientRequestContext, codes?: CodeProps[]): Promise<void>;
     }
@@ -968,6 +979,22 @@ export namespace ConcurrencyControl {
         objectId: string;
         // (undocumented)
         type: LockType;
+    }
+    export class LocksManager {
+        // @internal
+        constructor(_iModel: BriefcaseDb);
+        // @alpha
+        getHeldElementLock(elementId: Id64String): LockLevel;
+        // @alpha
+        getHeldLock(type: LockType, objectId: Id64String): LockLevel;
+        // @alpha
+        getHeldModelLock(modelId: Id64String): LockLevel;
+        get hasCodeSpecsLock(): boolean;
+        get hasSchemaLock(): boolean;
+        holdsLock(lock: ConcurrencyControl.LockProps): boolean;
+        lockCodeSpecs(requestContext: AuthorizedClientRequestContext): Promise<Lock[]>;
+        lockModels(requestContext: AuthorizedClientRequestContext, models: ModelProps[]): Promise<void>;
+        lockSchema(requestContext: AuthorizedClientRequestContext): Promise<Lock[]>;
     }
     // (undocumented)
     export interface ModelAndOpcode {

--- a/common/changes/@bentley/imodel-bridge/samw-improve-concurrency-control-api_2020-10-30-12-32.json
+++ b/common/changes/@bentley/imodel-bridge/samw-improve-concurrency-control-api_2020-10-30-12-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-bridge",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodel-bridge",
+  "email": "69692709+swwilson-bsi@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/samw-improve-concurrency-control-api_2020-10-30-12-06.json
+++ b/common/changes/@bentley/imodeljs-backend/samw-improve-concurrency-control-api_2020-10-30-12-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Reorganize ConcurrencyControl API",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "69692709+swwilson-bsi@users.noreply.github.com"
+}

--- a/core/backend/src/ConcurrencyControl.ts
+++ b/core/backend/src/ConcurrencyControl.ts
@@ -32,6 +32,7 @@ const loggerCategory: string = BackendLoggerCategory.ConcurrencyControl;
 export class ConcurrencyControl {
   private _pendingRequest = new ConcurrencyControl.Request();
   private _codes?: ConcurrencyControl.Codes;
+  private _locks?: ConcurrencyControl.Locks;
   private _policy: ConcurrencyControl.PessimisticPolicy | ConcurrencyControl.OptimisticPolicy;
   private _bulkMode: boolean = false;
   private _cache: ConcurrencyControl.StateCache;
@@ -66,7 +67,16 @@ export class ConcurrencyControl {
     return this._policy === ConcurrencyControl.PessimisticPolicy;
   }
 
-  /** @internal */
+  /** Start "bulk update mode". This mode is designed for bulk-loading or bulk-updating apps. It avoids the expense
+   * of acquiring many locks and codes individually by deferring them to a single bulk request at the end.
+   * In bulk update mode, you don't have to request locks and codes on elements or models before changing them in the briefcase.
+   * Instead, ConcurrencyControl keeps track of the locks and codes that will be needed needed. You must call endBulkMode
+   * before calling BriefcaseDb.saveChanges. That sends a single request for all of the required resources.
+   * Bulk update mode works with either optimistic or pessimistic concurrency policy. Bulk update mode does not represent
+   * different locking policy; it just defers the request of locks and codes.
+   * Bulk mode is a reasonable choice only when you know there is no chance of conflicts.
+   * @beta
+   */
   public startBulkMode() {
     if (this._bulkMode)
       throw new IModelError(IModelStatus.BadRequest, "Already in bulk mode", Logger.logError, loggerCategory);
@@ -75,12 +85,21 @@ export class ConcurrencyControl {
     this._bulkMode = true;
   }
 
-  /** @internal */
+  /**
+   * Query if changes are being monitored in "bulk update mode".
+   * @beta
+   */
   public get isBulkMode() {
     return this._bulkMode;
   }
 
-  /** @internal */
+  /**
+   * Call this when in bulk mode and before calling BriefcaseDb.saveChanges. This function sends a single request to the
+   * iModel server for all locks and codes that are required for the changes that you have made since calling startBulkMode.
+   * If the request fails, then you must call BriefcaseDb.abandonChanges.
+   * Bulk mode is a reasonable choice only when you know there is no chance of conflicts.
+   * @beta
+   */
   public async endBulkMode(rqctx: AuthorizedClientRequestContext) {
     if (!this._bulkMode)
       throw new IModelError(IModelStatus.BadRequest, "Not in bulk mode", Logger.logError, loggerCategory);
@@ -124,12 +143,19 @@ export class ConcurrencyControl {
 
   private applyTransactionOptions() { }
 
+  /** You must call this if you use classes other than ConcurrencyControl to manage locks and codes.
+   * For example, if you call IModelHost.imodelClient to call IModelClient functions directly to
+   * acquire or release locks or to reserve or reliquish codes, you must follow up by calling
+   * this function to allow ConcurrencyControl to synchronize its local resources cache with the
+   * actual state of locks and codes on the server.
+   * @beta
+   */
   public async syncCache(requestContext: AuthorizedClientRequestContext): Promise<void> {
     this._cache.clear();
     return this._cache.populate(requestContext);
   }
 
-  public async openOrCreateCache(requestContext: AuthorizedClientRequestContext): Promise<void> {
+  private async openOrCreateCache(requestContext: AuthorizedClientRequestContext): Promise<void> {
     if (this.iModel.isReadonly)
       throw new IModelError(IModelStatus.BadRequest, "not read-write", Logger.logError, loggerCategory);
     if (this._cache.isOpen)
@@ -165,10 +191,7 @@ export class ConcurrencyControl {
     }
   }
 
-  /**
-   * An app calls this method directly (or via Model.buildConcurrencyControlRequest) when it wants to acquire resources preemptively, before performing an editing operation.
-   * @internal [[Model.buildConcurrencyControlRequest]]
-   */
+  /** @internal [[Model.buildConcurrencyControlRequest]] */
   public buildRequestForModel(model: ModelProps, opcode: DbOpcode): void {
     const req = new ConcurrencyControl.Request();
     this.buildRequestForModelTo(req, model, opcode);
@@ -209,10 +232,7 @@ export class ConcurrencyControl {
     this._cache.insertLocks([ConcurrencyControl.Request.getModelLock(id, LockLevel.Exclusive)], this.iModel.txns.getCurrentTxnId());
   }
 
-  /**
-   * An app calls this method directly (or via Element.buildConcurrencyControlRequest) when it wants to acquire resources preemptively, before performing an editing operation.
-   * @internal [[Element.buildConcurrencyControlRequest]]
-   */
+  /** @internal [[Element.buildConcurrencyControlRequest]] */
   public buildRequestForElement(element: ElementProps, opcode: DbOpcode): void {
     const req = new ConcurrencyControl.Request();
     this.buildRequestForElementTo(req, element, opcode);
@@ -262,7 +282,7 @@ export class ConcurrencyControl {
   }
 
   /**
-   * Request the locks and/or Codes that will be required to carry out the intended write operations. This is a convenience method. It builds the requests and then sends them to the iModel server.
+   * Request the locks and/or Codes that will be required to carry out the intended write operations. This is a convenience method. It builds a request and sends it to the iModel server.
    * @param ctx RequestContext
    * @param elements The elements that will be written
    * @param models The models that will be written
@@ -332,26 +352,44 @@ export class ConcurrencyControl {
     }
   }
 
-  /** @internal */
+  /**
+   * Request the locks and/or Codes that will be required to insert the specified elements and/or models. This is a convenience method. It builds a request and sends it to the iModel server. It does not insert the elements or models.
+   * @param ctx RequestContext
+   * @param elements The elements that will be inserted
+   * @param models The models that will be inserted
+   * @param relationships The relationships that will be inserted
+   * See [[ConcurrencyControl.requestResources]], [[ConcurrencyControl.requestResourcesForUpdate]], [[ConcurrencyControl.requestResourcesForDelete]]
+   * @beta
+   */
   public async requestResourcesForInsert(ctx: AuthorizedClientRequestContext, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void> {
     return this.requestResourcesForOpcode(ctx, DbOpcode.Insert, elements, models, relationships);
   }
 
   /**
-   * Preemptively request exclusive locks on one or more elements and/or models.
+   * Request the locks and/or Codes that will be required to update the specified elements and/or models. This is a convenience method. It builds a request and sends it to the iModel server. It does not update the elements or models.
    * @param requestContext The client request context
    * @param elements The elements to lock
    * @param models The models to lock
    * @throws [[IModelHubError]] if some or all of the request could not be fulfilled by iModelHub.
    * @throws [[IModelError]] if the IModelDb is not open or is not connected to an iModel.
    * See [CodeHandler]($imodelhub-client) and [LockHandler]($imodelhub-client) for details on what errors may be thrown.
-   * @alpha
+   * See [[ConcurrencyControl.requestResources]], [[ConcurrencyControl.requestResourcesForInsert]], [[ConcurrencyControl.requestResourcesForDelete]]
+   * See [[ConcurrencyControl.Locks.lockModels]]
+   * @beta
    */
   public async requestResourcesForUpdate(ctx: AuthorizedClientRequestContext, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void> {
     return this.requestResourcesForOpcode(ctx, DbOpcode.Update, elements, models, relationships);
   }
 
-  /** @internal */
+  /**
+   * Request the locks and/or Codes that will be required to delete the specified elements and/or models. This is a convenience method. It builds a request and sends it to the iModel server. It does not delete the elements or models.
+   * @param ctx RequestContext
+   * @param elements The elements that will be deleted
+   * @param models The models that will be delete
+   * @param relationships The relationships that will be deleted
+   * See [[ConcurrencyControl.requestResources]], [[ConcurrencyControl.requestResourcesForUpdate]], [[ConcurrencyControl.requestResourcesForInsert]]
+   * @beta
+   */
   public async requestResourcesForDelete(ctx: AuthorizedClientRequestContext, elements: ElementProps[], models?: ModelProps[], relationships?: RelationshipProps[]): Promise<void> {
     return this.requestResourcesForOpcode(ctx, DbOpcode.Delete, elements, models, relationships);
   }
@@ -394,7 +432,7 @@ export class ConcurrencyControl {
     else
       this.cull(req);
 
-    await this.reserveCodes(requestContext, req.codes); // throws if any code cannot be reserved
+    await this.reserveCodes0(requestContext, req.codes); // throws if any code cannot be reserved
     requestContext.enter();
 
     await this.acquireLocks(requestContext, req.locks); // throws if any lock cannot be acquired.
@@ -426,6 +464,7 @@ export class ConcurrencyControl {
    * You should call this when you call IModelDb.abandonChanges.
    * This is called automatically by BriefcaseDb.cancelChanges and by BriefcaseDb.pushChanges in the event that there are
    * no changes to push.
+   * @beta
    */
   public async abandonResources(requestContext: AuthorizedClientRequestContext): Promise<void> {
     requestContext.enter();
@@ -496,11 +535,16 @@ export class ConcurrencyControl {
     this.addToPendingRequestIfNotHeld(req);
   }
 
-  /** Obtain the schema lock. This is always an immediate request, never deferred. See [LockHandler]($imodelhub-client) for details on what errors may be thrown. */
+  /** @deprecated Use concurrencyControl.locks.lockSchema */
   public async lockSchema(requestContext: AuthorizedClientRequestContext): Promise<Lock[]> {
+    return this.locks.lockSchema(requestContext);
+  }
+
+  /** @internal */
+  public async lockSchema0(requestContext: AuthorizedClientRequestContext): Promise<Lock[]> {
     const locks = [ConcurrencyControl.Request.getHubSchemaLock(this)];
 
-    if (this.hasSchemaLock)
+    if (this.locks.hasSchemaLock)
       return locks;
 
     requestContext.enter();
@@ -516,45 +560,47 @@ export class ConcurrencyControl {
     return res;
   }
 
-  /** Returns `true` if the schema lock is held.
-   * @param requestContext The client request context
-   * @alpha Need to determine if we want this method
-   */
+  /** @deprecated Use concurrencyControl.locks.hasSchemaLock */
   public get hasSchemaLock(): boolean {
-    return this.holdsLock(ConcurrencyControl.Request.schemaLock);
+    return this.locks.hasSchemaLock;
   }
 
-  /** Returns `true` if the CodeSpecs lock is held.
-   * @param requestContext The client request context
-   * @alpha Need to determine if we want this method
-   */
+  /** @deprecated Use concurrencyControl.locks.hasCodeSpecsLock */
   public get hasCodeSpecsLock(): boolean {
-    return this.holdsLock(ConcurrencyControl.Request.codeSpecsLock);
+    return this.locks.hasCodeSpecsLock;
   }
 
-  /** Returns `true` if the specified lock is held.
-   * @param lock The lock to check
-   * @alpha
-   */
+  /** @deprecated Use concurrencyControl.locks.holdsLock */
   public holdsLock(lock: ConcurrencyControl.LockProps): boolean {
+    return this.locks.holdsLock(lock);
+  }
+
+  /** @internal */
+  public holdsLock0(lock: ConcurrencyControl.LockProps): boolean {
     return this._cache.isLockHeld(lock);
   }
 
-  /** Returns `true` if the specified code has been reserved by this briefcase.
-   * @param code The code to check
-   * Also see [[ConcurrencyControl.areCodesAvailable]] and [[ConcurrencyControl.areCodesAvailable2]]
-   * @alpha
-   */
+  /** @deprecated concurrencyControl.codes.isReserved */
   public hasReservedCode(code: CodeProps): boolean {
+    return this.codes.isReserved(code);
+  }
+
+  public hasReservedCode0(code: CodeProps): boolean {
     return this._cache.isCodeReserved(code);
   }
 
-  /** Obtain the CodeSpec lock. This is always an immediate request, never deferred. See [LockHandler]($imodelhub-client) for details on what errors may be thrown. */
+
+  /** @deprecated Use ConcurrencyControl.Locks.lockCodeSpecs */
   public async lockCodeSpecs(requestContext: AuthorizedClientRequestContext): Promise<Lock[]> {
+    return this.lockCodeSpecs0(requestContext);
+  }
+
+  /** @internal */
+  public async lockCodeSpecs0(requestContext: AuthorizedClientRequestContext): Promise<Lock[]> {
 
     const locks = [ConcurrencyControl.Request.getHubCodeSpecsLock(this)];
 
-    if (this.hasCodeSpecsLock)
+    if (this.locks.hasCodeSpecsLock)
       return locks;
 
     requestContext.enter();
@@ -570,16 +616,24 @@ export class ConcurrencyControl {
     return res;
   }
 
+  /** @deprecated */
   public getHeldLock(type: LockType, objectId: Id64String): LockLevel {
+    return this.locks.getHeldLock(type, objectId);
+  }
+
+  /** @internal */
+  public getHeldLock0(type: LockType, objectId: Id64String): LockLevel {
     return this._cache.getHeldLock(type, objectId);
   }
 
+  /** @deprecated */
   public getHeldModelLock(modelId: Id64String): LockLevel {
-    return this.getHeldLock(LockType.Model, modelId);
+    return this.locks.getHeldLock(LockType.Model, modelId);
   }
 
+  /** @deprecated */
   public getHeldElementLock(elementId: Id64String): LockLevel {
-    return this.getHeldLock(LockType.Element, elementId);
+    return this.locks.getHeldLock(LockType.Element, elementId);
   }
 
   private checkLockRestrictions(locks: ConcurrencyControl.LockProps[]) {
@@ -612,8 +666,12 @@ export class ConcurrencyControl {
     return lockStates;
   }
 
-  /** @internal Apps should use ConcurrencyControl.codes.request */
+  /** @deprecated Apps should use ConcurrencyControl.codes.request */
   public async reserveCodes(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<HubCode[]> {
+    return this.reserveCodes0(requestContext, codes);
+  }
+
+  private async reserveCodes0(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<HubCode[]> {
     requestContext.enter();
 
     if (codes.length === 0)
@@ -632,35 +690,15 @@ export class ConcurrencyControl {
     return codeStates;
   }
 
-  /** @internal - use ConcurrencyControl.codes.query or ConcurrencyControl.hasReservedCode */
+
+  /** @deprecated Apps should use ConcurrencyControl.codes.query or ConcurrencyControl.codes.isReserved */
   public async queryCodeStates(requestContext: AuthorizedClientRequestContext, specId: Id64String, scopeId: string, value?: string): Promise<HubCode[]> {
-    requestContext.enter();
-    if (!this._iModel.isOpen)
-      throw new Error("not open");
-
-    const query = new CodeQuery();
-
-    if (value !== undefined) {
-      query.byCodes(ConcurrencyControl.Request.toHubCodes(this, [{ spec: specId, scope: scopeId, value }]));
-    } else {
-      query.byCodeSpecId(specId).byCodeScope(scopeId);
-    }
-
-    return BriefcaseManager.imodelClient.codes.get(requestContext, this._iModel.briefcase.iModelId, query);
+    return this.codes.query(requestContext, specId, scopeId, value);
   }
 
-  /**
-   * Check to see if *all* of the specified codes are available.
-   * @param requestContext The client request context
-   * @param req the list of code requests to be fulfilled. If not specified then all pending requests for codes are queried.
-   * @returns true if all codes are available or false if any is not.
-   * @beta
-   */
+  /** @deprecated concurrencyControl.codes.areAvailable */
   public async areCodesAvailable2(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<boolean> {
-    requestContext.enter();
-    const req = new ConcurrencyControl.Request();
-    req.addCodes(codes);
-    return this.areCodesAvailable(requestContext, req);
+    return this.codes.areAvailable(requestContext, codes);
   }
 
   /** Abandon any pending requests for locks or codes. */
@@ -669,13 +707,13 @@ export class ConcurrencyControl {
     this._cache.deleteLocksForTxn(this.iModel.txns.getCurrentTxnId());
   }
 
-  /**
-   * Check to see that this briefcase could reserve (or has already reserved) all of the specified Codes.
-   * @param requestContext The client request context
-   * @param req the codes to be checked for their available status. If not specified then all pending requests for codes are queried.
-   * @returns true if all codes are available or false if any is not.
-   */
+  /** @deprecated concurrencyControl.codes.areAvailable */
   public async areCodesAvailable(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean> {
+    return this.areCodesAvailable0(requestContext, req);
+  }
+
+  /** @internal */
+  public async areCodesAvailable0(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean> {
     requestContext.enter();
     if (!this._iModel.isOpen)
       throw new Error("not open");
@@ -769,7 +807,7 @@ export class ConcurrencyControl {
     if (req.isEmpty)
       return true;
 
-    const allCodesAreAvailable = await this.areCodesAvailable(requestContext, req);
+    const allCodesAreAvailable = await this.areCodesAvailable0(requestContext, req);
     requestContext.enter();
     if (!allCodesAreAvailable)
       return false;
@@ -809,11 +847,18 @@ export class ConcurrencyControl {
     this.applyTransactionOptions();
   }
 
-  /** API to reserve Codes and query the status of Codes */
+  /** API to reserve Codes and to query the status of Codes */
   public get codes(): ConcurrencyControl.Codes {
     if (this._codes === undefined)
       this._codes = new ConcurrencyControl.Codes(this._iModel);
     return this._codes;
+  }
+
+  /** API to acquire locks preemtively and to query the status of locks */
+  public get locks(): ConcurrencyControl.Locks {
+    if (this._locks === undefined)
+      this._locks = new ConcurrencyControl.Locks(this._iModel);
+    return this._locks;
   }
 }
 
@@ -880,7 +925,7 @@ export namespace ConcurrencyControl { // eslint-disable-line no-redeclare
         throw new ChannelConstraintError("Not in a channel");
 
       if (this.channelRoot === Channel.repositoryChannelRoot) {
-        await this._iModel.concurrencyControl.lockSchema(req);
+        await this._iModel.concurrencyControl.locks.lockSchema(req);
         req.enter();
         return;
       }
@@ -892,7 +937,7 @@ export namespace ConcurrencyControl { // eslint-disable-line no-redeclare
     public get isChannelRootLocked(): boolean {
       if (this.channelRoot === undefined)
         return false;
-      return this._iModel.concurrencyControl.holdsLock(ConcurrencyControl.Request.getElementLock(this.channelRoot, LockLevel.Exclusive));
+      return this._iModel.concurrencyControl.holdsLock0(ConcurrencyControl.Request.getElementLock(this.channelRoot, LockLevel.Exclusive));
     }
 
     /** @internal */
@@ -1318,7 +1363,6 @@ export namespace ConcurrencyControl { // eslint-disable-line no-redeclare
 
     /**
      * Reserve Codes.
-     * If no Codes are specified, then all of the Codes that are in currently pending requests are reserved.
      * This function may only be able to reserve some of the requested Codes. In that case, this function will return a rejection of type RequestError.
      * The error object will identify the codes that are unavailable.
      * <p><em>Example:</em>
@@ -1326,7 +1370,7 @@ export namespace ConcurrencyControl { // eslint-disable-line no-redeclare
      * [[include:ConcurrencyControl_Codes.reserve]]
      * ```
      * @param requestContext The client request context
-     * @param codes The Codes to reserve
+     * @param codes The Codes to reserve. If not specified, then all pending code-reservation requests will be processed.
      * @throws [[IModelHubError]]
      */
     public async reserve(requestContext: AuthorizedClientRequestContext, codes?: CodeProps[]): Promise<void> {
@@ -1349,7 +1393,111 @@ export namespace ConcurrencyControl { // eslint-disable-line no-redeclare
      * @param value Optional. The Code value to query.
      */
     public async query(requestContext: AuthorizedClientRequestContext, specId: Id64String, scopeId: string, value?: string): Promise<HubCode[]> {
-      return this._iModel.concurrencyControl.queryCodeStates(requestContext, specId, scopeId, value);
+      requestContext.enter();
+      if (!this._iModel.isOpen)
+        throw new Error("not open");
+
+      const query = new CodeQuery();
+
+      if (value !== undefined) {
+        query.byCodes(ConcurrencyControl.Request.toHubCodes(this._iModel.concurrencyControl, [{ spec: specId, scope: scopeId, value }]));
+      } else {
+        query.byCodeSpecId(specId).byCodeScope(scopeId);
+      }
+
+      return BriefcaseManager.imodelClient.codes.get(requestContext, this._iModel.briefcase.iModelId, query);
+    }
+
+    /** Returns `true` if the specified code has been reserved by this briefcase.
+     * @param code The code to check
+     * @beta
+     */
+    public isReserved(code: CodeProps): boolean {
+      return this._iModel.concurrencyControl.hasReservedCode0(code);
+    }
+
+    /**
+     * Check to see if all of the specified codes are available to be reserved.
+     * @param requestContext The client request context
+     * @param codes the list of codes to be reserved.
+     * @returns true if all codes are available or false if any is not.
+     * @beta
+     */
+    public async areAvailable(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<boolean> {
+      requestContext.enter();
+      const req = new ConcurrencyControl.Request();
+      req.addCodes(codes);
+      return this._iModel.concurrencyControl.areCodesAvailable0(requestContext, req);
+    }
+
+  }
+
+  /** Locks manager */
+  export class Locks {
+    constructor(private _iModel: BriefcaseDb) { }
+
+    /** Obtain the CodeSpec lock. This is always an immediate request, never deferred. See [LockHandler]($imodelhub-client) for details on what errors may be thrown. */
+    public async lockCodeSpecs(requestContext: AuthorizedClientRequestContext): Promise<Lock[]> {
+      return this._iModel.concurrencyControl.lockCodeSpecs0(requestContext);
+    }
+
+    /** Obtain the schema lock. This is always an immediate request, never deferred. See [LockHandler]($imodelhub-client) for details on what errors may be thrown. */
+    public async lockSchema(requestContext: AuthorizedClientRequestContext): Promise<Lock[]> {
+      return this._iModel.concurrencyControl.lockSchema0(requestContext);
+    }
+
+    /** Returns `true` if the schema lock is held.
+     * @param requestContext The client request context
+     * @alpha Need to determine if we want this method
+     */
+    public get hasSchemaLock(): boolean {
+      return this.holdsLock(ConcurrencyControl.Request.schemaLock);
+    }
+
+    /** Returns `true` if the CodeSpecs lock is held.
+     * @param requestContext The client request context
+     * @alpha Need to determine if we want this method
+     */
+    public get hasCodeSpecsLock(): boolean {
+      return this.holdsLock(ConcurrencyControl.Request.codeSpecsLock);
+    }
+
+    /** Returns `true` if the specified lock is held.
+     * @param lock The lock to check
+     * @alpha
+     */
+    public holdsLock(lock: ConcurrencyControl.LockProps): boolean {
+      return this._iModel.concurrencyControl.holdsLock0(lock);
+    }
+
+    /** Get the level at which the specified lock is held by this briefcase.
+     * @alpha
+     */
+    public getHeldLock(type: LockType, objectId: Id64String): LockLevel {
+      return this._iModel.concurrencyControl.getHeldLock0(type, objectId);
+    }
+
+    /** Get the level at which the specified model lock is held by this briefcase.
+     * @alpha
+     */
+    public getHeldModelLock(modelId: Id64String): LockLevel {
+      return this.getHeldLock(LockType.Model, modelId);
+    }
+
+    /** Get the level at which the specified element lock is held by this briefcase.
+     * @alpha
+     */
+    public getHeldElementLock(elementId: Id64String): LockLevel {
+      return this.getHeldLock(LockType.Element, elementId);
+    }
+
+    /** Lock the specified models exclusively.
+     * @param requestContext RequestContext
+     * @param models the models to lock
+     * See [LockHandler]($imodelhub-client) for details on what errors may be thrown.
+     */
+    public lockModels(requestContext: AuthorizedClientRequestContext, models: ModelProps[]): Promise<void> {
+      return this._iModel.concurrencyControl.requestResourcesForUpdate(requestContext, [], models);
     }
   }
 

--- a/core/backend/src/ConcurrencyControl.ts
+++ b/core/backend/src/ConcurrencyControl.ts
@@ -1515,7 +1515,7 @@ export namespace ConcurrencyControl { // eslint-disable-line no-redeclare
      * @param models the models to lock
      * See [LockHandler]($imodelhub-client) for details on what errors may be thrown.
      */
-    public lockModels(requestContext: AuthorizedClientRequestContext, models: ModelProps[]): Promise<void> {
+    public async lockModels(requestContext: AuthorizedClientRequestContext, models: ModelProps[]): Promise<void> {
       return this._iModel.concurrencyControl.requestResourcesForUpdate(requestContext, [], models);
     }
   }

--- a/core/backend/src/ConcurrencyControl.ts
+++ b/core/backend/src/ConcurrencyControl.ts
@@ -560,17 +560,26 @@ export class ConcurrencyControl {
     return res;
   }
 
-  /** @deprecated Use concurrencyControl.locks.hasSchemaLock */
+  /**
+   * @internal
+   * @deprecated Use concurrencyControl.locks.hasSchemaLock
+   */
   public get hasSchemaLock(): boolean {
     return this.locks.hasSchemaLock;
   }
 
-  /** @deprecated Use concurrencyControl.locks.hasCodeSpecsLock */
+  /**
+   * @internal
+   * @deprecated Use concurrencyControl.locks.hasCodeSpecsLock
+   */
   public get hasCodeSpecsLock(): boolean {
     return this.locks.hasCodeSpecsLock;
   }
 
-  /** @deprecated Use concurrencyControl.locks.holdsLock */
+  /**
+   * @internal
+   * @deprecated Use concurrencyControl.locks.holdsLock
+   */
   public holdsLock(lock: ConcurrencyControl.LockProps): boolean {
     return this.locks.holdsLock(lock);
   }
@@ -580,7 +589,10 @@ export class ConcurrencyControl {
     return this._cache.isLockHeld(lock);
   }
 
-  /** @deprecated concurrencyControl.codes.isReserved */
+  /**
+   * @internal
+   * @deprecated concurrencyControl.codes.isReserved
+   */
   public hasReservedCode(code: CodeProps): boolean {
     return this.codes.isReserved(code);
   }
@@ -616,7 +628,10 @@ export class ConcurrencyControl {
     return res;
   }
 
-  /** @deprecated */
+  /**
+   * @internal
+   * @deprecated
+   */
   public getHeldLock(type: LockType, objectId: Id64String): LockLevel {
     return this.locks.getHeldLock(type, objectId);
   }
@@ -626,12 +641,18 @@ export class ConcurrencyControl {
     return this._cache.getHeldLock(type, objectId);
   }
 
-  /** @deprecated */
+  /**
+   * @internal
+   * @deprecated
+   */
   public getHeldModelLock(modelId: Id64String): LockLevel {
     return this.locks.getHeldLock(LockType.Model, modelId);
   }
 
-  /** @deprecated */
+  /**
+   * @internal
+   * @deprecated
+   */
   public getHeldElementLock(elementId: Id64String): LockLevel {
     return this.locks.getHeldLock(LockType.Element, elementId);
   }
@@ -666,7 +687,10 @@ export class ConcurrencyControl {
     return lockStates;
   }
 
-  /** @deprecated Apps should use ConcurrencyControl.codes.request */
+  /**
+   * @internal
+   * @deprecated Use ConcurrencyControl.codes.request
+   */
   public async reserveCodes(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<HubCode[]> {
     return this.reserveCodes0(requestContext, codes);
   }
@@ -691,12 +715,18 @@ export class ConcurrencyControl {
   }
 
 
-  /** @deprecated Apps should use ConcurrencyControl.codes.query or ConcurrencyControl.codes.isReserved */
+  /**
+   * @internal
+   * @deprecated Use ConcurrencyControl.codes.query or ConcurrencyControl.codes.isReserved
+   */
   public async queryCodeStates(requestContext: AuthorizedClientRequestContext, specId: Id64String, scopeId: string, value?: string): Promise<HubCode[]> {
     return this.codes.query(requestContext, specId, scopeId, value);
   }
 
-  /** @deprecated concurrencyControl.codes.areAvailable */
+  /**
+   * @internal
+   * @deprecated concurrencyControl.codes.areAvailable
+   */
   public async areCodesAvailable2(requestContext: AuthorizedClientRequestContext, codes: CodeProps[]): Promise<boolean> {
     return this.codes.areAvailable(requestContext, codes);
   }
@@ -707,7 +737,10 @@ export class ConcurrencyControl {
     this._cache.deleteLocksForTxn(this.iModel.txns.getCurrentTxnId());
   }
 
-  /** @deprecated concurrencyControl.codes.areAvailable */
+  /**
+   * @internal
+   * @deprecated concurrencyControl.codes.areAvailable
+   */
   public async areCodesAvailable(requestContext: AuthorizedClientRequestContext, req?: ConcurrencyControl.Request): Promise<boolean> {
     return this.areCodesAvailable0(requestContext, req);
   }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -709,7 +709,7 @@ export abstract class IModelDb extends IModel {
     }
   }
 
-  /** Abandon pending changes in this iModel - also be sure to call [ConcurrencyControl.abandonResources]($backend) if this is a briefcase. */
+  /** Abandon pending changes in this iModel. You might also want to call [ConcurrencyControl.abandonResources]($backend) if this is a briefcase and you want to relinquish locks or codes that you acquired preemptively. */
   public abandonChanges(): void {
     if (this.isBriefcaseDb() && this.isPushEnabled) {
       this.concurrencyControl.abandonRequest();

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -742,7 +742,7 @@ export abstract class IModelDb extends IModel {
       throw new IModelError(BentleyStatus.ERROR, "Importing the schema requires an AuthorizedClientRequestContext");
     }
     if (this.isBriefcaseDb() && this.isPushEnabled) {
-      await this.concurrencyControl.lockSchema(requestContext);
+      await this.concurrencyControl.locks.lockSchema(requestContext);
       requestContext.enter();
     }
 
@@ -794,7 +794,7 @@ export abstract class IModelDb extends IModel {
       throw new IModelError(BentleyStatus.ERROR, "Importing the schema requires an AuthorizedClientRequestContext");
     }
     if (this.isBriefcaseDb() && this.isPushEnabled) {
-      await this.concurrencyControl.lockSchema(requestContext);
+      await this.concurrencyControl.locks.lockSchema(requestContext);
       requestContext.enter();
     }
 

--- a/core/backend/src/domains/FunctionalSchema.ts
+++ b/core/backend/src/domains/FunctionalSchema.ts
@@ -39,7 +39,7 @@ export class FunctionalSchema extends Schema {
       if (!(requestContext instanceof AuthorizedClientRequestContext)) {
         throw new IModelError(AuthStatus.Error, "Importing the schema requires an AuthorizedClientRequestContext");
       }
-      await iModelDb.concurrencyControl.lockSchema(requestContext);
+      await iModelDb.concurrencyControl.locks.lockSchema(requestContext);
       requestContext.enter();
     }
     const stat = iModelDb.nativeDb.importFunctionalSchema();

--- a/core/backend/src/test/integration/IModelTransformerHub.test.ts
+++ b/core/backend/src/test/integration/IModelTransformerHub.test.ts
@@ -268,9 +268,9 @@ describe("IModelTransformerHub (#integration)", () => {
       const seedBisCoreVersion = sourceDb.querySchemaVersion(BisCoreSchema.schemaName)!;
       assert.isTrue(semver.satisfies(seedBisCoreVersion, ">= 1.0.1"));
       sourceDb.concurrencyControl.setPolicy(ConcurrencyControl.OptimisticPolicy);
-      assert.isFalse(sourceDb.concurrencyControl.hasSchemaLock);
+      assert.isFalse(sourceDb.concurrencyControl.locks.hasSchemaLock);
       await sourceDb.importSchemas(requestContext, [BisCoreSchema.schemaFilePath, GenericSchema.schemaFilePath]);
-      assert.isTrue(sourceDb.concurrencyControl.hasSchemaLock);
+      assert.isTrue(sourceDb.concurrencyControl.locks.hasSchemaLock);
       const updatedBisCoreVersion = sourceDb.querySchemaVersion(BisCoreSchema.schemaName)!;
       assert.isTrue(semver.satisfies(updatedBisCoreVersion, ">= 1.0.10"));
       assert.isTrue(sourceDb.containsClass(ExternalSourceAspect.classFullName), "Expect BisCore to be updated and contain ExternalSourceAspect");
@@ -281,17 +281,17 @@ describe("IModelTransformerHub (#integration)", () => {
       assert.equal(sourceDb.nativeDb.hasPendingTxns(), expectedHasPendingTxns, "Expect importSchemas to have saved changes");
       assert.isFalse(sourceDb.nativeDb.hasUnsavedChanges(), "Expect no unsaved changes after importSchemas");
       await sourceDb.pushChanges(requestContext, "Import schemas to upgrade BisCore"); // may push schema changes
-      assert.isFalse(sourceDb.concurrencyControl.hasSchemaLock);
+      assert.isFalse(sourceDb.concurrencyControl.locks.hasSchemaLock);
 
       // import schemas again to test common scenario of not knowing whether schemas are up-to-date or not..
       await sourceDb.importSchemas(requestContext, [BisCoreSchema.schemaFilePath, GenericSchema.schemaFilePath]);
-      assert.isTrue(sourceDb.concurrencyControl.hasSchemaLock);
-      assert.isTrue(sourceDb.concurrencyControl.hasSchemaLock);
+      assert.isTrue(sourceDb.concurrencyControl.locks.hasSchemaLock);
+      assert.isTrue(sourceDb.concurrencyControl.locks.hasSchemaLock);
       assert.isFalse(sourceDb.nativeDb.hasPendingTxns(), "Expect importSchemas to be a no-op");
       assert.isFalse(sourceDb.nativeDb.hasUnsavedChanges(), "Expect importSchemas to be a no-op");
       sourceDb.saveChanges(); // will be no changes to save in this case
       await sourceDb.pushChanges(requestContext, "Import schemas again"); // will be no changes to push in this case
-      assert.isFalse(sourceDb.concurrencyControl.hasSchemaLock);
+      assert.isFalse(sourceDb.concurrencyControl.locks.hasSchemaLock);
 
       // populate sourceDb
       IModelTransformerUtils.populateTeamIModel(sourceDb, "Test", Point3d.createZero(), ColorDef.green);
@@ -299,7 +299,7 @@ describe("IModelTransformerHub (#integration)", () => {
       await sourceDb.concurrencyControl.request(requestContext);
       sourceDb.saveChanges();
       await sourceDb.pushChanges(requestContext, "Populate Source");
-      assert.isFalse(sourceDb.concurrencyControl.hasSchemaLock);
+      assert.isFalse(sourceDb.concurrencyControl.locks.hasSchemaLock);
 
       // open/upgrade targetDb
       const targetDb = await IModelTestUtils.downloadAndOpenBriefcaseDb(requestContext, projectId, targetIModelId, SyncMode.PullAndPush, IModelVersion.latest());

--- a/core/backend/src/test/integration/IModelWrite.test.ts
+++ b/core/backend/src/test/integration/IModelWrite.test.ts
@@ -111,25 +111,25 @@ describe("IModelWriteTest (#integration)", () => {
     const codeSpec1 = CodeSpec.create(iModel, "MyCodeSpec1", CodeScopeSpec.Type.Model);
     iModel.concurrencyControl.setPolicy(new ConcurrencyControl.OptimisticPolicy());
 
-    const locks = await iModel.concurrencyControl.lockCodeSpecs(superRequestContext);
+    const locks = await iModel.concurrencyControl.locks.lockCodeSpecs(superRequestContext);
     assert.equal(locks.length, 1);
-    const locksRedundant = await iModel.concurrencyControl.lockCodeSpecs(superRequestContext);
+    const locksRedundant = await iModel.concurrencyControl.locks.lockCodeSpecs(superRequestContext);
     assert.equal(locksRedundant.length, 1);
-    assert.isTrue(iModel.concurrencyControl.hasCodeSpecsLock);
+    assert.isTrue(iModel.concurrencyControl.locks.hasCodeSpecsLock);
     iModel.insertCodeSpec(codeSpec1);
     iModel.saveChanges();
     await iModel.pushChanges(superRequestContext, "inserted MyCodeSpec1");
-    assert.isFalse(iModel.concurrencyControl.hasCodeSpecsLock, "pushChanges should automatically release all locks");
+    assert.isFalse(iModel.concurrencyControl.locks.hasCodeSpecsLock, "pushChanges should automatically release all locks");
 
     // Verify that locks are released even if there are no changes.
     const prePushChangesetId = iModel.briefcase.parentChangeSetId;
-    await iModel.concurrencyControl.lockCodeSpecs(superRequestContext);
-    assert.isTrue(iModel.concurrencyControl.hasCodeSpecsLock);
+    await iModel.concurrencyControl.locks.lockCodeSpecs(superRequestContext);
+    assert.isTrue(iModel.concurrencyControl.locks.hasCodeSpecsLock);
     /* make no changes */
     await iModel.pushChanges(superRequestContext, "did nothing");
     assert.equal(prePushChangesetId, iModel.briefcase.parentChangeSetId, "no changeset was pushed");
 
-    assert.isFalse(iModel.concurrencyControl.hasCodeSpecsLock, "pushChanges should automatically release all locks");
+    assert.isFalse(iModel.concurrencyControl.locks.hasCodeSpecsLock, "pushChanges should automatically release all locks");
 
     await IModelTestUtils.closeAndDeleteBriefcaseDb(superRequestContext, iModel);
   });
@@ -390,7 +390,7 @@ describe("IModelWriteTest (#integration)", () => {
     rwIModel.saveChanges("inserted generic objects");
     timer.end();
 
-    assert.isTrue(rwIModel.concurrencyControl.hasReservedCode(code), "I reserved the code newPhysicalModel");
+    assert.isTrue(rwIModel.concurrencyControl.codes.isReserved(code), "I reserved the code newPhysicalModel");
 
     timer = new Timer("push changes");
 
@@ -412,11 +412,11 @@ describe("IModelWriteTest (#integration)", () => {
     // Now verify that code reservations are released even if we call pushChanges with no changes.
     const code2 = IModelTestUtils.getUniqueModelCode(rwIModel, "anotherCode");
     await rwIModel.concurrencyControl.codes.reserve(adminRequestContext, [code2]);
-    assert.isTrue(rwIModel.concurrencyControl.hasReservedCode(code2), "I reserved the code anotherCode");
+    assert.isTrue(rwIModel.concurrencyControl.codes.isReserved(code2), "I reserved the code anotherCode");
     /* make no changes */
     await rwIModel.pushChanges(adminRequestContext, "no changes");
     assert.equal(postPushChangeSetId, rwIModel.changeSetId), "no changeset created or pushed";
-    assert.isFalse(rwIModel.concurrencyControl.hasReservedCode(code2), "I released my reservation of the code anotherCode");
+    assert.isFalse(rwIModel.concurrencyControl.codes.isReserved(code2), "I released my reservation of the code anotherCode");
 
     const codesAfter = await BriefcaseManager.imodelClient.codes.get(adminRequestContext, rwIModelId);
     assert.deepEqual(codesAfter, codes, "The code that used above is still marked as used");
@@ -439,7 +439,7 @@ describe("IModelWriteTest (#integration)", () => {
     const dictionary: DictionaryModel = rwIModel.models.getModel<DictionaryModel>(IModel.dictionaryId);
     const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
     const newCategoryCode2 = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory2");
-    assert.isTrue(await rwIModel.concurrencyControl.areCodesAvailable2(adminRequestContext, [newCategoryCode]));
+    assert.isTrue(await rwIModel.concurrencyControl.codes.areAvailable(adminRequestContext, [newCategoryCode]));
     const subCategory = new SubCategoryAppearance({ color: 0xff0000 });
     const newModelCode = IModelTestUtils.getUniqueModelCode(rwIModel, "newPhysicalModel");
 
@@ -564,7 +564,7 @@ describe("IModelWriteTest (#integration)", () => {
     const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(rwIModel, IModelTestUtils.getUniqueModelCode(rwIModel, "newPhysicalModel"), true);
     const dictionary: DictionaryModel = rwIModel.models.getModel<DictionaryModel>(IModel.dictionaryId);
     const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
-    assert.isTrue(await rwIModel.concurrencyControl.areCodesAvailable2(adminRequestContext, [newCategoryCode]));
+    assert.isTrue(await rwIModel.concurrencyControl.codes.areAvailable(adminRequestContext, [newCategoryCode]));
     const spatialCategoryId: Id64String = SpatialCategory.insert(rwIModel, IModel.dictionaryId, newCategoryCode.value!, new SubCategoryAppearance({ color: 0xff0000 }));
     const elid1 = rwIModel.elements.insertElement(IModelTestUtils.createPhysicalObject(rwIModel, newModelId, spatialCategoryId));
     const elid2 = rwIModel.elements.insertElement(IModelTestUtils.createPhysicalObject(rwIModel, newModelId, spatialCategoryId));
@@ -604,7 +604,7 @@ describe("IModelWriteTest (#integration)", () => {
       rwIModel.elements.updateElement(el1Props);
       // Also create another new element as part of the same txn.
       elid3 = rwIModel.elements.insertElement(IModelTestUtils.createPhysicalObject(rwIModel, newModelId, spatialCategoryId));
-      assert.isTrue(rwIModel.concurrencyControl.holdsLock(ConcurrencyControl.Request.getElementLock(elid3, LockLevel.Exclusive))); // (tricky: ccmgr pretends that new elements are locked.)
+      assert.isTrue(rwIModel.concurrencyControl.locks.holdsLock(ConcurrencyControl.Request.getElementLock(elid3, LockLevel.Exclusive))); // (tricky: ccmgr pretends that new elements are locked.)
       assert.isTrue(rwIModel.concurrencyControl.hasPendingRequests); // we have to get the lock before we can carry through with this
       let rejectedWithError: Error | undefined;
       try {
@@ -624,10 +624,10 @@ describe("IModelWriteTest (#integration)", () => {
     assert.isFalse(rwIModel.concurrencyControl.hasPendingRequests); // when we abandon changes, we also abandon the pending resource request
     assert.isUndefined(rwIModel.elements.getElement(elid1).userLabel, "the modification of element #1 should have been unwound");
     assert.isUndefined(rwIModel.elements.tryGetElement(elid3), "the insert of element #3 should have been unwound");
-    assert.isFalse(rwIModel.concurrencyControl.holdsLock(ConcurrencyControl.Request.getElementLock(elid3, LockLevel.Exclusive)), "The fake local lock on element #3 should have been discarded");
+    assert.isFalse(rwIModel.concurrencyControl.locks.holdsLock(ConcurrencyControl.Request.getElementLock(elid3, LockLevel.Exclusive)), "The fake local lock on element #3 should have been discarded");
     // ... but all committed changes and temporary locks were retained.
     assert.isTrue(undefined !== rwIModel.elements.tryGetElement(elid4), "the insert of the first new element should have been retained");
-    assert.isTrue(rwIModel.concurrencyControl.holdsLock(ConcurrencyControl.Request.getElementLock(elid4, LockLevel.Exclusive)), "The fake local lock on element #4 should have been retained");
+    assert.isTrue(rwIModel.concurrencyControl.locks.holdsLock(ConcurrencyControl.Request.getElementLock(elid4, LockLevel.Exclusive)), "The fake local lock on element #4 should have been retained");
 
     // This briefcase should be able to modify element #2.
     if (true) {
@@ -753,7 +753,7 @@ describe("IModelWriteTest (#integration)", () => {
     // Find or create a SpatialCategory.
     const dictionary: DictionaryModel = rwIModel.models.getModel<DictionaryModel>(IModel.dictionaryId);
     const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
-    assert.isTrue(await rwIModel.concurrencyControl.areCodesAvailable2(adminRequestContext, [newCategoryCode]));
+    assert.isTrue(await rwIModel.concurrencyControl.codes.areAvailable(adminRequestContext, [newCategoryCode]));
     const spatialCategoryId: Id64String = SpatialCategory.insert(rwIModel, IModel.dictionaryId, newCategoryCode.value!, new SubCategoryAppearance({ color: 0xff0000 }));
 
     timer.end();
@@ -988,7 +988,7 @@ describe("IModelWriteTest (#integration)", () => {
     assert.isTrue(iModel.nativeDb.hasPendingTxns());
 
     // Validate state after upgrade
-    assert.isTrue(iModel.concurrencyControl.hasSchemaLock);
+    assert.isTrue(iModel.concurrencyControl.locks.hasSchemaLock);
     let schemaLocks = await BriefcaseManager.imodelClient.locks.get(managerRequestContext, iModelId, new LockQuery().byLockType(LockType.Schemas).byLockLevel(LockLevel.Exclusive));
     assert.isTrue(schemaLocks.length === 1);
     assert.isFalse(iModel.nativeDb.hasUnsavedChanges());
@@ -1012,7 +1012,7 @@ describe("IModelWriteTest (#integration)", () => {
     await iModel.pushChanges(managerRequestContext, "Upgrading schemas");
 
     // Validate that the schema lock is now released
-    assert.isFalse(iModel.concurrencyControl.hasSchemaLock);
+    assert.isFalse(iModel.concurrencyControl.locks.hasSchemaLock);
     schemaLocks = await BriefcaseManager.imodelClient.locks.get(managerRequestContext, iModelId, new LockQuery().byLockType(LockType.Schemas).byLockLevel(LockLevel.Exclusive));
     assert.isTrue(schemaLocks.length === 0);
 
@@ -1054,7 +1054,7 @@ describe("IModelWriteTest (#integration)", () => {
     assert.isFalse(superIModel.nativeDb.hasPendingTxns()); // Validate no changes were made
     schemaLocks = await BriefcaseManager.imodelClient.locks.get(superRequestContext, iModelId, new LockQuery().byLockType(LockType.Schemas).byLockLevel(LockLevel.Exclusive));
     assert.isTrue(schemaLocks.length === 0); // Validate no schema locks held by the hub
-    assert.isFalse(superIModel.concurrencyControl.hasSchemaLock); // Validate no schema locks cached in briefcase
+    assert.isFalse(superIModel.concurrencyControl.locks.hasSchemaLock); // Validate no schema locks cached in briefcase
 
     /* Cleanup after test */
     iModel.close();

--- a/core/backend/src/test/integration/IModelWrite.test.ts
+++ b/core/backend/src/test/integration/IModelWrite.test.ts
@@ -473,7 +473,7 @@ describe("IModelWriteTest (#integration)", () => {
     const bcId = rwIModel.concurrencyControl.iModel.briefcase.briefcaseId;
     const iModelId = rwIModel.concurrencyControl.iModel.iModelId;
 
-    var heldLocks = await BriefcaseManager.imodelClient.locks.get(adminRequestContext, iModelId, new LockQuery().byBriefcaseId(bcId));
+    let heldLocks = await BriefcaseManager.imodelClient.locks.get(adminRequestContext, iModelId, new LockQuery().byBriefcaseId(bcId));
     assert.isTrue(heldLocks.length !== 0);
 
     await expect(rwIModel.concurrencyControl.abandonResources(adminRequestContext)).to.be.rejectedWith(IModelError, "");

--- a/core/imodel-bridge/src/BridgeRunner.ts
+++ b/core/imodel-bridge/src/BridgeRunner.ts
@@ -341,11 +341,11 @@ class BriefcaseDbBuilder extends IModelDbBuilder {
     assert(this._imodel instanceof BriefcaseDb);
     assert(!this._imodel.concurrencyControl.hasPendingRequests);
     assert(this._imodel.concurrencyControl.isBulkMode);
-    assert(!this._imodel.concurrencyControl.hasSchemaLock, "bridgeRunner must release all locks before switching channels");
-    assert(!this._imodel.concurrencyControl.hasCodeSpecsLock, "bridgeRunner must release all locks before switching channels");
+    assert(!this._imodel.concurrencyControl.locks.hasSchemaLock, "bridgeRunner must release all locks before switching channels");
+    assert(!this._imodel.concurrencyControl.locks.hasCodeSpecsLock, "bridgeRunner must release all locks before switching channels");
     const currentRoot = this._imodel.concurrencyControl.channel.channelRoot;
     if (currentRoot !== undefined)
-      assert(!this._imodel.concurrencyControl.holdsLock(ConcurrencyControl.Request.getElementLock(currentRoot, LockLevel.Exclusive)), "bridgeRunner must release channel locks before switching channels");
+      assert(!this._imodel.concurrencyControl.locks.holdsLock(ConcurrencyControl.Request.getElementLock(currentRoot, LockLevel.Exclusive)), "bridgeRunner must release channel locks before switching channels");
   }
 
   protected async _enterChannel(channelRootId: Id64String, lockRoot: boolean = true) {
@@ -385,7 +385,7 @@ class BriefcaseDbBuilder extends IModelDbBuilder {
       await this.enterRepositoryChannel();
     }
 
-    assert(this._imodel.concurrencyControl.hasSchemaLock);
+    assert(this._imodel.concurrencyControl.locks.hasSchemaLock);
     assert(briefcaseDb.concurrencyControl.isBulkMode);
 
     await this._bridge.importDefinitions();
@@ -396,7 +396,7 @@ class BriefcaseDbBuilder extends IModelDbBuilder {
   protected async _initDomainSchema() {
     assert(this._requestContext !== undefined);
     assert(this._imodel instanceof BriefcaseDb);
-    assert(!this._imodel.concurrencyControl.hasSchemaLock);
+    assert(!this._imodel.concurrencyControl.locks.hasSchemaLock);
     assert(this._imodel.concurrencyControl.isBulkMode);
 
     await this._saveAndPushChanges("Initialization", ChangesType.Definition); // in case openSourceData or any other preliminary step wrote anything
@@ -415,7 +415,7 @@ class BriefcaseDbBuilder extends IModelDbBuilder {
   protected async _updateExistingData(): Promise<void> {
     assert(this._requestContext !== undefined);
     assert(this._imodel instanceof BriefcaseDb);
-    assert(!this._imodel.concurrencyControl.hasSchemaLock);
+    assert(!this._imodel.concurrencyControl.locks.hasSchemaLock);
     assert(this._imodel.concurrencyControl.isBulkMode);
 
     await this.enterBridgeChannel();


### PR DESCRIPTION
Slim down and rationalize the ConcurrencyControl class API. For API purposes, move lock- and code-specific functions out of the main ConcurrencyControl class and into helper objects that are specific to each area. ConcurrencyControl has internal methods to implement some of them, where the operation involves managing the cache.

Also fixed a bug in abandonResources - you can't do that if you have pending txns to push.