### PR TITLE
Add closestPoint method to CurveCollection (peer of maxGap, sumLengths)

### DIFF
--- a/common/api/geometry-core.api.md
+++ b/common/api/geometry-core.api.md
@@ -1358,6 +1358,7 @@ export abstract class CurveCollection extends GeometryQuery {
     abstract cloneStroked(options?: StrokeOptions): AnyCurve;
     cloneTransformed(transform: Transform): CurveCollection | undefined;
     cloneWithExpandedLineStrings(): CurveCollection | undefined;
+    closestPoint(spacePoint: Point3d): CurveLocationDetail | undefined;
     collectCurvePrimitives(collectorArray?: CurvePrimitive[], smallestPossiblePrimitives?: boolean, explodeLineStrings?: boolean): CurvePrimitive[];
     static createCurveLocationDetailOnAnyCurvePrimitive(source: GeometryQuery | undefined, fraction?: number): CurveLocationDetail | undefined;
     abstract readonly curveCollectionType: CurveCollectionType;
@@ -1471,6 +1472,7 @@ export class CurveLocationDetail {
     a: number;
     captureFraction1Point1(fraction1: number, point1: Point3d): void;
     childDetail?: CurveLocationDetail;
+    static chooseSmallerA(detailA: CurveLocationDetail | undefined, detailB: CurveLocationDetail | undefined): CurveLocationDetail | undefined;
     clone(result?: CurveLocationDetail): CurveLocationDetail;
     collapseToEnd(): void;
     collapseToStart(): void;

--- a/common/changes/@bentley/geometry-core/EDLCurveCollectionClosestPoint_2020-11-02-16-01.json
+++ b/common/changes/@bentley/geometry-core/EDLCurveCollectionClosestPoint_2020-11-02-16-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "method to search a curve collection and return the curvePrimitive, fraction, and xyz of point closest to a spacePoint",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "69321059+EarlinLutz@users.noreply.github.com"
+}

--- a/core/geometry/src/curve/CurveCollection.ts
+++ b/core/geometry/src/curve/CurveCollection.ts
@@ -9,6 +9,7 @@
 import { Geometry } from "../Geometry";
 import { GeometryHandler } from "../geometry3d/GeometryHandler";
 import { GrowableXYZArray } from "../geometry3d/GrowableXYZArray";
+import { Point3d } from "../geometry3d/Point3dVector3d";
 import { Range3d } from "../geometry3d/Range";
 import { Transform } from "../geometry3d/Transform";
 import { AnyCurve } from "./CurveChain";
@@ -56,6 +57,23 @@ export abstract class CurveCollection extends GeometryQuery {
   public isInner: boolean = false;
   /** Return the sum of the lengths of all contained curves. */
   public sumLengths(): number { return SumLengthsContext.sumLengths(this); }
+  /** Return the closest point on the contained curves */
+  public closestPoint(spacePoint: Point3d): CurveLocationDetail | undefined {
+    let detailA: CurveLocationDetail | undefined;
+    if (this.children !== undefined) {
+      for (const child of this.children) {
+        if (child instanceof CurvePrimitive) {
+          const detailB = child.closestPoint(spacePoint, false);
+          detailA = CurveLocationDetail.chooseSmallerA(detailA, detailB);
+        } else if (child instanceof CurveCollection) {
+          const detailB = child.closestPoint(spacePoint);
+          detailA = CurveLocationDetail.chooseSmallerA(detailA, detailB);
+        }
+      }
+    }
+    return detailA;
+  }
+
   /** return the max gap between adjacent primitives in Path and Loop collections.
    *
    * * In a Path, gaps are computed between consecutive primitives.

--- a/core/geometry/src/curve/CurveLocationDetail.ts
+++ b/core/geometry/src/curve/CurveLocationDetail.ts
@@ -396,6 +396,19 @@ export class CurveLocationDetail {
       return defaultFraction;
     return a;
   }
+  /**
+   * Return the detail with smaller `a` value -- detailA returned if equal.
+   * @param detailA first candidate
+   * @param detailB second candidate
+   */
+  public static chooseSmallerA(detailA: CurveLocationDetail | undefined, detailB: CurveLocationDetail | undefined): CurveLocationDetail | undefined {
+    if (detailA) {
+      if (!detailB)
+        return detailA;
+      return detailA.a <= detailB.a ? detailA : detailB;
+    }
+    return detailB;
+  }
 }
 /** Enumeration of configurations for intersections and min/max distance-between-curve
  * @public

--- a/core/geometry/src/test/curve/CurveCollection.test.ts
+++ b/core/geometry/src/test/curve/CurveCollection.test.ts
@@ -307,7 +307,7 @@ describe("ConsolidateAdjacentPrimitives", () => {
     ck.testExactNumber(1, singlePointPathB.children.length, "Single point path consolidates to stub");
     expect(ck.getNumErrors()).equals(0);
   });
-  it.only("ClosestPointInCollection", () => {
+  it("ClosestPointInCollection", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     const loops = Sample.createSimpleLoops();

--- a/core/geometry/src/test/curve/CurveCollection.test.ts
+++ b/core/geometry/src/test/curve/CurveCollection.test.ts
@@ -7,8 +7,9 @@ import { expect } from "chai";
 import * as fs from "fs";
 import { BezierCurve3d } from "../../bspline/BezierCurve3d";
 import { Arc3d } from "../../curve/Arc3d";
-import { ConsolidateAdjacentCurvePrimitivesOptions, CurveCollection } from "../../curve/CurveCollection";
+import { BagOfCurves, ConsolidateAdjacentCurvePrimitivesOptions, CurveCollection } from "../../curve/CurveCollection";
 import { CurveFactory } from "../../curve/CurveFactory";
+import { CurveLocationDetail } from "../../curve/CurveLocationDetail";
 import { CurvePrimitive } from "../../curve/CurvePrimitive";
 import { GeometryQuery } from "../../curve/GeometryQuery";
 import { LineSegment3d } from "../../curve/LineSegment3d";
@@ -306,6 +307,46 @@ describe("ConsolidateAdjacentPrimitives", () => {
     ck.testExactNumber(1, singlePointPathB.children.length, "Single point path consolidates to stub");
     expect(ck.getNumErrors()).equals(0);
   });
+  it.only("ClosestPointInCollection", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+    const loops = Sample.createSimpleLoops();
+    const paths = Sample.createSimplePaths();
+    const parityRegions = Sample.createSimpleParityRegions();
+    const collection = BagOfCurves.create();
+    let x0 = 0;
+    const tolerance = 1.0e-8;
+    const localPoints: Point3d[] = [];
+    for (const x of [-0.2, 0.3, 0.8, 1.1]) {
+      for (const y of [-0.4, 0.45, 1.2])
+        localPoints.push(Point3d.create(x, y));
+    }
+    for (const c of [...loops, ...paths, ...parityRegions]) {
+      const range = c.range();
+      collection.tryAddChild(c);
+      GeometryCoreTestIO.captureCloneGeometry(allGeometry, c, x0, 0, 0);
+      for (const xyzLocal of localPoints) {
+        const xyz = range.localToWorld(xyzLocal)!;
+        const detail = c.closestPoint(xyz);
+        GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, xyz, 0.2, x0, 0, 0);
+        if (ck.testType<CurveLocationDetail>(detail) && detail) {
+          GeometryCoreTestIO.captureCloneGeometry(allGeometry, [xyz, detail.point], x0, 0, 0);
+          // verify that the close point is closer than a small test set on its own primitive.
+          //  (This does not confirm that the correct primitive was chosen)
+          if (ck.testDefined(detail.curve)) {
+            for (const f of [0.0, 0.153, 0.389, 0.82342, 1.0]) {
+              const xyzF = detail.curve!.fractionToPoint(f);
+              ck.testLE(detail.a, xyz.distance(xyzF) + tolerance);
+            }
+          }
+        }
+      }
+      x0 += 2.0 * range.xLength();
+    }
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCollection", "ClosestPoint");
+    expect(ck.getNumErrors()).equals(0);
+  });
+
 
 });
 /**


### PR DESCRIPTION
New method to search a curve collection and return the curvePrimitive, fraction, and xyz of point closest to a spacePoint
```
in class CurveCollection
  /** Return the closest point on the contained curves */
  public closestPoint(spacePoint: Point3d): CurveLocationDetail | undefined ...
```