### PR TITLE
Fix formatting of triggers. Do not build draft PRs

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -3,7 +3,7 @@
 trigger: none
 
 pr:
-  draft: false
+  drafts: false
   branches:
     include:
     - master

--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -1,21 +1,22 @@
 # iModel.js CI Build
 
-trigger:
-  schedules:
-  - cron: "0 0 * * *"
+pr:
+  draft: false
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    include:
+    - common/config/azure-pipelines/ci.yaml
+
+schedules:
+  - cron: "0 5 * * *"
     displayName: Daily midnight build
     branches:
       include:
       - master
       - releases/*
-  pr:
-    branches:
-      include:
-      - master
-      - releases/*
-    paths:
-      include:
-      - common/config/azure-pipelines/ci.yaml
 
 jobs:
   - template: jobs/ci-core.yaml

--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -1,5 +1,7 @@
 # iModel.js CI Build
 
+trigger: none
+
 pr:
   draft: false
   branches:

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -6,6 +6,13 @@ trigger:
   - master
   - release/*
 
+pr:
+  drafts: false
+  branches:
+    include:
+    - master
+    - releases/*
+
 variables:
 - group: iModel.js non-secret config variables
 - group: iModel.js Integration Test Users

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -10,7 +10,6 @@ pr:
     include:
     - master
     - releases/*
-    - imodel02
 
 jobs:
   - template: ci-core.yaml

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -1,9 +1,9 @@
 # iModel.js CI Build
 
 trigger:
-  branches:
-    - master
-    - release/*
+  - master
+  - release/*
+
 pr:
   drafts: false
   branches:

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -5,7 +5,7 @@ trigger:
     - master
     - release/*
 pr:
-  draft: false
+  drafts: false
   branches:
     include:
     - master

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -1,8 +1,16 @@
 # iModel.js CI Build
 
 trigger:
-  - master
-  - release/*
+  branches:
+    - master
+    - release/*
+pr:
+  draft: false
+  branches:
+    include:
+    - master
+    - releases/*
+    - imodel02
 
 jobs:
   - template: ci-core.yaml

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -8,7 +8,7 @@
 
 trigger:
   schedules:
-  - cron: "0 0 * * *"
+  - cron: "0 5 * * *"
     displayName: Daily midnight build
     branches:
       include:

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -6,14 +6,15 @@
 #
 # The current LTS is tested in all normal CI/PR builds so no need to test it here.
 
-trigger:
-  schedules:
-  - cron: "0 5 * * *"
-    displayName: Daily midnight build
-    branches:
-      include:
-      - master
-      - releases/*
+trigger: none
+
+schedules:
+- cron: "0 5 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - master
+    - releases/*
 
 jobs:
 - template: ci-core.yaml

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -30,7 +30,7 @@ parameters:
 trigger: none
 
 schedules:
-- cron: "0 0 * * *"
+- cron: "0 5 * * *"
   displayName: Daily midnight build
   branches:
     include:


### PR DESCRIPTION
Clean up various build triggers and schedules.

- Switch from `0 0 * * *` to `0 5 * * *` for cron jobs to run them at midnight Eastern instead of 7pm.
- Do not build draft PRs automatically
- Add explicit PR triggers. Previously were being overridden directly in the build.