### PR TITLE
Update build status in README. Add triggers to regression testing build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you have questions, or wish to contribute to iModel.js, see our [Contributing
 
 ## About this Repository
 
-[![Build status](https://dev.azure.com/imodeljs/imodeljs/_apis/build/status/iModel.js)](https://dev.azure.com/imodeljs/imodeljs/_build/latest?definitionId=1)
+[![Build status](https://dev.azure.com/imodeljs/imodeljs/_apis/build/status/iModel.js)](https://dev.azure.com/imodeljs/imodeljs/_build/latest?definitionId=12)
 
 This repository is a [monorepo](https://en.wikipedia.org/wiki/Monorepo) that holds the source code to multiple iModel.js npm packages. It is built using [Rush](http://rushjs.io/).
 

--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -1,8 +1,21 @@
 # iModel.js CI Build
 
 trigger:
-  - master
-  - release/*
+  schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily midnight build
+    branches:
+      include:
+      - master
+      - releases/*
+  pr:
+    branches:
+      include:
+      - master
+      - releases/*
+    paths:
+      include:
+      - common/config/azure-pipelines/ci.yaml
 
 jobs:
   - template: jobs/ci-core.yaml

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -1,10 +1,19 @@
 # iModel.js Regression Testing Build
 #
-# Tests all supported versions of iModel.js on all platforms.
+# Tests all supported versions of iModel.js on 3 main supported platforms; Windows 10, Ubuntu 10.04, and MacOS.
 #
 # Starts with the minimum version (currently 10.16.0) and then follows the tip of each subsequent minor version
 #
 # The current LTS is tested in all normal CI/PR builds so no need to test it here.
+
+trigger:
+  schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily midnight build
+    branches:
+      include:
+      - master
+      - releases/*
 
 jobs:
 - template: ci-core.yaml


### PR DESCRIPTION
The current build status link goes to the incorrect build.  Update it and fix the trigger for that build to run nightly on the correct release branches.

Also update the trigger for the regression testing. 