### PR TITLE
Briefcase abandon fix

### DIFF
--- a/clients/imodelhub/src/imodelhub/Briefcases.ts
+++ b/clients/imodelhub/src/imodelhub/Briefcases.ts
@@ -280,7 +280,7 @@ export class BriefcaseHandler {
     ArgumentCheck.validGuid("iModelId", iModelId);
     ArgumentCheck.validBriefcaseId("briefcaseId", briefcaseId);
 
-    const existingLocksOwnedByBriefcase = await this._imodelClient.locks.get(requestContext, iModelId, new LockQuery().byBriefcaseId(briefcaseId));
+    const existingLocksOwnedByBriefcase = await this._imodelClient.locks.get(requestContext, iModelId, new LockQuery().byBriefcaseId(briefcaseId).top(1));
     requestContext.enter();
     if (existingLocksOwnedByBriefcase.length > 0) {
       await this._imodelClient.locks.deleteAll(requestContext, iModelId, briefcaseId);

--- a/common/changes/@bentley/imodelhub-client-tests/briefcase-delete-fix_2020-11-03-16-06.json
+++ b/common/changes/@bentley/imodelhub-client-tests/briefcase-delete-fix_2020-11-03-16-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client-tests",
+      "comment": "Tests to ensure correct behavior regarding lock deletion before abandoning a briefcase",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client-tests",
+  "email": "70565417+austeja-bentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client/briefcase-delete-fix_2020-11-03-16-06.json
+++ b/common/changes/@bentley/imodelhub-client/briefcase-delete-fix_2020-11-03-16-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "Fixed the briefcase deletion optimization - added a lock query to see if there are any locks to delete to avoid users with no permissions attempting to delete  locks",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client",
+  "email": "70565417+austeja-bentley@users.noreply.github.com"
+}

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Briefcases.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Briefcases.test.ts
@@ -93,7 +93,7 @@ function mockDeleteBriefcase(imodelId: GuidString, briefcaseId: number) {
   ResponseBuilder.mockResponse(utils.IModelHubUrlMock.getUrl(), RequestType.Delete, requestPath, {});
 }
 
-describe.only("iModelHub BriefcaseHandler", () => {
+describe("iModelHub BriefcaseHandler", () => {
   let requestContext: AuthorizedClientRequestContext;
   let contextId: string;
   let imodelId: GuidString;

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Briefcases.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Briefcases.test.ts
@@ -198,7 +198,7 @@ describe("iModelHub BriefcaseHandler", () => {
     chai.expect(briefcases.length).to.equal(0);
   });
 
-  it("should delete a briefcase that owns locks without write permission (#iModelBank|#unit)", async () => {
+  it("should delete a briefcase that owns locks without write permission (#unit)", async () => {
     let newBriefcase: Briefcase = utils.generateBriefcase(briefcaseId);
     utils.mockCreateBriefcase(imodelId, undefined, newBriefcase);
     newBriefcase = await iModelClient.briefcases.create(requestContext, imodelId, newBriefcase);


### PR DESCRIPTION
- Added a check before abandoning briefcase if it owns any locks. This prevents users without appropriate permissions from attempting to release briefcase locks.
- Added tests to ensure correct behavior