### PR TITLE
Hilite emphasis in dpta

### DIFF
--- a/test-apps/display-performance-test-app/src/backend/CsvWriter.ts
+++ b/test-apps/display-performance-test-app/src/backend/CsvWriter.ts
@@ -49,7 +49,7 @@ function addColumn(origFile: string, newName: string, columnsIndex: number): str
         curIndex++;
       }
       if (pos < 0) pos = line.length;
-      newFile += `${line.slice(0, pos) + (pos !== 0 ? "," : "") + (lineIndex === 0 ? newName : (newName === "ReadPixels Selector" ? "" : 0))
+      newFile += `${line.slice(0, pos) + (pos !== 0 ? "," : "") + (lineIndex === 0 ? newName : (newName === "ReadPixels Selector" || newName === "Other Props" ? "" : 0))
         + (line[pos] !== "," ? "," : "") + line.slice(pos)}\r\n`;
     }
   });
@@ -107,12 +107,12 @@ export function addDataToCsvFile(file: string, data: Map<string, number | string
     columns.forEach((colName, index) => {
       let value = data.get(colName);
       if (value === undefined) {
-        if (index < 2 || colName === "ReadPixels Selector")
+        if (index < 2 || colName === "ReadPixels Selector" || colName === "Other Props")
           value = "";
         else
           value = 0;
       }
-      if (colName === "iModel" || colName === "View Flags" || colName === "Disabled Ext" || colName === "ReadPixels Selector" || colName === "Tile Props")
+      if (colName === "iModel" || colName === "View Flags" || colName === "Disabled Ext" || colName === "ReadPixels Selector" || colName === "Tile Props" || colName === "Other Props")
         stringData += `"${value}",`;
       else if (colName !== "" || index !== columns.length - 1)
         stringData += `${value},`;

--- a/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
+++ b/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
@@ -10,8 +10,8 @@ import {
 } from "@bentley/frontend-authorization-client";
 import { HubIModel } from "@bentley/imodelhub-client";
 import {
-  BackgroundMapProps, BackgroundMapType, BentleyCloudRpcManager, DesktopAuthorizationClientConfiguration, DisplayStyleProps, ElectronRpcConfiguration,
-  ElectronRpcManager, FeatureAppearance, FeatureAppearanceProps, IModelReadRpcInterface, IModelTileRpcInterface, MobileRpcConfiguration, MobileRpcManager,
+  BackgroundMapProps, BackgroundMapType, BentleyCloudRpcManager, ColorDef, DesktopAuthorizationClientConfiguration, DisplayStyleProps, ElectronRpcConfiguration,
+  ElectronRpcManager, FeatureAppearance, FeatureAppearanceProps, Hilite, IModelReadRpcInterface, IModelTileRpcInterface, MobileRpcConfiguration, MobileRpcManager,
   RenderMode, RpcConfiguration, SnapshotIModelRpcInterface, ViewDefinitionProps,
 } from "@bentley/imodeljs-common";
 import {
@@ -33,6 +33,8 @@ let gpuFramesCollected = 0; // Keep track of how many gpu timings we have collec
 const fixed = 4; // The number of decimal places the csv file should save for each data point
 const testNamesImages = new Map<string, number>(); // Keep track of test names and how many duplicate names exist for images
 const testNamesTimings = new Map<string, number>(); // Keep track of test names and how many duplicate names exist for timings
+const defaultHilite = new Hilite.Settings();
+const defaultEmphasis = new Hilite.Settings(ColorDef.black, 0, 0, Hilite.Silhouette.Thick);
 let minimize = false;
 interface Options {
   [key: string]: any; // Add index signature
@@ -259,6 +261,25 @@ function getBackgroundMapProps(): string {
   return bmPropsStr;
 }
 
+function hiliteSettingsStr(settings: Hilite.Settings): string {
+  let hsStr = (settings.color.colors.r * 256 * 256 + settings.color.colors.g * 256 + settings.color.colors.b).toString(36).padStart(5, "0");
+  hsStr += (settings.silhouette * 256 * 256 + Math.round(settings.visibleRatio * 255) * 256 + Math.round(settings.hiddenRatio * 255)).toString(36).padStart(4, "0");
+  return hsStr.toUpperCase();
+}
+
+function getOtherProps(): string {
+  let propsStr = "";
+  if (undefined !== theViewport!.hilite) {
+    if (!Hilite.equalSettings(theViewport!.hilite, defaultHilite))
+      propsStr += `+h${hiliteSettingsStr(theViewport!.hilite)}`;
+  }
+  if (undefined !== theViewport!.emphasisSettings) {
+    if (!Hilite.equalSettings(theViewport!.emphasisSettings, defaultEmphasis))
+      propsStr += `+e${hiliteSettingsStr(theViewport!.emphasisSettings)}`;
+  }
+  return propsStr;
+}
+
 function getViewFlagsString(): string {
   let vfString = "";
   if (activeViewState.viewState) for (const [key, value] of Object.entries(activeViewState.viewState.displayStyle.viewFlags)) {
@@ -409,6 +430,7 @@ function getRowData(finalFrameTimings: Array<Map<string, number>>, finalGPUFrame
   rowData.set("Render Options", getRenderOpts() !== "" ? ` ${getRenderOpts()}` : "");
   rowData.set("Tile Props", getTileProps() !== "" ? ` ${getTileProps()}` : "");
   rowData.set("Bkg Map Props", getBackgroundMapProps() !== "" ? ` ${getBackgroundMapProps()}` : "");
+  if (getOtherProps() !== "") rowData.set("Other Props", ` ${getOtherProps()}`);
   if (pixSelectStr) rowData.set("ReadPixels Selector", ` ${pixSelectStr}`);
   rowData.set("Test Name", getTestName(configs));
   rowData.set("Browser", getBrowserName(IModelApp.queryRenderCompatibility().userAgent));
@@ -524,6 +546,7 @@ function getTestName(configs: DefaultConfigs, prefix?: string, isImage = false, 
   testName += getRenderOpts() !== "" ? `_${getRenderOpts()}` : "";
   testName += getTileProps() !== "" ? `_${getTileProps()}` : "";
   testName += getBackgroundMapProps() !== "" ? `_${getBackgroundMapProps()}` : "";
+  testName += getOtherProps() !== "" ? `_${getOtherProps()}` : "";
   testName = removeOptsFromString(testName, configs.filenameOptsToIgnore);
   if (!ignoreDupes) {
     let testNum = isImage ? testNamesImages.get(testName) : testNamesTimings.get(testName);
@@ -581,6 +604,8 @@ class DefaultConfigs {
   public backgroundMap?: BackgroundMapProps;
   public renderOptions: RenderSystem.Options = {};
   public tileProps?: TileAdmin.Props;
+  public hilite?: Hilite.Settings;
+  public emphasis?: Hilite.Settings;
 
   public constructor(jsonData: any, prevConfigs?: DefaultConfigs, useDefaults = false) {
     if (useDefaults) {
@@ -615,6 +640,10 @@ class DefaultConfigs {
       this.tileProps = this.updateData(prevConfigs.tileProps, this.tileProps) as TileAdmin.Props || undefined;
       this.viewFlags = this.updateData(prevConfigs.viewFlags, this.viewFlags);
       this.backgroundMap = this.updateData(prevConfigs.backgroundMap, this.backgroundMap) as BackgroundMapProps || undefined;
+      if (undefined !== prevConfigs.hilite)
+        this.hilite = Hilite.cloneSettings(prevConfigs.hilite);
+      if (undefined !== prevConfigs.emphasis)
+        this.emphasis = Hilite.cloneSettings(prevConfigs.emphasis);
     } else if (jsonData.argOutputPath)
       this.outputPath = jsonData.argOutputPath;
     if (jsonData.view) this.view = new ViewSize(jsonData.view.width, jsonData.view.height);
@@ -646,6 +675,54 @@ class DefaultConfigs {
     this.tileProps = this.updateData(jsonData.tileProps, this.tileProps) as TileAdmin.Props || undefined;
     this.viewFlags = this.updateData(jsonData.viewFlags, this.viewFlags); // as ViewFlags || undefined;
     this.backgroundMap = this.updateData(jsonData.backgroundMap, this.backgroundMap) as BackgroundMapProps || undefined;
+    if (jsonData.hilite) {
+      // /*q*/console.log(`jsonData.hilite:      ${JSON.stringify(jsonData.hilite)}`);
+      if (undefined === this.hilite)
+        this.hilite = Hilite.cloneSettings(defaultHilite);
+      // /*q*/console.log(`this.hilite   BEFORE: ${JSON.stringify(this.hilite)} ${JSON.stringify(this.hilite.color.colors)}`);
+      const colors = this.hilite.color.colors;
+      let visibleRatio = this.hilite.visibleRatio;
+      let hiddenRatio = this.hilite.hiddenRatio;
+      let silhouette = this.hilite.silhouette;
+      if (undefined !== jsonData.hilite.red)
+        colors.r = jsonData.hilite.red;
+      if (undefined !== jsonData.hilite.green)
+        colors.g = jsonData.hilite.green;
+      if (undefined !== jsonData.hilite.blue)
+        colors.b = jsonData.hilite.blue;
+      if (undefined !== jsonData.hilite.visibleRatio)
+        visibleRatio = jsonData.hilite.visibleRatio;
+      if (undefined !== jsonData.hilite.hiddenRatio)
+        hiddenRatio = jsonData.hilite.hiddenRatio;
+      if (undefined !== jsonData.hilite.silhouette)
+        silhouette = jsonData.hilite.silhouette;
+      this.hilite = new Hilite.Settings(ColorDef.from(colors.r, colors.g, colors.b, 0), visibleRatio, hiddenRatio, silhouette);
+      // /*q*/console.log(`this.hilite    AFTER: ${JSON.stringify(this.hilite)} ${JSON.stringify(this.hilite.color.colors)}`);
+    }
+    if (jsonData.emphasis) {
+      // /*q*/console.log(`jsonData.emphasis:    ${JSON.stringify(jsonData.emphasis)}`);
+      if (undefined === this.emphasis)
+        this.emphasis = Hilite.cloneSettings(defaultEmphasis);
+      // /*q*/console.log(`this.emphasis BEFORE: ${JSON.stringify(this.emphasis)} ${JSON.stringify(this.emphasis.color.colors)}`);
+      const colors = this.emphasis.color.colors;
+      let visibleRatio = this.emphasis.visibleRatio;
+      let hiddenRatio = this.emphasis.hiddenRatio;
+      let silhouette = this.emphasis.silhouette;
+      if (undefined !== jsonData.emphasis.red)
+        colors.r = jsonData.emphasis.red;
+      if (undefined !== jsonData.emphasis.green)
+        colors.g = jsonData.emphasis.green;
+      if (undefined !== jsonData.emphasis.blue)
+        colors.b = jsonData.emphasis.blue;
+      if (undefined !== jsonData.emphasis.visibleRatio)
+        visibleRatio = jsonData.emphasis.visibleRatio;
+      if (undefined !== jsonData.emphasis.hiddenRatio)
+        hiddenRatio = jsonData.emphasis.hiddenRatio;
+      if (undefined !== jsonData.emphasis.silhouette)
+        silhouette = jsonData.emphasis.silhouette;
+      this.emphasis = new Hilite.Settings(ColorDef.from(colors.r, colors.g, colors.b, 0), visibleRatio, hiddenRatio, silhouette);
+      // /*q*/console.log(`this.emphasis  AFTER: ${JSON.stringify(this.emphasis)} ${JSON.stringify(this.emphasis.color.colors)}`);
+    }
 
     debugPrint(`view: ${this.view !== undefined ? (`${this.view.width}X${this.view.height}`) : "undefined"}`);
     debugPrint(`numRendersToTime: ${this.numRendersToTime}`);
@@ -972,6 +1049,20 @@ async function loadIModel(testConfig: DefaultConfigs): Promise<boolean> {
   // now connect the view to the canvas
   await openView(activeViewState, testConfig.view!);
   // assert(theViewport !== undefined, "ERROR: theViewport is undefined");
+
+  // /*q*/console.log(JSON.stringify(`testConfig.hilite:   ${JSON.stringify(testConfig.hilite)} ${undefined === testConfig.hilite ? "undefined" : JSON.stringify(testConfig.hilite.color.colors)}`));
+  // /*q*/console.log(JSON.stringify(`testConfig.emphasis: ${JSON.stringify(testConfig.emphasis)} ${undefined === testConfig.emphasis ? "undefined" : JSON.stringify(testConfig.emphasis.color.colors)}`));
+  // /*q*/console.log(JSON.stringify(`theViewport!.hilite   BEFORE: ${JSON.stringify(theViewport!.hilite)} ${JSON.stringify(theViewport!.hilite.color.colors)}`));
+  // /*q*/console.log(JSON.stringify(`theViewport!.emphasis BEFORE: ${JSON.stringify(theViewport!.emphasisSettings)} ${JSON.stringify(theViewport!.emphasisSettings.color.colors)}`));
+  // Set the hilite/emphasis settings
+  // theViewport!.hilite = (undefined !== testConfig.hilite ? Hilite.cloneSettings(testConfig.hilite) : Hilite.cloneSettings(defaultHilite));
+  // theViewport!.emphasisSettings = (undefined !== testConfig.emphasis ? Hilite.cloneSettings(testConfig.emphasis) : Hilite.cloneSettings(defaultEmphasis));
+  if (undefined !== testConfig.hilite)
+    theViewport!.hilite = Hilite.cloneSettings(testConfig.hilite);
+  if (undefined !== testConfig.emphasis)
+    theViewport!.emphasisSettings = Hilite.cloneSettings(testConfig.emphasis);
+  // /*q*/console.log(JSON.stringify(`theViewport!.hilite    AFTER: ${JSON.stringify(theViewport!.hilite)} ${JSON.stringify(theViewport!.hilite.color.colors)}`));
+  // /*q*/console.log(JSON.stringify(`theViewport!.emphasis  AFTER: ${JSON.stringify(theViewport!.emphasisSettings)} ${JSON.stringify(theViewport!.emphasisSettings.color.colors)}`));
 
   // Set the display style
   const iModCon = activeViewState.iModelConnection;

--- a/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
+++ b/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
@@ -676,10 +676,8 @@ class DefaultConfigs {
     this.viewFlags = this.updateData(jsonData.viewFlags, this.viewFlags); // as ViewFlags || undefined;
     this.backgroundMap = this.updateData(jsonData.backgroundMap, this.backgroundMap) as BackgroundMapProps || undefined;
     if (jsonData.hilite) {
-      // /*q*/console.log(`jsonData.hilite:      ${JSON.stringify(jsonData.hilite)}`);
       if (undefined === this.hilite)
         this.hilite = Hilite.cloneSettings(defaultHilite);
-      // /*q*/console.log(`this.hilite   BEFORE: ${JSON.stringify(this.hilite)} ${JSON.stringify(this.hilite.color.colors)}`);
       const colors = this.hilite.color.colors;
       let visibleRatio = this.hilite.visibleRatio;
       let hiddenRatio = this.hilite.hiddenRatio;
@@ -697,13 +695,10 @@ class DefaultConfigs {
       if (undefined !== jsonData.hilite.silhouette)
         silhouette = jsonData.hilite.silhouette;
       this.hilite = new Hilite.Settings(ColorDef.from(colors.r, colors.g, colors.b, 0), visibleRatio, hiddenRatio, silhouette);
-      // /*q*/console.log(`this.hilite    AFTER: ${JSON.stringify(this.hilite)} ${JSON.stringify(this.hilite.color.colors)}`);
     }
     if (jsonData.emphasis) {
-      // /*q*/console.log(`jsonData.emphasis:    ${JSON.stringify(jsonData.emphasis)}`);
       if (undefined === this.emphasis)
         this.emphasis = Hilite.cloneSettings(defaultEmphasis);
-      // /*q*/console.log(`this.emphasis BEFORE: ${JSON.stringify(this.emphasis)} ${JSON.stringify(this.emphasis.color.colors)}`);
       const colors = this.emphasis.color.colors;
       let visibleRatio = this.emphasis.visibleRatio;
       let hiddenRatio = this.emphasis.hiddenRatio;
@@ -721,7 +716,6 @@ class DefaultConfigs {
       if (undefined !== jsonData.emphasis.silhouette)
         silhouette = jsonData.emphasis.silhouette;
       this.emphasis = new Hilite.Settings(ColorDef.from(colors.r, colors.g, colors.b, 0), visibleRatio, hiddenRatio, silhouette);
-      // /*q*/console.log(`this.emphasis  AFTER: ${JSON.stringify(this.emphasis)} ${JSON.stringify(this.emphasis.color.colors)}`);
     }
 
     debugPrint(`view: ${this.view !== undefined ? (`${this.view.width}X${this.view.height}`) : "undefined"}`);
@@ -1050,19 +1044,11 @@ async function loadIModel(testConfig: DefaultConfigs): Promise<boolean> {
   await openView(activeViewState, testConfig.view!);
   // assert(theViewport !== undefined, "ERROR: theViewport is undefined");
 
-  // /*q*/console.log(JSON.stringify(`testConfig.hilite:   ${JSON.stringify(testConfig.hilite)} ${undefined === testConfig.hilite ? "undefined" : JSON.stringify(testConfig.hilite.color.colors)}`));
-  // /*q*/console.log(JSON.stringify(`testConfig.emphasis: ${JSON.stringify(testConfig.emphasis)} ${undefined === testConfig.emphasis ? "undefined" : JSON.stringify(testConfig.emphasis.color.colors)}`));
-  // /*q*/console.log(JSON.stringify(`theViewport!.hilite   BEFORE: ${JSON.stringify(theViewport!.hilite)} ${JSON.stringify(theViewport!.hilite.color.colors)}`));
-  // /*q*/console.log(JSON.stringify(`theViewport!.emphasis BEFORE: ${JSON.stringify(theViewport!.emphasisSettings)} ${JSON.stringify(theViewport!.emphasisSettings.color.colors)}`));
   // Set the hilite/emphasis settings
-  // theViewport!.hilite = (undefined !== testConfig.hilite ? Hilite.cloneSettings(testConfig.hilite) : Hilite.cloneSettings(defaultHilite));
-  // theViewport!.emphasisSettings = (undefined !== testConfig.emphasis ? Hilite.cloneSettings(testConfig.emphasis) : Hilite.cloneSettings(defaultEmphasis));
   if (undefined !== testConfig.hilite)
     theViewport!.hilite = Hilite.cloneSettings(testConfig.hilite);
   if (undefined !== testConfig.emphasis)
     theViewport!.emphasisSettings = Hilite.cloneSettings(testConfig.emphasis);
-  // /*q*/console.log(JSON.stringify(`theViewport!.hilite    AFTER: ${JSON.stringify(theViewport!.hilite)} ${JSON.stringify(theViewport!.hilite.color.colors)}`));
-  // /*q*/console.log(JSON.stringify(`theViewport!.emphasis  AFTER: ${JSON.stringify(theViewport!.emphasisSettings)} ${JSON.stringify(theViewport!.emphasisSettings.color.colors)}`));
 
   // Set the display style
   const iModCon = activeViewState.iModelConnection;


### PR DESCRIPTION
Add capability to modify hilite and emphasis settings changes in display-performance-test-app so that they can be tested on a regular basis with the image compare tests.

If the settings are not the default settings then filenames for output images have a +hXXXXXXXXX and/or +eXXXXXXXXX added to them to indicate the changes made to the hilite and/or emphasis settings (where XXXXXXXXX is a base36 number representing the changes).

A new column is added to the CVS output for "Other Props" (only if at leastr one test exists which modified the default hilite or emphasis settings) which will contain an entry if the hilite or emphasis settings were modified from the defaults with entries like those added to the output file names of images.