### PR TITLE
Add version bump yaml

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -1,0 +1,237 @@
+# The following build handles everything needed to bump the iModel.js package versions
+#
+# There are currently 4 different types of version bumps:
+#   - Nightly
+#     - Move to the next `dev.x` version
+#     - On master, occurs on a nightly basis, if there are changes to master since the last version bump
+#     - On all other branches, can be triggered on-demand
+#     - Can be run on any branch but normally used for `master` and `release/*` branches
+#   - Release Candidate
+#     - Only runs on the `master` branch
+#     - Bumps the `dev.x` version on `master`, creates release branch and bumps `master` to the next minor dev version
+#   - Minor
+#     - Only runs on `release/*` branches
+#     - Bumps the version to the next Minor version
+#   - Patch
+#     - Only runs on `release/*` branches
+#     - Bumps the version to the next Patch version
+
+parameters:
+  - name: BumpType
+    displayName: Version Bump Type
+    type: string
+    default: 'nightly'
+    values:
+    - nightly
+    - minor
+    - patch
+    - releaseCandidate
+
+trigger: none
+
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - master
+
+pool:
+  vmImage: ubuntu-latest
+
+jobs:
+  - job: Bump
+    displayName: Bump Version
+    steps:
+    - checkout: self
+
+    - task: NodeTool@0
+      displayName: Use Node 12.x
+      inputs:
+        versionSpec: 12.x
+        checkLatest: true
+
+    - bash: |
+        git config --local user.email 38288322+imodeljs-admin@users.noreply.github.com
+        git config --local user.name imodeljs-admin
+      displayName: Setup Git
+
+    # Can be run on any branch to do a standard version bump. Which is currently -dev bumps.
+    - ${{ if or(eq(parameters.BumpType, 'nightly'), eq(parameters.BumpType, 'releaseCandidate')) }}:
+      - bash: 'node common/scripts/install-run-rush version --bump'
+        displayName: Rush version --bump
+
+    # Support two separate bump types on release branches
+    - ${{ if or(eq(parameters.BumpType, 'minor'), eq(parameters.BumpType, 'patch')) }}:
+      - bash: 'node common/scripts/install-run-rush version --override-bump ${{ parameters.BumpType }} --version-policy prerelease-monorepo-lockStep --bump'
+        displayName: Release version bump
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
+
+    - bash: |
+        version=$(jq '.[] | .version' common/config/rush/version-policies.json)
+
+        # Remove quotes or else vso task complains
+        quotelessVersion=$(sed -e 's/^"//' -e 's/"$//' <<<"$version")
+        echo "##vso[build.updatebuildnumber]iModel.js_$quotelessVersion"
+        echo "##vso[task.setvariable variable=version;isOutput=true]$quotelessVersion"
+      displayName: Get new version number
+      name: getVersion
+
+    # When creating a minor release, the NextVersion.md need to be cleared and the contents placed into a {Version Number}.md file
+    - ${{ if eq(parameters.BumpType, 'minor') }}:
+      - powershell: |
+          $sourceFile = 'docs/changehistory/NextVersion.md'
+
+          # If NextVersion has content do work
+          IF ((Get-Content -Path $sourceFile -ReadCount 1 | Measure-Object -line).Lines -gt 5) {
+              # Replace placeholder header
+              (Get-Content $sourceFile ) -replace 'NextVersion', "$(getVersion.version) Change Notes" | Set-Content $sourceFile
+
+              # Remove old frontmatter
+              (Get-Content $sourceFile | Select-Object -Skip 3) | Set-Content $sourceFile
+
+              # Copy NextVersion to index.md
+              Copy-Item $sourceFile docs/changehistory/index.md -Force
+
+              # Add relevant frontmatter
+              "---`ndeltaDoc: true`nversion: '$(getVersion.version)'`n---`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile
+
+              # Rename NextVersion
+              Rename-Item -Path $sourceFile -NewName "$(getVersion.version).md"
+
+              # Add link to leftNav.md
+              (Get-Content -Path docs/changehistory/leftNav.md) -replace '### Versions', "### Versions`n- [$(getVersion.version)](./$(getVersion.version).md)`n" | Set-Content -Path docs/changehistory/leftNav.md
+
+              # Create new NextVersion.md
+              New-Item $sourceFile
+
+              # Update NextVersion.md with template
+              "---`npublish: false`n---`n# NextVersion`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile
+          }
+
+          # Change header tab in docSite.json
+          (Get-Content 'docs/config/docSites.json') -replace '\".*?\":\s.?\"changehistory\"', "`"v$(getVersion.version)`": `"changehistory`"" | Set-Content 'docs/config/docSites.json'
+
+        failOnStderr: true
+        displayName: NextVersion.md rename and replace
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
+
+    - bash: 'git add .'
+      displayName: Git add
+
+    - bash: |
+        echo Committing version bump $(getVersion.version)...
+
+        git commit -m "$(getVersion.version)" --author="imodeljs-admin <38288322+imodeljs-admin@users.noreply.github.com>"
+      displayName: Commit version bump
+
+    - bash: 'git push https://$(GITHUBTOKEN)@github.com/imodeljs/imodeljs HEAD:$(Build.SourceBranch)'
+      displayName: Push version bump
+
+  - ${{ if eq(parameters.BumpType, 'releaseCandidate') }}:
+    - job: CreateBranch
+      displayName: Create branch for next release
+      dependsOn: Bump
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      variables:
+        version: $[ dependencies.Bump.outputs['getVersion.version'] ]
+
+      steps:
+      - checkout: self
+      - bash: |
+          git config --local user.email 38288322+imodeljs-admin@users.noreply.github.com
+          git config --local user.name imodeljs-admin
+        displayName: Setup Git
+
+      - bash: git checkout --track origin/$(Build.SourceBranchName)
+        displayName: Switching to source branch
+
+      - bash: |
+          echo  The current version is $(version)
+          officialVersion=$(sed -e 's/-dev.*$//' <<<"$(version)")
+
+          branchName="release/"$officialVersion
+
+          echo Release branch name is $branchName
+
+          echo "##vso[task.setvariable variable=releaseBranchName]$branchName"
+        displayName: Get Branch Name
+
+      - bash: git checkout -b $(releaseBranchName)
+        displayName: Create and publish branch
+
+      - bash: git push --set-upstream https://$(GITHUBTOKEN)@github.com/imodeljs/imodeljs $(releaseBranchName) -q
+        displayName: Publish the release branch
+
+  - ${{ if eq(parameters.BumpType, 'releaseCandidate') }}:
+    - job: UpdateMaster
+      displayName: Update master to next minor version
+      dependsOn: CreateBranch
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+      steps:
+      - checkout: self
+      - task: NodeTool@0
+        displayName: 'Use Node 12.x'
+        inputs:
+          versionSpec: 12.x
+          checkLatest: true
+
+      - bash: |
+          git config --local user.email 38288322+imodeljs-admin@users.noreply.github.com
+          git config --local user.name imodeljs-admin
+        displayName: 'Setup Git'
+
+      - bash: git checkout --track origin/$(Build.SourceBranchName)
+        displayName: Switching to source branch
+
+      # Running this rush command will bump the version number to the next minor version, which in turn deletes everything within common/change.
+      - bash: node common/scripts/install-run-rush version --override-bump minor --version-policy prerelease-monorepo-lockStep --bump
+        displayName: Update to new dev version on master
+
+      # Only add the changes which delete the changelogs, we do not want them on master anymore.
+      - bash: git add common
+        displayName: 'Add changelog deletion'
+
+      - bash: |
+          # Resets all changes, other than the deletion of the changelogs.
+          git checkout -- .
+
+          # Cleans up all untracked files. This could happen if there are new packages that do not have change logs yet.
+          git clean -f -d
+
+          git status
+        displayName: Reset all changes besides changelog
+
+      # The real rush command that we would like to run.
+      # Sets the version number to the next version's first pre-release version.
+      - bash: node common/scripts/install-run-rush version --override-bump preminor --version-policy prerelease-monorepo-lockStep --bump --override-prerelease-id dev
+        displayName: Rush version to new pre-release version
+
+      - powershell: |
+          # Clear the current NextVersion.md to prepare for the next version on master.
+          $sourceFile = 'docs/changehistory/NextVersion.md'
+
+          # Overwrite everything with just the header
+          "---`nignore: true`n---`n# NextVersion`n" | Set-Content $sourceFile
+        displayName: 'Clear current NextVersion.md'
+
+      - bash: git add .
+        displayName: Git add all changes
+
+      - powershell: |
+          # Get the new dev version number. (Hint this is different than the overall version number used elsewhere)
+          $json = Get-Content -Raw -Path common/config/rush/version-policies.json | ConvertFrom-Json
+
+          $newVersion = $json[0].version
+
+          Write-Host The new version is $newVersion
+          Write-Host Committing version bump...
+
+          git commit -m "$newVersion" --author="imodeljs-admin <38288322+imodeljs-admin@users.noreply.github.com>"
+
+          git status
+        displayName: Get version and committing
+
+      - bash: git push https://$(GITHUBTOKEN)@github.com/imodeljs/imodeljs $(Build.SourceBranchName) -q
+        displayName: 'Push version bump'


### PR DESCRIPTION
Converted the current Designer Version of the Version bump job to a yaml-based one and made a few enhancements along the way.

The main changes I made were to convert (almost) everything to bash and simplify the conditions on all of the jobs. Previously we had a matrix of variables needed in order to queue each bump but now it's distilled down to 4 options.

I'll need to cherry-pick this change back to the `release/2.8.0` branch in order to make the patch release today.

I've tested each of the four options in a fork and I'll link to the results of each of them for review;

- `nightly`
  - Run on [master](https://github.com/calebmshafer/imodeljs/commit/a480cf2c8f5ab8102de8cc7bc19782eb5af6a71f)
  - Run on [release branch](https://github.com/calebmshafer/imodeljs/commit/1506836452fcf64ab990d29821ab8d04fca016a3)
- `releaseCandidate`
  - [Regular version bump commit](https://github.com/calebmshafer/imodeljs/commit/a480cf2c8f5ab8102de8cc7bc19782eb5af6a71f)
  - [New branch](https://github.com/calebmshafer/imodeljs/commits/release/2.10.0)
  - [Updated to next minor dev cycle](https://github.com/calebmshafer/imodeljs/commit/fae07ecae2ac24d31337529699369f08083a1c61)
- [minor](https://github.com/calebmshafer/imodeljs/commit/cdd2797317a360f49cce23125048933cce916312)
- [patch](https://github.com/calebmshafer/imodeljs/commit/594d1b404f1b327e34a5848fdd8c8cb2d7ea5c54)

@williamkbentley let me know if you see anything wrong related to the docs changes.  I didn't convert those two from ps, mostly due to time.  I'll may try in the coming weeks to circle back and re-write them in bash.