### PR TITLE
Move flatbuffers from the root package.json to common-versions

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -3,9 +3,10 @@
   "preferredVersions": {
     "@types/react": "16.9.43",
     "event-stream": "~4.0.1",
+    "flatbuffers": "~1.12.0",
     "lint-staged": "^10.2.11",
+    "object-is": "1.0.2",
     "ssri": "^6.0.1",
-    "typescript": "~3.7.4",
-    "object-is": "1.0.2"
+    "typescript": "~3.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "url": "http://www.bentley.com"
   },
   "//dependencies": "NOTE: dependencies will be empty here and instead specified in each package.",
-  "dependencies": {
-    "flatbuffers": "^1.12.0"
-  },
+  "dependencies": {},
   "//devDependencies": "NOTE: devDependencies will be empty here and instead specified in each package.",
   "devDependencies": {}
 }


### PR DESCRIPTION
The root package.json shouldn't have any packages defined in it.  Moving the flat buffer requirement to the common-versions to always force that version.

@EarlinLutz the `@types/flatbuffers` package is currently the latest version so there isn't anything to update there.