### PR TITLE
Fix rush change for release branches

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -15,32 +15,32 @@ steps:
       script: |
         import sys, subprocess
 
-        # First param, is always the python file executing the script, so start at the second.
         srcBranch = sys.argv[1]
-
         targetBranch = srcBranch
 
         # Second param, is the build reason which will be used to determine the target branch.
-        #   If the build reason is for a PR, this changes the target branch that you'll want to point at.
+        #   If the build reason is a PR, the target branch changes.
         buildReason = sys.argv[2]
 
         if buildReason == "PullRequest":
-            # Third param, if the build reason is a pull request then the target branch will be specified
+            # Third param, is the target branch of the PR
             targetBranch = sys.argv[3]
 
         print ("Current branch: " + srcBranch)
         print ("Target branch: " + targetBranch)
 
-        if targetBranch.find("release") != -1:
-            # Need to get the current branch with reference to the remote.
-            srcBranch = "origin/" + targetBranch
-
-            # Retarget the rush change command to look at the state of the changelog files from the released branch instead of the default of master.
-            command = "node common/scripts/install-run-rush.js change -v -b " + srcBranch
+        # Verifying with rush change requires the branch that is being merged into to be provided.  More details, https://rushjs.io/pages/commands/rush_change/.
+        # With release/* being a potential target branch in addition to master, special case those branches.
+        if targetBranch.find("refs/heads/release") != -1:
+            branchCmd = " -b " + targetBranch.replace("refs/heads/", "origin/")
+        elif targetBranch.find("release") != -1:
+            # ADOps uses the branch name (i.e. 'release/2.8.0') for GH PR branch names instead of full refs.
+            branchCmd = " -b origin/" + targetBranch
         else:
-            # Defaults back to the default head, i.e. "origin/master"
-            command = "node common/scripts/install-run-rush.js change -v"
+            # Uses default head ("origin/master"), if not defined
+            branchCmd = ""
 
+        command = "node common/scripts/install-run-rush.js change -v" + branchCmd
         print ("Executing " + command)
 
         proc = subprocess.Popen(command, stdin = subprocess.PIPE, stdout = subprocess.PIPE, shell=True)

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -31,9 +31,9 @@ steps:
         print ("Current branch: " + srcBranch)
         print ("Target branch: " + targetBranch)
 
-        if targetBranch.find("refs/heads/release") != -1 or targetBranch.find("refs/heads/hotfix") != -1:
+        if targetBranch.find("release") != -1:
             # Need to get the current branch with reference to the remote.
-            srcBranch = targetBranch.replace("refs/heads/", "origin/")
+            srcBranch = "origin/" + targetBranch
 
             # Retarget the rush change command to look at the state of the changelog files from the released branch instead of the default of master.
             command = "node common/scripts/install-run-rush.js change -v -b " + srcBranch


### PR DESCRIPTION
ADOps Pipelines handled the `System.PullRequest.TargetBranch` variable differently between GitHub and ADOps repos.  In the latter, the resulting string would always include `refs/heads` whereas the former it includes only the branch name after the `refs/heads`. 

Updated the script to correctly check for the release branch and in addition append `origin/` to avoid ambiguity between a branch and git tag. 