### PR TITLE
Cleanup the codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,9 @@
 # No one specific needs to review changelogs. That will be left up to the reviewers specified in other places
 !/common/changes
 
-.gitattributes .gitignore rush.json @calebmshafer @scsewall
+.gitattributes @calebmshafer @scsewall
+.gitignore @calebmshafer @scsewall
+rush.json @calebmshafer @scsewall
 
 /clients              @calebmshafer @ramanujam-raman
 /clients/imodelhub    @amikoliunas @Animagne
@@ -86,7 +88,8 @@
 /core/quantity                  @bsteinbk @calebmshafer
 /core/webgl-compatibility       @pmconne @mgooding
 
-/docs/getting-started /docs/config @calebmshafer @williamkbentley
+/docs/getting-started @calebmshafer @williamkbentley
+/docs/config @calebmshafer @williamkbentley
 
 # These domains should be split up a bit more
 /domains      @scsewall
@@ -122,11 +125,19 @@
 /test-apps/ui-test-app                      @bsteinbk @Dan-East @GerardasB @grigasp
 /test-apps/ui-test-extension                @bsteinbk @Dan-East @GerardasB
 
-/tools/backend-webpack /tools/build /tools/certa /tools/config-loader /tools/extension-webpack /tools/oidc-signin-tool /tools/webpack-core @calebmshafer @wgoehrig
+/tools/backend-webpack @calebmshafer @wgoehrig
+/tools/build @calebmshafer @wgoehrig
+/tools/certa @calebmshafer @wgoehrig
+/tools/config-loader @calebmshafer @wgoehrig
+/tools/extension-webpack @calebmshafer @wgoehrig
+/tools/oidc-signin-tool @calebmshafer @wgoehrig
+/tools/webpack-core @calebmshafer @wgoehrig
 /tools/ecschema2ts @calebmshafer @ColinKerr @wgoehrig
 /tools/eslint-plugin /tools/extension-cli @calebmshafer @pauliunas
 /tools/internal @calebmshafer @wgoehrig
 /tools/perf-tools @calebmshafer @wgoehrig
 
 /ui @bsteinbk @Dan-East @GerardasB @grigasp
-/ui/components/src/ui-components/properties /ui/components/src/ui-components/propertygrid /ui/components/src/ui-components/tree   @bsteinbk @Dan-East @grigasp @saskliutas @roluk
+/ui/components/src/ui-components/properties   @bsteinbk @Dan-East @grigasp @saskliutas @roluk
+/ui/components/src/ui-components/propertygrid @bsteinbk @Dan-East @grigasp @saskliutas @roluk
+/ui/components/src/ui-components/tree         @bsteinbk @Dan-East @grigasp @saskliutas @roluk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@
 
 *  @kabentley @scsewall @ramanujam-raman @pmconne @calebmshafer @swwilson-bsi
 
+# No one specific needs to review changelogs. That will be left up to the reviewers specified in other places
+!/common/changes
+
 .gitattributes .gitignore rush.json @calebmshafer @scsewall
 
 /clients              @calebmshafer @ramanujam-raman
@@ -43,14 +46,14 @@
 /common/api/imodeljs-markup.api.md                  @kabentley @pmconne
 /common/api/imodeljs-quantity.api.md                @bsteinbk @calebmshafer
 /common/api/itwin-client.api.md                     @calebmshafer @ramanujam-raman
-/common/api/linear-referencing-backend.api.md       @scsewall @diegoalexdiaz
-/common/api/linear-referencing-common.api.md        @scsewall @diegoalexdiaz
+/common/api/linear-referencing-backend.api.md       @diegoalexdiaz @scsewall
+/common/api/linear-referencing-common.api.md        @diegoalexdiaz @scsewall
 /common/api/logger-config.api.md                    @swwilson-bsi @scsewall
 /common/api/oauth-introspection-client.api.model    @calebmshafer @ramanujam-raman
-/common/api/orbitgt-core.api.md                     @RBBentley @pmconne
+/common/api/orbitgt-core.api.md                     @pmconne @RBBentley
 /common/api/perf-tools.api.md                       @calebmshafer @wgoehrig
 /common/api/physical-material-backend.api.md        @scsewall
-/common/api/presentation-*.api.md                   @grigasp @saskliutas @roluk
+/common/api/presentation-*.api.md                   @grigasp @roluk @saskliutas
 /common/api/product-settings-client.api.md          @calebmshafer @ramanujam-raman
 /common/api/projectshare-client.api.md              @calebmshafer @ramanujam-raman
 /common/api/rbac-client.api.md                      @calebmshafer @ramanujam-raman
@@ -58,7 +61,7 @@
 /common/api/telemetry-client.api.md                 @calebmshafer @ramanujam-raman
 /common/api/ui-*.api.md                             @bsteinbk @Dan-East @GerardasB @grigasp
 /common/api/usage-logging-client.api.md             @calebmshafer @ramanujam-raman
-/common/api/webgl-compatibility.api.md
+/common/api/webgl-compatibility.api.md              @pmconne
 
 /common/config/azure-pipelines  @calebmshafer @wgoehrig @ColinKerr
 
@@ -66,14 +69,14 @@
 /core/backend-itwin-client
 /core/bentley                   @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /core/common                    @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
-/core/common/src/rpc/IModelTileRpcInterface.ts            @pmconne
-/core/ecschema-locaters         @calebmshafer @wgoehrig @ColinKerr
-/core/ecschema-metadata         @calebmshafer @wgoehrig @ColinKerr
+/core/common/src/rpc/IModelTileRpcInterface.ts    @pmconne
+/core/ecschema-locaters         @calebmshafer @ColinKerr @wgoehrig
+/core/ecschema-metadata         @calebmshafer @ColinKerr @wgoehrig
 /core/electron-manager          @wgoehrig @ramanujam-raman
 /core/express-server            @calebmshafer @wgoehrig @ramanujam-raman
 /core/frontend                  @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /core/frontend-devtools         @pmconne @mgooding
-/core/geometry                  @mgooding @RBBentley @bbastings @EarlinLutz
+/core/geometry                  @bbastings @EarlinLutz @mgooding @RBBentley
 /core/hypermodeling             @pmconne @bbastings
 /core/i18n                      @wgoehrig @calebmshafer
 /core/imodel-bridge             @abeesh @c-macdonald @swwilson-bsi
@@ -83,31 +86,30 @@
 /core/quantity                  @bsteinbk @calebmshafer
 /core/webgl-compatibility       @pmconne @mgooding
 
-/docs/getting-started/ /docs/config   @calebmshafer @williamkbentley
+/docs/getting-started /docs/config @calebmshafer @williamkbentley
 
-# These domains should most likely be split up
+# These domains should be split up a bit more
 /domains      @scsewall
 /domains/analytical @diegoalexdiaz @scsewall
 /domains/linear-referencing @diegoalexdiaz @scsewall
-
 
 /example-code                         @scsewall @swwilson-bsi
 
 /extensions                           @bsteinbk @calebmshafer
 
-/full-stack-tests/core                @pmconne @kabentley @scsewall @ramanujam-raman
+/full-stack-tests/core                @kabentley @pmconne @scsewall @ramanujam-raman
 /full-stack-tests/imodelhub-client    @amikoliunas @Animagne
 /full-stack-tests/native-app    @calebmshafer @khanaffan @ramanujam-raman
-/full-stack-tests/presentation  @grigasp @saskliutas @roluk
+/full-stack-tests/presentation  @grigasp @roluk @saskliutas
 /full-stack-tests/rpc           @calebmshafer @wgoehrig @swbsi
 /full-stack-tests/rpc-interface @calebmshafer @wgoehrig
 
-/presentation                   @grigasp @saskliutas @roluk
+/presentation                   @grigasp @roluk @saskliutas
 /presentation/common/src/PresentationRpcInterface.ts  @grigasp
 
 /test-apps/analysis-importer                @RBBentley
 /test-apps/display-performance-test-app     @hnn0003 @pmconne
-/test-apps/display-test-app                 @mgooding @pmconne @RBBentley @kabentley
+/test-apps/display-test-app                 @kabentley @mgooding @pmconne @RBBentley
 /test-apps/export-gltf                      @mgooding
 /test-apps/export-obj                       @mgooding
 /test-apps/imjs-importer                    @EarlinLutz
@@ -120,11 +122,11 @@
 /test-apps/ui-test-app                      @bsteinbk @Dan-East @GerardasB @grigasp
 /test-apps/ui-test-extension                @bsteinbk @Dan-East @GerardasB
 
-/tools/backend-webpack /tools/build /tools/certa /tools/config-loader /tools/extension-webpack /tools/oidc-signin-tool /tools/webpack-core   @wgoehrig @calebmshafer
-/tools/ecschema2ts @calebmshafer @wgoehrig @ColinKerr
+/tools/backend-webpack /tools/build /tools/certa /tools/config-loader /tools/extension-webpack /tools/oidc-signin-tool /tools/webpack-core @calebmshafer @wgoehrig
+/tools/ecschema2ts @calebmshafer @ColinKerr @wgoehrig
 /tools/eslint-plugin /tools/extension-cli @calebmshafer @pauliunas
-/tools/internal @calebmshafer
-/tools/perf-tools @calebmshafer
+/tools/internal @calebmshafer @wgoehrig
+/tools/perf-tools @calebmshafer @wgoehrig
 
 /ui @bsteinbk @Dan-East @GerardasB @grigasp
 /ui/components/src/ui-components/properties /ui/components/src/ui-components/propertygrid /ui/components/src/ui-components/tree   @bsteinbk @Dan-East @grigasp @saskliutas @roluk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 *  @kabentley @scsewall @ramanujam-raman @pmconne @calebmshafer @swwilson-bsi
 
 # No one specific needs to review changelogs. That will be left up to the reviewers specified in other places
-!/common/changes
+# !/common/changes
 
 .gitattributes @calebmshafer @scsewall
 .gitignore @calebmshafer @scsewall

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,8 @@ rush.json @calebmshafer @scsewall
 /clients              @calebmshafer @ramanujam-raman
 /clients/imodelhub    @amikoliunas @Animagne
 
-/common/api/analytical-backend.api.md               @scsewall @diegoalexdiaz
+# /common/api/analytical-backend.api.md              @diegoalexdiaz @scsewall
+/common/api/analytical-backend.api.md               @scsewall
 /common/api/backend-application-insights-client.api.md @calebmshafer @ramanujam-raman
 /common/api/backend-itwin-client.api.md             @calebmshafer @ramanujam-raman
 /common/api/bentleyjs-core.api.md                   @kabentley @grigasp @pmconne @ramanujam-raman @swwilson-bsi @scsewall
@@ -48,14 +49,18 @@ rush.json @calebmshafer @scsewall
 /common/api/imodeljs-markup.api.md                  @kabentley @pmconne
 /common/api/imodeljs-quantity.api.md                @bsteinbk @calebmshafer
 /common/api/itwin-client.api.md                     @calebmshafer @ramanujam-raman
-/common/api/linear-referencing-backend.api.md       @diegoalexdiaz @scsewall
-/common/api/linear-referencing-common.api.md        @diegoalexdiaz @scsewall
+# /common/api/linear-referencing-backend.api.md       @diegoalexdiaz @scsewall
+# /common/api/linear-referencing-common.api.md        @diegoalexdiaz @scsewall
+/common/api/linear-referencing-backend.api.md       @scsewall
+/common/api/linear-referencing-common.api.md        @scsewall
 /common/api/logger-config.api.md                    @swwilson-bsi @scsewall
 /common/api/oauth-introspection-client.api.model    @calebmshafer @ramanujam-raman
-/common/api/orbitgt-core.api.md                     @pmconne @RBBentley
+# /common/api/orbitgt-core.api.md                     @pmconne @RBBentley
+/common/api/orbitgt-core.api.md                     @pmconne
 /common/api/perf-tools.api.md                       @calebmshafer @wgoehrig
 /common/api/physical-material-backend.api.md        @scsewall
-/common/api/presentation-*.api.md                   @grigasp @roluk @saskliutas
+# /common/api/presentation-*.api.md                   @grigasp @roluk @saskliutas
+/common/api/presentation-*.api.md                   @grigasp @saskliutas
 /common/api/product-settings-client.api.md          @calebmshafer @ramanujam-raman
 /common/api/projectshare-client.api.md              @calebmshafer @ramanujam-raman
 /common/api/rbac-client.api.md                      @calebmshafer @ramanujam-raman
@@ -78,13 +83,17 @@ rush.json @calebmshafer @scsewall
 /core/express-server            @calebmshafer @wgoehrig @ramanujam-raman
 /core/frontend                  @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /core/frontend-devtools         @pmconne @mgooding
-/core/geometry                  @bbastings @EarlinLutz @mgooding @RBBentley
-/core/hypermodeling             @pmconne @bbastings
+# /core/geometry                  @bbastings @EarlinLutz @mgooding @RBBentley
+/core/geometry                  @EarlinLutz @mgooding
+# /core/hypermodeling             @pmconne @bbastings
+/core/hypermodeling             @pmconne
 /core/i18n                      @wgoehrig @calebmshafer
-/core/imodel-bridge             @abeesh @c-macdonald @swwilson-bsi
+# /core/imodel-bridge             @abeesh @c-macdonald @swwilson-bsi
+/core/imodel-bridge             @abeesh @swwilson-bsi
 /core/logger-config             @swwilson-bsi @scsewall
 /core/markup                    @kabentley @pmconne
-/core/orbitgt                   @RBBentley @pmconne
+# /core/orbitgt                   @RBBentley @pmconne
+/core/orbitgt                   @pmconne
 /core/quantity                  @bsteinbk @calebmshafer
 /core/webgl-compatibility       @pmconne @mgooding
 
@@ -93,35 +102,38 @@ rush.json @calebmshafer @scsewall
 
 # These domains should be split up a bit more
 /domains      @scsewall
-/domains/analytical @diegoalexdiaz @scsewall
-/domains/linear-referencing @diegoalexdiaz @scsewall
+# /domains/analytical @diegoalexdiaz @scsewall
+# /domains/linear-referencing @diegoalexdiaz @scsewall
 
 /example-code                         @scsewall @swwilson-bsi
 
 /extensions                           @bsteinbk @calebmshafer
 
 /full-stack-tests/core                @kabentley @pmconne @scsewall @ramanujam-raman
-/full-stack-tests/imodelhub-client    @amikoliunas @Animagne
+# /full-stack-tests/imodelhub-client    @amikoliunas @Animagne
 /full-stack-tests/native-app    @calebmshafer @khanaffan @ramanujam-raman
-/full-stack-tests/presentation  @grigasp @roluk @saskliutas
+# /full-stack-tests/presentation  @grigasp @roluk @saskliutas
+/full-stack-tests/presentation  @grigasp @saskliutas
 /full-stack-tests/rpc           @calebmshafer @wgoehrig @swbsi
 /full-stack-tests/rpc-interface @calebmshafer @wgoehrig
 
-/presentation                   @grigasp @roluk @saskliutas
+# /presentation                   @grigasp @roluk @saskliutas
+/presentation                   @grigasp @saskliutas
 /presentation/common/src/PresentationRpcInterface.ts  @grigasp
 
-/test-apps/analysis-importer                @RBBentley
+# /test-apps/analysis-importer                @RBBentley
 /test-apps/display-performance-test-app     @hnn0003 @pmconne
 /test-apps/display-test-app                 @kabentley @mgooding @pmconne @RBBentley
+/test-apps/display-test-app                 @kabentley @mgooding @pmconne
 /test-apps/export-gltf                      @mgooding
 /test-apps/export-obj                       @mgooding
-/test-apps/imjs-importer                    @EarlinLutz
+# /test-apps/imjs-importer                    @EarlinLutz
 /test-apps/imodel-from-geojson              @mgooding
-/test-apps/imodel-from-orbitgt              @RBBentley
-/test-apps/imodel-from-reality-model        @RBBentley
+# /test-apps/imodel-from-orbitgt              @RBBentley
+# /test-apps/imodel-from-reality-model        @RBBentley
 /test-apps/ninezone-test-app                @bsteinbk @DanEastBentley @GerardasB
 /test-apps/presentation-test-app            @grigasp @saskliutas @roluk
-/test-apps/synchro-schedule-importer        @RBBentley
+# /test-apps/synchro-schedule-importer        @RBBentley
 /test-apps/ui-test-app                      @bsteinbk @DanEastBentley @GerardasB @grigasp
 /test-apps/ui-test-extension                @bsteinbk @DanEastBentley @GerardasB
 
@@ -133,11 +145,15 @@ rush.json @calebmshafer @scsewall
 /tools/oidc-signin-tool @calebmshafer @wgoehrig
 /tools/webpack-core @calebmshafer @wgoehrig
 /tools/ecschema2ts @calebmshafer @ColinKerr @wgoehrig
-/tools/eslint-plugin /tools/extension-cli @calebmshafer @pauliunas
+/tools/eslint-plugin @calebmshafer @pauliunas
+/tools/extension-cli @calebmshafer @pauliunas
 /tools/internal @calebmshafer @wgoehrig
 /tools/perf-tools @calebmshafer @wgoehrig
 
 /ui @bsteinbk @DanEastBentley @GerardasB @grigasp
+/ui/components/src/ui-components/properties   @bsteinbk @DanEastBentley @grigasp @saskliutas
+/ui/components/src/ui-components/propertygrid @bsteinbk @DanEastBentley @grigasp @saskliutas
+/ui/components/src/ui-components/tree         @bsteinbk @DanEastBentley @grigasp @saskliutas
 /ui/components/src/ui-components/properties   @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
 /ui/components/src/ui-components/propertygrid @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
 /ui/components/src/ui-components/tree         @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,7 +73,7 @@ rush.json @calebmshafer @scsewall
 /common/config/azure-pipelines  @calebmshafer @wgoehrig @ColinKerr
 
 /core/backend                   @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
-/core/backend-itwin-client
+/core/backend-itwin-client      @calebmshafer @ramanujam-raman
 /core/bentley                   @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /core/common                    @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /core/common/src/rpc/IModelTileRpcInterface.ts    @pmconne
@@ -127,7 +127,7 @@ rush.json @calebmshafer @scsewall
 /test-apps/display-test-app                 @kabentley @mgooding @pmconne
 /test-apps/export-gltf                      @mgooding
 /test-apps/export-obj                       @mgooding
-# /test-apps/imjs-importer                    @EarlinLutz
+/test-apps/imjs-importer                    @EarlinLutz
 /test-apps/imodel-from-geojson              @mgooding
 # /test-apps/imodel-from-orbitgt              @RBBentley
 # /test-apps/imodel-from-reality-model        @RBBentley
@@ -154,6 +154,6 @@ rush.json @calebmshafer @scsewall
 /ui/components/src/ui-components/properties   @bsteinbk @DanEastBentley @grigasp @saskliutas
 /ui/components/src/ui-components/propertygrid @bsteinbk @DanEastBentley @grigasp @saskliutas
 /ui/components/src/ui-components/tree         @bsteinbk @DanEastBentley @grigasp @saskliutas
-/ui/components/src/ui-components/properties   @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
-/ui/components/src/ui-components/propertygrid @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
-/ui/components/src/ui-components/tree         @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
+# /ui/components/src/ui-components/properties   @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
+# /ui/components/src/ui-components/propertygrid @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
+# /ui/components/src/ui-components/tree         @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,7 +61,7 @@ rush.json @calebmshafer @scsewall
 /common/api/rbac-client.api.md                      @calebmshafer @ramanujam-raman
 /common/api/reality-data-client.api.md              @calebmshafer @ramanujam-raman
 /common/api/telemetry-client.api.md                 @calebmshafer @ramanujam-raman
-/common/api/ui-*.api.md                             @bsteinbk @Dan-East @GerardasB @grigasp
+/common/api/ui-*.api.md                             @bsteinbk @DanEastBentley @GerardasB @grigasp
 /common/api/usage-logging-client.api.md             @calebmshafer @ramanujam-raman
 /common/api/webgl-compatibility.api.md              @pmconne
 
@@ -119,11 +119,11 @@ rush.json @calebmshafer @scsewall
 /test-apps/imodel-from-geojson              @mgooding
 /test-apps/imodel-from-orbitgt              @RBBentley
 /test-apps/imodel-from-reality-model        @RBBentley
-/test-apps/ninezone-test-app                @bsteinbk @Dan-East @GerardasB
+/test-apps/ninezone-test-app                @bsteinbk @DanEastBentley @GerardasB
 /test-apps/presentation-test-app            @grigasp @saskliutas @roluk
 /test-apps/synchro-schedule-importer        @RBBentley
-/test-apps/ui-test-app                      @bsteinbk @Dan-East @GerardasB @grigasp
-/test-apps/ui-test-extension                @bsteinbk @Dan-East @GerardasB
+/test-apps/ui-test-app                      @bsteinbk @DanEastBentley @GerardasB @grigasp
+/test-apps/ui-test-extension                @bsteinbk @DanEastBentley @GerardasB
 
 /tools/backend-webpack @calebmshafer @wgoehrig
 /tools/build @calebmshafer @wgoehrig
@@ -137,7 +137,7 @@ rush.json @calebmshafer @scsewall
 /tools/internal @calebmshafer @wgoehrig
 /tools/perf-tools @calebmshafer @wgoehrig
 
-/ui @bsteinbk @Dan-East @GerardasB @grigasp
-/ui/components/src/ui-components/properties   @bsteinbk @Dan-East @grigasp @saskliutas @roluk
-/ui/components/src/ui-components/propertygrid @bsteinbk @Dan-East @grigasp @saskliutas @roluk
-/ui/components/src/ui-components/tree         @bsteinbk @Dan-East @grigasp @saskliutas @roluk
+/ui @bsteinbk @DanEastBentley @GerardasB @grigasp
+/ui/components/src/ui-components/properties   @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
+/ui/components/src/ui-components/propertygrid @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk
+/ui/components/src/ui-components/tree         @bsteinbk @DanEastBentley @grigasp @saskliutas @roluk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,8 @@
 # No one specific needs to review changelogs. That will be left up to the reviewers specified in other places
 # !/common/changes
 
+.github/workflows @calebmshafer @wgoehrig @ColinKerr
+
 .gitattributes @calebmshafer @scsewall
 .gitignore @calebmshafer @scsewall
 rush.json @calebmshafer @scsewall

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,8 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-*  @kabentley @scsewall @ramanujam-raman @pmconne @calebmshafer @swwilson-bsi
+# *  @kabentley @scsewall @ramanujam-raman @pmconne @calebmshafer @swwilson-bsi
+*  @kabentley @scsewall @ramanujam-raman @pmconne @calebmshafer
 
 # No one specific needs to review changelogs. That will be left up to the reviewers specified in other places
 # !/common/changes
@@ -19,7 +20,7 @@
 rush.json @calebmshafer @scsewall
 
 /clients              @calebmshafer @ramanujam-raman
-/clients/imodelhub    @amikoliunas @Animagne
+# /clients/imodelhub    @amikoliunas @Animagne
 
 # /common/api/analytical-backend.api.md              @diegoalexdiaz @scsewall
 /common/api/analytical-backend.api.md               @scsewall
@@ -38,10 +39,13 @@ rush.json @calebmshafer @scsewall
 /common/api/frontend-application-insights-client.api.md     @calebmshafer @ramanujam-raman
 /common/api/frontend-authorization-client.api.md     @calebmshafer @ramanujam-raman
 /common/api/frontend-devtools.api.md                @pmconne @mgooding
-/common/api/geometry-core.api.md                    @mgooding @RBBentley @bbastings @EarlinLutz
-/common/api/hypermodeling-frontend.api.md           @pmconne @bbastings
-/common/api/imodel-bridge.api.md                    @abeesh @c-macdonald @swwilson-bsi
-/common/api/imodelhub-client.api.md                 @amikoliunas @Animagne
+# /common/api/geometry-core.api.md                   @EarlinLutz @mgooding @RBBentley @bbastings
+/common/api/geometry-core.api.md                    @EarlinLutz @mgooding
+# /common/api/hypermodeling-frontend.api.md           @pmconne @bbastings
+/common/api/hypermodeling-frontend.api.md           @pmconne
+# /common/api/imodel-bridge.api.md                    @abeesh @c-macdonald @swwilson-bsi
+/common/api/imodel-bridge.api.md                    @abeesh @swwilson-bsi
+# /common/api/imodelhub-client.api.md                 @amikoliunas @Animagne
 /common/api/imodeljs-backend.api.md                 @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /common/api/imodeljs-common.api.md                  @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
 /common/api/imodeljs-frontend.api.md                @kabentley @pmconne @ramanujam-raman @swwilson-bsi @scsewall
@@ -54,7 +58,7 @@ rush.json @calebmshafer @scsewall
 /common/api/linear-referencing-backend.api.md       @scsewall
 /common/api/linear-referencing-common.api.md        @scsewall
 /common/api/logger-config.api.md                    @swwilson-bsi @scsewall
-/common/api/oauth-introspection-client.api.model    @calebmshafer @ramanujam-raman
+/common/api/oauth-introspection-client.api.md       @calebmshafer @ramanujam-raman
 # /common/api/orbitgt-core.api.md                     @pmconne @RBBentley
 /common/api/orbitgt-core.api.md                     @pmconne
 /common/api/perf-tools.api.md                       @calebmshafer @wgoehrig
@@ -66,7 +70,7 @@ rush.json @calebmshafer @scsewall
 /common/api/rbac-client.api.md                      @calebmshafer @ramanujam-raman
 /common/api/reality-data-client.api.md              @calebmshafer @ramanujam-raman
 /common/api/telemetry-client.api.md                 @calebmshafer @ramanujam-raman
-/common/api/ui-*.api.md                             @bsteinbk @DanEastBentley @GerardasB @grigasp
+ /common/api/ui-*.api.md                             @bsteinbk @DanEastBentley @GerardasB @grigasp
 /common/api/usage-logging-client.api.md             @calebmshafer @ramanujam-raman
 /common/api/webgl-compatibility.api.md              @pmconne
 
@@ -119,20 +123,21 @@ rush.json @calebmshafer @scsewall
 
 # /presentation                   @grigasp @roluk @saskliutas
 /presentation                   @grigasp @saskliutas
-/presentation/common/src/PresentationRpcInterface.ts  @grigasp
+/presentation/common/src/presentation-common/PresentationRpcInterface.ts @grigasp
 
 # /test-apps/analysis-importer                @RBBentley
 /test-apps/display-performance-test-app     @hnn0003 @pmconne
-/test-apps/display-test-app                 @kabentley @mgooding @pmconne @RBBentley
+# /test-apps/display-test-app                 @kabentley @mgooding @pmconne @RBBentley
 /test-apps/display-test-app                 @kabentley @mgooding @pmconne
 /test-apps/export-gltf                      @mgooding
 /test-apps/export-obj                       @mgooding
-/test-apps/imjs-importer                    @EarlinLutz
+# /test-apps/imjs-importer                    @EarlinLutz
 /test-apps/imodel-from-geojson              @mgooding
 # /test-apps/imodel-from-orbitgt              @RBBentley
 # /test-apps/imodel-from-reality-model        @RBBentley
 /test-apps/ninezone-test-app                @bsteinbk @DanEastBentley @GerardasB
-/test-apps/presentation-test-app            @grigasp @saskliutas @roluk
+# /test-apps/presentation-test-app            @grigasp @saskliutas @roluk
+/test-apps/presentation-test-app            @grigasp @saskliutas
 # /test-apps/synchro-schedule-importer        @RBBentley
 /test-apps/ui-test-app                      @bsteinbk @DanEastBentley @GerardasB @grigasp
 /test-apps/ui-test-extension                @bsteinbk @DanEastBentley @GerardasB

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -2,10 +2,6 @@ name: "Codeowners Validator"
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-    - '.github/CODEOWNERS'
-    - '.github/workflows/sanity.yaml'
   pull_request:
     paths:
     - '.github/CODEOWNERS'
@@ -23,6 +19,6 @@ jobs:
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.5.0
         with:
-          checks: "files,owners,duppatterns,syntax"
+          checks: "files,duppatterns,syntax"
           # GitHub access token is required only if the `owners` check is enabled
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,0 +1,20 @@
+name: "Codeowners Validator"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at 08:00 UTC every day
+    - cron:  '0 8 * * *'
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository, which is validated in the next step
+      - uses: actions/checkout@v2
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.5.0
+        with:
+          checks: "files,owners,duppatterns,syntax"
+          # GitHub access token is required only if the `owners` check is enabled
+          github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -2,6 +2,7 @@ name: "Codeowners Validator"
 
 on:
   workflow_dispatch:
+  push:
   schedule:
     # Runs at 08:00 UTC every day
     - cron:  '0 8 * * *'

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -3,6 +3,13 @@ name: "Codeowners Validator"
 on:
   workflow_dispatch:
   push:
+    paths:
+    - '.github/CODEOWNERS'
+    - '.github/workflows/sanity.yaml'
+  pull_request:
+    paths:
+    - '.github/CODEOWNERS'
+    - '.github/workflows/sanity.yaml'
   schedule:
     # Runs at 08:00 UTC every day
     - cron:  '0 8 * * *'


### PR DESCRIPTION
Due to a few of the current users in the CODEOWNERS file not having write access yet, removing them temporarily from the file.

Also, added a GitHub Workflow that helps validate changes to the CODEOWNERS file to avoid syntax errors in the future.