### PR TITLE
Check entity class

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -1838,6 +1838,11 @@ export class Entity implements EntityProps {
     toJSON(): EntityProps;
 }
 
+// @public
+export type EntityClassType<T> = Function & {
+    prototype: T;
+};
+
 // @internal
 export class EventSink implements IDisposable {
     constructor(id: string);
@@ -2514,7 +2519,7 @@ export namespace IModelDb {
         deleteElement(ids: Id64Arg): void;
         getAspect(aspectInstanceId: Id64String): ElementAspect;
         getAspects(elementId: Id64String, aspectClassFullName?: string): ElementAspect[];
-        getElement<T extends Element>(elementId: Id64String | GuidString | Code | ElementLoadProps): T;
+        getElement<T extends Element>(elementId: Id64String | GuidString | Code | ElementLoadProps, elementClass?: EntityClassType<Element>): T;
         // @internal
         getElementJson<T extends ElementProps>(elementIdArg: string): T;
         getElementProps<T extends ElementProps>(elementId: Id64String | GuidString | Code | ElementLoadProps): T;
@@ -2528,7 +2533,7 @@ export namespace IModelDb {
         queryElementIdByCode(code: Code): Id64String | undefined;
         // @internal
         queryLastModifiedTime(elementId: Id64String): string;
-        tryGetElement<T extends Element>(elementId: Id64String | GuidString | Code | ElementLoadProps): T | undefined;
+        tryGetElement<T extends Element>(elementId: Id64String | GuidString | Code | ElementLoadProps, elementClass?: EntityClassType<Element>): T | undefined;
         tryGetElementProps<T extends ElementProps>(elementId: Id64String | GuidString | Code | ElementLoadProps): T | undefined;
         updateAspect(aspectProps: ElementAspectProps): void;
         updateElement(elProps: ElementProps): void;
@@ -2538,17 +2543,17 @@ export namespace IModelDb {
         constructor(_iModel: IModelDb);
         createModel<T extends Model>(modelProps: ModelProps): T;
         deleteModel(ids: Id64Arg): void;
-        getModel<T extends Model>(modelId: Id64String): T;
+        getModel<T extends Model>(modelId: Id64String, modelClass?: EntityClassType<Model>): T;
         // @internal
         getModelJson(modelIdArg: string): string;
         getModelProps<T extends ModelProps>(modelId: Id64String): T;
-        getSubModel<T extends Model>(modeledElementId: Id64String | GuidString | Code): T;
+        getSubModel<T extends Model>(modeledElementId: Id64String | GuidString | Code, modelClass?: EntityClassType<Model>): T;
         insertModel(props: ModelProps): Id64String;
         // @internal
         queryLastModifiedTime(modelId: Id64String): string;
-        tryGetModel<T extends Model>(modelId: Id64String): T | undefined;
+        tryGetModel<T extends Model>(modelId: Id64String, modelClass?: EntityClassType<Model>): T | undefined;
         tryGetModelProps<T extends ModelProps>(modelId: Id64String): T | undefined;
-        tryGetSubModel<T extends Model>(modeledElementId: Id64String | GuidString | Code): T | undefined;
+        tryGetSubModel<T extends Model>(modeledElementId: Id64String | GuidString | Code, modelClass?: EntityClassType<Model>): T | undefined;
         updateModel(props: UpdateModelOptions): void;
     }
     // @internal

--- a/common/api/summary/imodeljs-backend.exports.csv
+++ b/common/api/summary/imodeljs-backend.exports.csv
@@ -114,6 +114,7 @@ public;ElementUniqueAspect
 public;ElevationCallout 
 public;EmbeddedFileLink 
 public;Entity 
+public;EntityClassType
 internal;EventSink 
 public;ExportGraphics
 public;ExportGraphicsFunction = (info: ExportGraphicsInfo) => void

--- a/common/changes/@bentley/imodeljs-backend/check-entity-class_2020-11-03-20-56.json
+++ b/common/changes/@bentley/imodeljs-backend/check-entity-class_2020-11-03-20-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "getElement and getModel can optionally validate the expected class",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "36768600+scsewall@users.noreply.github.com"
+}

--- a/core/backend/src/Entity.ts
+++ b/core/backend/src/Entity.ts
@@ -86,3 +86,8 @@ export class Entity implements EntityProps {
   /** @internal */
   public static get protectedOperations(): string[] { return []; }
 }
+
+/** Parameter type that can accept both abstract constructor types and non-abstract constructor types for `instanceof` to test.
+ * @public
+ */
+export type EntityClassType<T> = Function & { prototype: T };

--- a/core/backend/src/test/standalone/IModel.test.ts
+++ b/core/backend/src/test/standalone/IModel.test.ts
@@ -27,9 +27,9 @@ import {
   BriefcaseManager, Category, ClassRegistry, DefinitionContainer, DefinitionGroup, DefinitionGroupGroupsDefinitions, DefinitionModel,
   DefinitionPartition, DictionaryModel, DisplayStyle3d, DisplayStyleCreationOptions, DocumentPartition, DrawingGraphic, ECSqlStatement, Element,
   ElementDrivesElement, ElementGroupsMembers, ElementOwnsChildElements, Entity, GeometricElement2d, GeometricElement3d, GeometricModel,
-  GroupInformationPartition, IModelDb, IModelHost, IModelJsFs, InformationPartitionElement, LightLocation, LinkPartition, Model, PhysicalModel,
-  PhysicalObject, PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SqliteStatement, SqliteValue, SqliteValueType, StandaloneDb,
-  SubCategory, Subject, Texture, ViewDefinition,
+  GroupInformationPartition, IModelDb, IModelHost, IModelJsFs, InformationPartitionElement, LightLocation, LinkPartition, Model, PhysicalElement,
+  PhysicalModel, PhysicalObject, PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SqliteStatement, SqliteValue, SqliteValueType,
+  StandaloneDb, SubCategory, Subject, Texture, ViewDefinition,
 } from "../../imodeljs-backend";
 import { DisableNativeAssertions, IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
@@ -334,6 +334,48 @@ describe("iModel", () => {
     newEl.federationGuid = undefined;
     const newId: Id64String = imodel2.elements.insertElement(newEl);
     assert.isTrue(Id64.isValidId64(newId), "insert worked");
+  });
+
+  it("should optionally detect class mismatches", () => {
+    // tryGetElement
+    const subjectUnvalidated = imodel1.elements.tryGetElement<Subject>(IModel.rootSubjectId);
+    assert.isDefined(subjectUnvalidated);
+    const subjectValidated = imodel1.elements.tryGetElement<Subject>(IModel.rootSubjectId, Subject);
+    assert.isDefined(subjectValidated);
+    const physicalElementUnvalidated = imodel1.elements.tryGetElement<PhysicalElement>(IModel.rootSubjectId);
+    assert.isDefined(physicalElementUnvalidated); // wrong type, but class to validate was not passed
+    const physicalElementValidated = imodel1.elements.tryGetElement<PhysicalElement>(IModel.rootSubjectId, PhysicalElement); // abstract class
+    assert.isUndefined(physicalElementValidated); // wrong type
+    const physicalObjectUnvalidated = imodel1.elements.tryGetElement<PhysicalObject>(IModel.rootSubjectId);
+    assert.isDefined(physicalObjectUnvalidated); // wrong type, but class to validate was not passed
+    const physicalObjectValidated = imodel1.elements.tryGetElement<PhysicalObject>(IModel.rootSubjectId, PhysicalObject); // concrete class
+    assert.isUndefined(physicalObjectValidated); // wrong type
+    // tryGetModel
+    const dictionaryUnvalidated = imodel1.models.tryGetModel<DictionaryModel>(IModel.dictionaryId);
+    assert.isDefined(dictionaryUnvalidated);
+    const dictionaryValidated = imodel1.models.tryGetModel<DictionaryModel>(IModel.dictionaryId, DictionaryModel);
+    assert.isDefined(dictionaryValidated);
+    const geometricModelUnvalidated = imodel1.models.tryGetModel<GeometricModel>(IModel.dictionaryId);
+    assert.isDefined(geometricModelUnvalidated); // wrong type, but class to validate was not passed
+    const geometricModelValidated = imodel1.models.tryGetModel<GeometricModel>(IModel.dictionaryId, GeometricModel); // abstract class
+    assert.isUndefined(geometricModelValidated); // wrong type
+    const physicalModelUnvalidated = imodel1.models.tryGetModel<PhysicalModel>(IModel.dictionaryId);
+    assert.isDefined(physicalModelUnvalidated); // wrong type, but class to validate was not passed
+    const physicalModelValidated = imodel1.models.tryGetModel<PhysicalModel>(IModel.dictionaryId, PhysicalModel); // concrete class
+    assert.isUndefined(physicalModelValidated); // wrong type
+    // tryGetSubModel
+    const dictionarySubUnvalidated = imodel1.models.tryGetSubModel<DictionaryModel>(IModel.dictionaryId);
+    assert.isDefined(dictionarySubUnvalidated);
+    const dictionarySubValidated = imodel1.models.tryGetSubModel<DictionaryModel>(IModel.dictionaryId, DictionaryModel);
+    assert.isDefined(dictionarySubValidated);
+    const geometricSubModelUnvalidated = imodel1.models.tryGetSubModel<GeometricModel>(IModel.dictionaryId);
+    assert.isDefined(geometricSubModelUnvalidated); // wrong type, but class to validate was not passed
+    const geometricSubModelValidated = imodel1.models.tryGetSubModel<GeometricModel>(IModel.dictionaryId, GeometricModel); // abstract class
+    assert.isUndefined(geometricSubModelValidated); // wrong type
+    const physicalSubModelUnvalidated = imodel1.models.tryGetSubModel<PhysicalModel>(IModel.dictionaryId);
+    assert.isDefined(physicalSubModelUnvalidated); // wrong type, but class to validate was not passed
+    const physicalSubModelValidated = imodel1.models.tryGetSubModel<PhysicalModel>(IModel.dictionaryId, PhysicalModel); // concrete class
+    assert.isUndefined(physicalSubModelValidated); // wrong type
   });
 
   it("should create elements", () => {


### PR DESCRIPTION
getElement, getModel, and getSubModel can now optionally validate the expected entity class.