### PR TITLE
Support for Node 14

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ FROM debian:10
 RUN \
   apt-get update \
   && apt-get install -y curl \
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y libnss3 libxss1 libatk-bridge2.0-0 libgtk-3-0 libasound2 \
   libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 \
   libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 #----------------------------------------------------------------------------------------------
-# Copyright (c) 2021 Bentley Systems, Incorporated. All rights reserved.
-# Licensed under the MIT License. See LICENSE.md in the project root for license terms.
+# Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+# See LICENSE.md in the project root for license terms and full copyright notice.
 #----------------------------------------------------------------------------------------------
 
 FROM debian:10

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each package has its own **node_modules** directory that contains symbolic links
 ## Prerequisites
 
 * [Git](https://git-scm.com/)
-* [Node](https://nodejs.org/en/): an installation of the latest security patch of Node 12. The Node installation also includes the **npm** package manager.
+* [Node](https://nodejs.org/en/): an installation of the latest security patch of Node 14. The Node installation also includes the **npm** package manager.
 * [Rush](https://github.com/Microsoft/web-build-tools/wiki/Rush): to install `npm install -g @microsoft/rush`
 * [TypeScript](https://www.typescriptlang.org/): this is listed as a devDependency, so if you're building it from source, you will get it with `rush install`.
 * [Visual Studio Code](https://code.visualstudio.com/): an optional dependency, but the repository structure is optimized for its use

--- a/clients/imodelhub/src/IModelClient.ts
+++ b/clients/imodelhub/src/IModelClient.ts
@@ -24,7 +24,7 @@ import { CheckpointV2Handler } from "./imodelhub/CheckpointsV2";
 
 /**
  * Base class that allows access to different iModel related Class handlers. Handlers should be accessed through an instance of this class, rather than constructed directly.
- * @beta
+ * @public
  */
 export abstract class IModelClient {
   protected _handler: IModelBaseHandler;
@@ -69,6 +69,7 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[HubIModel]].
+   * @beta
    */
   public get iModel(): IModelHandler {
     return new IModelHandler(new IModelsHandler(this._handler, this._fileHandler));
@@ -84,7 +85,6 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[ChangeSet]]s.
-   * @beta
    */
   public get changeSets(): ChangeSetHandler {
     return new ChangeSetHandler(this._handler, this._fileHandler);
@@ -92,7 +92,7 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[Checkpoint]]s.
-   * @alpha
+   * @internal
    */
   public get checkpoints(): CheckpointHandler {
     return new CheckpointHandler(this._handler, this._fileHandler);
@@ -100,7 +100,7 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[CheckpointV2]]s.
-   * @alpha
+   * @internal
    */
   public get checkpointsV2(): CheckpointV2Handler {
     return new CheckpointV2Handler(this._handler);
@@ -108,7 +108,7 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[Lock]]s.
-   * @alpha
+   * @internal
    */
   public get locks(): LockHandler {
     return new LockHandler(this._handler);
@@ -116,7 +116,7 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [Code]($common)s.
-   * @alpha
+   * @internal
    */
   public get codes(): CodeHandler {
     return new CodeHandler(this._handler);
@@ -124,7 +124,6 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[UserInfo]].
-   * @alpha
    */
   public get users(): UserInfoHandler {
     return new UserInfoHandler(this._handler);
@@ -132,7 +131,6 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[Version]]s.
-   * @beta
    */
   public get versions(): VersionHandler {
     return new VersionHandler(this._handler);
@@ -140,7 +138,6 @@ export abstract class IModelClient {
 
   /**
    * Get the handler for [[Thumbnail]]s.
-   * @alpha
    */
   public get thumbnails(): ThumbnailHandler {
     return new ThumbnailHandler(this._handler);
@@ -180,6 +177,7 @@ export abstract class IModelClient {
   /**
    * Adds a method that will be called for every request to modify HttpRequestOptions.
    * @param func Method that will be used to modify HttpRequestOptions.
+   * @beta
    */
   public use(transformer: HttpRequestOptionsTransformer) {
     this._handler.use(transformer);

--- a/clients/imodelhub/src/IModelHubClientLoggerCategories.ts
+++ b/clients/imodelhub/src/IModelHubClientLoggerCategories.ts
@@ -9,7 +9,7 @@
 /** Logger categories used by this package
  * @note All logger categories in this package start with the `imodelhub-client` prefix.
  * @see [Logger]($bentley)
- * @beta
+ * @public
  */
 export enum IModelHubClientLoggerCategory {
   /** The logger category used by iModelHub clients */

--- a/clients/imodelhub/src/imodelbank/IModelBankHandler.ts
+++ b/clients/imodelhub/src/imodelbank/IModelBankHandler.ts
@@ -11,7 +11,7 @@ import { IModelBaseHandler } from "../imodelhub/BaseHandler";
 
 /**
  * This class acts as the WsgClient for other iModelBank Handlers.
- * @beta
+ * @internal
  */
 export class IModelBankHandler extends IModelBaseHandler {
   private _baseUrl: string;

--- a/clients/imodelhub/src/imodelhub/BaseHandler.ts
+++ b/clients/imodelhub/src/imodelhub/BaseHandler.ts
@@ -65,7 +65,7 @@ export function addCsrfHeader(headerName: string = "X-XSRF-TOKEN", cookieName: s
 
 /**
  * This class acts as the WsgClient for other iModelHub Handlers.
- * @beta
+ * @public
  */
 export class IModelBaseHandler extends WsgClient {
   protected _url?: string;
@@ -88,14 +88,21 @@ export class IModelBaseHandler extends WsgClient {
     this._agent = require("https").Agent({ keepAlive: keepAliveDuration > 0, keepAliveMsecs: keepAliveDuration, secureProtocol: "TLSv1_2_method" });
   }
 
+  /**
+   * @internal
+   */
   public formatContextIdForUrl(contextId: string) { return contextId; }
 
+  /**
+   * @internal
+   */
   public getFileHandler(): FileHandler | undefined { return this._fileHandler; }
 
   /**
    * Augment request options with defaults returned by the DefaultIModelHubRequestOptionsProvider. Note that the options passed in by clients override any defaults where necessary.
    * @param options Options the caller wants to augment with the defaults.
    * @returns Promise resolves after the defaults are setup.
+   * @internal
    */
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     if (!this._defaultIModelHubOptionsProvider)
@@ -108,6 +115,7 @@ export class IModelBaseHandler extends WsgClient {
    * Populates HTTP request options with additional data.
    * @param options Options that need to be populated.
    * @returns Options populated with additional data.
+   * @internal
    */
   protected setupHttpOptions(options?: HttpRequestOptions): HttpRequestOptions {
     const httpOptions: HttpRequestOptions = { ...options };
@@ -122,6 +130,7 @@ export class IModelBaseHandler extends WsgClient {
   /**
    * Adds a method that will be called for every request to modify HttpRequestOptions.
    * @param func Method that will be used to modify HttpRequestOptions.
+   * @beta
    */
   public use(func: HttpRequestOptionsTransformer) {
     this._httpRequestOptionsTransformers.push(func);
@@ -130,6 +139,7 @@ export class IModelBaseHandler extends WsgClient {
   /**
    * Get name/key to query the service URLs from the URL Discovery Service ("Buddi")
    * @returns Search key for the URL.
+   * @internal
    */
   protected getUrlSearchKey(): string {
     return IModelBaseHandler.searchKey;
@@ -138,6 +148,7 @@ export class IModelBaseHandler extends WsgClient {
   /**
    * Gets theRelyingPartyUrl for the service.
    * @returns RelyingPartyUrl for the service.
+   * @internal
    */
   protected getRelyingPartyUrl(): string {
     if (Config.App.has(IModelBaseHandler.configRelyingPartyUri))
@@ -154,6 +165,7 @@ export class IModelBaseHandler extends WsgClient {
   /**
    * Get the agent used for imodelhub connection pooling.
    * @returns The agent used for imodelhub connection pooling.
+   * @internal
    */
   public getAgent(): any {
     return this._agent;
@@ -162,6 +174,7 @@ export class IModelBaseHandler extends WsgClient {
   /**
    * Get the URL of the service. This method attempts to discover and cache the URL from the URL Discovery Service. If not found uses the default URL provided by client implementations. Note that for consistency sake, the URL is stripped of any trailing "/"
    * @returns URL for the service
+   * @internal
    */
   public async getUrl(requestContext: ClientRequestContext): Promise<string> {
     return super.getUrl(requestContext);
@@ -272,6 +285,7 @@ export class IModelBaseHandler extends WsgClient {
 
   /**
    * Get an instance of CustomRequestOptions, which can be used to set custom request parameters for all future requests made by this handler.
+   * @internal
    */
   public getCustomRequestOptions(): CustomRequestOptions {
     return this._customRequestOptions;

--- a/clients/imodelhub/src/imodelhub/Briefcases.ts
+++ b/clients/imodelhub/src/imodelhub/Briefcases.ts
@@ -193,7 +193,6 @@ export class BriefcaseHandler {
   /** Get relative url for Briefcase requests.
    * @param iModelId Id of the iModel. See [[HubIModel]].
    * @param briefcaseId Id of the briefcase.
-   * @internal
    */
   private getRelativeUrl(iModelId: GuidString, briefcaseId?: number) {
     return `/Repositories/iModel--${iModelId}/iModelScope/Briefcase/${briefcaseId || ""}`;

--- a/clients/imodelhub/src/imodelhub/ChangeSets.ts
+++ b/clients/imodelhub/src/imodelhub/ChangeSets.ts
@@ -17,7 +17,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /**
  * Specifies types of changes in a [[ChangeSet]].
- * @beta
+ * @public
  */
 export enum ChangesType {
   /** [[ChangeSet]] contains regular file changes (e.g. changes to elements or models). */
@@ -38,7 +38,7 @@ export enum ChangesType {
 
 /**
  * [ChangeSet]($docs/learning/Glossary.md#changeset) represents a file containing changes to the iModel. A single ChangeSet contains changes made on a single [[Briefcase]] file and pushed as a single file. ChangeSets form a linear change history of the iModel. If a user wants to push their changes to iModelHub, they first have to merge all ChangeSet they do not have yet. Only a single briefcase is allowed to push their changes at a time.
- * @beta
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.ChangeSet", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class ChangeSet extends WsgInstance {
@@ -66,7 +66,10 @@ export class ChangeSet extends WsgInstance {
   @ECJsonTypeMap.propertyToJson("wsg", "properties.ParentId")
   public parentId?: string;
 
-  /** Id of the file that this ChangeSet belongs to. It has to be set during the push. See [IModelDb.getGuid]($backend). */
+  /**
+   * Id of the file that this ChangeSet belongs to. It has to be set during the push. See [IModelDb.getGuid]($backend).
+   * @internal @deprecated
+   */
   @ECJsonTypeMap.propertyToJson("wsg", "properties.SeedFileId")
   public seedFileId?: GuidString;
 
@@ -86,15 +89,24 @@ export class ChangeSet extends WsgInstance {
   @ECJsonTypeMap.propertyToJson("wsg", "properties.ContainingChanges")
   public changesType?: ChangesType;
 
-  /** Flag that needs to be marked true, when confirming successful ChangeSet upload. */
+  /**
+   * Flag that needs to be marked true, when confirming successful ChangeSet upload.
+   * @internal
+   */
   @ECJsonTypeMap.propertyToJson("wsg", "properties.IsUploaded")
   public isUploaded?: boolean;
 
-  /** URL from where the ChangeSet file can be downloaded. See [[ChangeSetQuery.selectDownloadUrl]]. */
+  /**
+   * URL from where the ChangeSet file can be downloaded. See [[ChangeSetQuery.selectDownloadUrl]].
+   * @internal
+   */
   @ECJsonTypeMap.propertyToJson("wsg", "relationshipInstances[FileAccessKey].relatedInstance[AccessKey].properties.DownloadUrl")
   public downloadUrl?: string;
 
-  /** URL where the ChangeSet file has to be uploaded. */
+  /**
+   * URL where the ChangeSet file has to be uploaded.
+   * @internal
+   */
   @ECJsonTypeMap.propertyToJson("wsg", "relationshipInstances[FileAccessKey].relatedInstance[AccessKey].properties.UploadUrl")
   public uploadUrl?: string;
 
@@ -135,7 +147,7 @@ export class ChangeSet extends WsgInstance {
 
 /**
  * Query object for getting [[ChangeSet]]s. You can use this to modify the query. See [[ChangeSetHandler.get]].
- * @beta
+ * @public
  */
 export class ChangeSetQuery extends StringIdQuery {
   /**
@@ -372,7 +384,7 @@ class DownloadProgress {
 
 /**
  * Handler for managing [[ChangeSet]]s. Use [[IModelClient.ChangeSets]] to get an instance of this class. In most cases, you should use [BriefcaseDb]($backend) methods instead.
- * @beta
+ * @public
  */
 export class ChangeSetHandler {
   private _handler: IModelBaseHandler;
@@ -448,6 +460,7 @@ export class ChangeSetHandler {
    * @throws [[IModelHubClientError]] with [IModelHubStatus.UndefinedArgumentError]($bentley), if one of the required arguments is undefined or empty.
    * @param progressCallback Callback for tracking progress.
    * @throws [ResponseError]($itwin-client) if the download fails.
+   * @internal
    */
   public async download(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query: ChangeSetQuery, path: string, progressCallback?: ProgressCallback): Promise<ChangeSet[]> {
     ArgumentCheck.defined("requestContext", requestContext);
@@ -610,7 +623,6 @@ export class ChangeSetHandler {
    * @param path Path of file where the ChangeSet should be downloaded.
    * @param expectedFileSize Size of the file that's being downloaded.
    * @param changeSet ChangeSet that's being downloaded.
-   * @internal
    */
   private wasChangeSetDownloaded(path: string, expectedFileSize: number, changeSet: ChangeSet): boolean {
     if (!this._fileHandler)
@@ -647,6 +659,7 @@ export class ChangeSetHandler {
    * @throws [IModelHubStatus.ChangeSetAlreadyExists]($bentley) if a ChangeSet with this id already exists. This usually happens if previous upload attempt has succeeded.
    * @throws [IModelHubStatus.ChangeSetPointsToBadSeed]($bentley) if changeSet.seedFileId is not set to the correct file id. That file id should match to the value written to the Briefcase file.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, changeSet: ChangeSet, path: string, progressCallback?: ProgressCallback): Promise<ChangeSet> {
     requestContext.enter();

--- a/clients/imodelhub/src/imodelhub/Checkpoints.ts
+++ b/clients/imodelhub/src/imodelhub/Checkpoints.ts
@@ -23,7 +23,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
  * Checkpoint is a copy of the master file, that is intended to be read-only and reduces amount of merging required to get an iModel to a specific previous state.
  *
  * File properties describe the file that would be downloaded through downloadUrl.
- * @alpha
+ * @internal
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.Checkpoint", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class Checkpoint extends WsgInstance {
@@ -62,7 +62,7 @@ export class Checkpoint extends WsgInstance {
 
 /**
  * Query object for getting [[Checkpoint]]s. You can use this to modify the [[CheckpointHandler.get]] results.
- * @alpha
+ * @internal
  */
 export class CheckpointQuery extends WsgQuery {
   /** Query will return closest [[Checkpoint]] to target [[ChangeSet]], based on ChangeSets size.
@@ -103,7 +103,7 @@ export class CheckpointQuery extends WsgQuery {
 /**
  * Handler for managing [[Checkpoint]]s. Use [[IModelClient.checkpoints]] to get an instance of this class.
  * In most cases, you should use [BriefcaseDb]($backend) methods instead.
- * @alpha
+ * @internal
  */
 export class CheckpointHandler {
   private _handler: IModelBaseHandler;
@@ -112,7 +112,7 @@ export class CheckpointHandler {
   /** Constructor for CheckpointHandler. Use [[IModelClient]] instead of directly constructing this.
    * @param handler Handler for WSG requests.
    * @param fileHandler Handler for file system.
-   * @alpha
+   * @internal
    */
   constructor(handler: IModelBaseHandler, fileHandler?: FileHandler) {
     this._handler = handler;
@@ -121,7 +121,7 @@ export class CheckpointHandler {
 
   /** Get relative url for Checkpoint requests.
    * @param iModelId Id of the iModel. See [[HubIModel]].
-   * @alpha
+   * @internal
    */
   private getRelativeUrl(iModelId: GuidString) {
     return `/Repositories/iModel--${iModelId}/iModelScope/Checkpoint/`;

--- a/clients/imodelhub/src/imodelhub/CheckpointsV2.ts
+++ b/clients/imodelhub/src/imodelhub/CheckpointsV2.ts
@@ -18,7 +18,7 @@ import { addSelectContainerAccessKey } from "./HubQuery";
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /** [[CheckpointV2]] creation state.
- * @alpha
+ * @internal
  */
 export enum CheckpointV2State {
   /** CheckpointV2 creation is in progress. */
@@ -30,7 +30,7 @@ export enum CheckpointV2State {
 }
 
 /** [[CheckpointV2]] generation error id.
- * @alpha
+ * @internal
  */
 export enum CheckpointV2ErrorId {
   UnknownError = 0,
@@ -44,7 +44,7 @@ export enum CheckpointV2ErrorId {
 /**
  * Checkpoint is a copy of the master file, that is intended to be read-only and reduces amount of merging required to get an iModel to a specific previous state.
  * [[CheckpointV2]] is stored as a set of binary blocks, while [[Checkpoint]] is a single binary file.
- * @alpha
+ * @internal
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.CheckpointV2", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class CheckpointV2 extends WsgInstance {
@@ -99,7 +99,7 @@ export class CheckpointV2 extends WsgInstance {
 
 /**
  * Query object for getting [[CheckpointV2]]s. You can use this to modify the [[CheckpointV2Handler.get]] results.
- * @alpha
+ * @internal
  */
 export class CheckpointV2Query extends WsgQuery {
   /** Query will return [[CheckpointV2]] with specified [[ChangeSet]] id.
@@ -151,14 +151,14 @@ export class CheckpointV2Query extends WsgQuery {
 /**
  * Handler for managing [[CheckpointV2]]s. Use [[IModelClient.checkpointsV2]] to get an instance of this class.
  * In most cases, you should use [BriefcaseDb]($backend) methods instead.
- * @alpha
+ * @internal
  */
 export class CheckpointV2Handler {
   private _handler: IModelBaseHandler;
 
   /** Constructor for CheckpointV2Handler. Use [[IModelClient]] instead of directly constructing this.
    * @param handler Handler for WSG requests.
-   * @alpha
+   * @internal
    */
   constructor(handler: IModelBaseHandler) {
     this._handler = handler;
@@ -167,7 +167,7 @@ export class CheckpointV2Handler {
   /** Get relative url for [[CheckpointV2]] requests.
    * @param iModelId Id of the iModel. See [[HubIModel]].
    * @param briefcaseId Id of the checkpoint.
-   * @alpha
+   * @internal
    */
   private getRelativeUrl(iModelId: GuidString, checkpointId?: number) {
     return `/Repositories/iModel--${iModelId}/iModelScope/CheckpointV2/${checkpointId || ""}`;

--- a/clients/imodelhub/src/imodelhub/Client.ts
+++ b/clients/imodelhub/src/imodelhub/Client.ts
@@ -14,7 +14,7 @@ import { RbacClient } from "@bentley/rbac-client";
 
 /**
  * Class that allows access to different iModelHub class handlers. Handlers should be accessed through an instance of this class, rather than constructed directly.
- * @beta
+ * @public
  */
 export class IModelHubClient extends IModelClient {
   /**

--- a/clients/imodelhub/src/imodelhub/Codes.ts
+++ b/clients/imodelhub/src/imodelhub/Codes.ts
@@ -17,7 +17,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /**
  * [Code]($common) state describes whether the code is currently in use or owned by a [[Briefcase]].
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export enum CodeState {
   /** Code with this state is not persisted in iModelHub. Code that is updated to 'Available' state is deleted from iModelHub. */
@@ -31,7 +31,7 @@ export enum CodeState {
 }
 
 /** Base class for [Code]($common)s.
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class CodeBase extends WsgInstance {
   /** Code specification Id. */
@@ -61,7 +61,7 @@ export class CodeBase extends WsgInstance {
 
 /**
  * Code instance. Codes ensure uniqueness of names in the file.
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.Code", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class HubCode extends CodeBase {
@@ -106,7 +106,7 @@ function getCodeInstanceId(code: HubCode): string | undefined {
 
 /**
  * Object for specifying options when sending [Code]($common) update requests. See [[CodeHandler.update]].
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export interface CodeUpdateOptions {
   /** Return [Code]($common)s that could not be acquired. Conflicting Codes will be set to [[ConflictingCodesError.conflictingCodes]]. If unlimitedReporting is enabled and CodesPerRequest value is high, some conflicting Codes could be missed.  */
@@ -145,7 +145,7 @@ export class DefaultCodeUpdateOptionsProvider {
 
 /**
  * Error for conflicting [Code]($common)s. It contains an array of Codes that failed to acquire. This is returned when calling [[CodeHandler.update]] with [[CodeUpdateOptions.deniedCodes]] set to true.
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class ConflictingCodesError extends IModelHubError {
   /** Codes that couldn't be updated due to other users owning them or setting them to [[CodeState.Retired]]. */
@@ -192,7 +192,7 @@ export class ConflictingCodesError extends IModelHubError {
 
 /**
  * Query object for getting [Code]($common)s. You can use this to modify the query. See [[CodeHandler.get]].
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class CodeQuery extends WsgQuery {
   private _isMultiCodeQuery = true;
@@ -299,7 +299,7 @@ export class CodeQuery extends WsgQuery {
 }
 
 /** Type of [[CodeSequence]] results.
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export enum CodeSequenceType {
   /** Return largest already used value. */
@@ -309,7 +309,7 @@ export enum CodeSequenceType {
 }
 
 /** Sequence of [Code]($common)s matching a pattern. This class allows getting next available index based [Code]($common)
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.CodeSequence", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class CodeSequence extends WsgInstance {
@@ -344,7 +344,7 @@ export class CodeSequence extends WsgInstance {
 
 /**
  * Handler for querying [[CodeSequence]]s. Use [[CodeHandler.Sequences]] to get an instance of this class.
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class CodeSequenceHandler {
   private _handler: IModelBaseHandler;
@@ -388,7 +388,7 @@ export class CodeSequenceHandler {
 
 /**
  * Handler for managing [Code]($common)s. Use [[IModelClient.Codes]] to get an instance of this class. In most cases, you should use [ConcurrencyControl]($backend) methods instead. You can read more about concurrency control [here]($docs/learning/backend/concurrencycontrol).
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class CodeHandler {
   private _handler: IModelBaseHandler;

--- a/clients/imodelhub/src/imodelhub/Errors.ts
+++ b/clients/imodelhub/src/imodelhub/Errors.ts
@@ -15,7 +15,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /**
  * Error returned from iModelHub service.
- * @beta
+ * @public
  */
 export class IModelHubError extends WsgError {
   /** Extended data of the error. */
@@ -169,7 +169,7 @@ export class IModelHubError extends WsgError {
 
 /**
  * Errors for incorrect iModelHub requests.
- * @beta
+ * @public
  */
 export class IModelHubClientError extends IModelHubError {
   /** Creates IModelHubClientError from id.
@@ -302,7 +302,7 @@ export class ArgumentCheck {
 }
 
 /** Class for aggregating errors from multiple requests. Only thrown when more than 1 error has occurred.
- * @internal
+ * @public
  */
 export class AggregateResponseError extends Error {
   /** Errors that happened over multiple requests. */

--- a/clients/imodelhub/src/imodelhub/Events.ts
+++ b/clients/imodelhub/src/imodelhub/Events.ts
@@ -21,15 +21,15 @@ import { LockLevel, LockType } from "./Locks";
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /** Type of [[IModelHubEvent]]. Event type is used to define which events you wish to receive from your [[EventSubscription]]. See [[EventSubscriptionHandler.create]] and [[EventSubscriptionHandler.update]].
- * @beta
+ * @public
  */
 export enum IModelHubEventType {
   /** Sent when one or more [[Lock]]s are updated. See [[LockEvent]].
-   * @alpha Hide Lock API while focused on readonly viewing scenarios
+   * @internal
    */
   LockEvent = "LockEvent",
   /** Sent when all [[Lock]]s for a [[Briefcase]] are deleted. See [[AllLocksDeletedEvent]].
-   * @alpha Hide Lock API while focused on readonly viewing scenarios
+   * @internal
    */
   AllLocksDeletedEvent = "AllLocksDeletedEvent",
   /** Sent when a [[ChangeSet]] is successfully pushed. See [[ChangeSetPostPushEvent]]. */
@@ -37,11 +37,11 @@ export enum IModelHubEventType {
   /** Sent when a [[ChangeSet]] push has started. See [[ChangeSetPrePushEvent]]. */
   ChangeSetPrePushEvent = "ChangeSetPrePushEvent",
   /** Sent when one or more [Code]($common)s are updated. See [[CodeEvent]].
-   * @alpha Hide Code API while focused on readonly viewing scenarios
+   * @internal
    */
   CodeEvent = "CodeEvent",
   /** Sent when all [Code]($common)s for a [[Briefcase]] are deleted. See [[AllCodesDeletedEvent]].
-   * @alpha Hide Code API while focused on readonly viewing scenarios
+   * @internal
    */
   AllCodesDeletedEvent = "AllCodesDeletedEvent",
   /** Sent when a [[Briefcase]] is deleted. See [[BriefcaseDeletedEvent]].
@@ -52,20 +52,23 @@ export enum IModelHubEventType {
   iModelDeletedEvent = "iModelDeletedEvent",
   /** Sent when a new named [[Version]] is created. See [[VersionEvent]]. */
   VersionEvent = "VersionEvent",
-  /** Sent when a new [[Checkpoint]] is generated. See [[CheckpointCreatedEvent]]. */
+  /**
+   * Sent when a new [[Checkpoint]] is generated. See [[CheckpointCreatedEvent]].
+   * @internal
+   */
   CheckpointCreatedEvent = "CheckpointCreatedEvent",
 }
 
 /* eslint-enable @typescript-eslint/no-shadow */
 
-/** @beta @deprecated Use [[IModelHubEventType]] instead */
+/** @internal @deprecated Use [[IModelHubEventType]] instead */
 export type EventType = "LockEvent" | "AllLocksDeletedEvent" | "ChangeSetPostPushEvent" | "ChangeSetPrePushEvent" | "CodeEvent" | "AllCodesDeletedEvent" | "BriefcaseDeletedEvent" | "iModelDeletedEvent" | "VersionEvent" | "CheckpointCreatedEvent";
 
 /** Base type for all iModelHub events.
- * @beta
+ * @public
  */
 export abstract class IModelHubEvent extends IModelHubBaseEvent {
-  /** Id of the iModel where the event occured. */
+  /** Id of the iModel where the event occurred. */
   public iModelId?: GuidString;
 
   /** Construct this event from object instance.
@@ -79,7 +82,7 @@ export abstract class IModelHubEvent extends IModelHubBaseEvent {
 }
 
 /** Base type for iModelHub events that have BriefcaseId.
- * @beta
+ * @public
  */
 export abstract class BriefcaseEvent extends IModelHubEvent {
   /** Id of the [[Briefcase]] involved in this event. */
@@ -96,7 +99,7 @@ export abstract class BriefcaseEvent extends IModelHubEvent {
 }
 
 /** Sent when one or more [[Lock]]s are updated. Lock updates can be very frequent, so it's recommended to not to subscribe to LockEvents, if it's not necessary.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export class LockEvent extends BriefcaseEvent {
   /** [[LockType]] of the updated Locks. */
@@ -122,13 +125,13 @@ export class LockEvent extends BriefcaseEvent {
 }
 
 /** Sent when all [[Lock]]s for a [[Briefcase]] are deleted. Can occur when calling [[LockHandler.deleteAll]] or [[BriefcaseHandler.delete]].
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export class AllLocksDeletedEvent extends BriefcaseEvent {
 }
 
 /** Sent when a [[ChangeSet]] is successfully pushed. See [[ChangeSetHandler.create]]. It's sent when a new [[ChangeSet]] is successfully pushed to an iModel. See [[ChangeSetPrePushEvent]] for the event indicating the start of a ChangeSet push.
- * @beta
+ * @public
  */
 export class ChangeSetPostPushEvent extends BriefcaseEvent {
   /** Id of the ChangeSet that was pushed. */
@@ -148,13 +151,13 @@ export class ChangeSetPostPushEvent extends BriefcaseEvent {
 }
 
 /** Sent when a [[ChangeSet]] push has started. See [[ChangeSetHandler.create]]. ChangeSetPrePushEvent indicates that iModelHub allowed one of the [[Briefcase]]s to push a ChangeSet and all other push attempts will fail, until this push times out or succeeds. See [[ChangeSetPostPushEvent]] for an event indicating a successful push.
- * @beta
+ * @public
  */
 export class ChangeSetPrePushEvent extends IModelHubEvent {
 }
 
 /** Sent when one or more [Code]($common)s are updated. See [[CodeHandler.update]]. Code updates can be very frequent, so it's recommended to not to subscribe to CodeEvents, if it's not necessary.
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class CodeEvent extends BriefcaseEvent {
   /** Id of the [CodeSpec]($common) for the updated Codes. */
@@ -180,7 +183,7 @@ export class CodeEvent extends BriefcaseEvent {
 }
 
 /** Sent when all [Code]($common)s for a [[Briefcase]] are deleted. Can occur when calling [[CodeHandler.deleteAll]] or [[BriefcaseHandler.delete]].
- * @alpha Hide Code API while focused on readonly viewing scenarios
+ * @internal
  */
 export class AllCodesDeletedEvent extends BriefcaseEvent {
 }
@@ -192,13 +195,13 @@ export class BriefcaseDeletedEvent extends BriefcaseEvent {
 }
 
 /** Sent when an iModel is deleted. See [[IModelHandler.delete]]. [[EventSubscription]] will be deleted 5 minutes after iModel is deleted, removing all events from subscription queues, making it possible for this event to be missed if not retrieved immediately.
- * @beta
+ * @public
  */
 export class IModelDeletedEvent extends IModelHubEvent {
 }
 
 /** Sent when a new named [[Version]] is created. See [[VersionHandler.create]].
- * @beta
+ * @public
  */
 export class VersionEvent extends IModelHubEvent {
   /** Id of the created Version. */
@@ -221,7 +224,7 @@ export class VersionEvent extends IModelHubEvent {
 }
 
 /** Sent when a new [[Checkpoint]] is generated. [[Checkpoint]]s can be generated daily when there are new [[ChangeSet]]s pushed or when a new [[Version]] is created.
- * @beta
+ * @internal
  */
 export class CheckpointCreatedEvent extends IModelHubEvent {
   /** Index of the [[ChangeSet]] this [[Checkpoint]] was created for.  */
@@ -290,7 +293,7 @@ export function ParseEvent(response: Response) {
 }
 
 /** Subscription to receive [[IModelHubEvent]]s. Each subscription has a separate queue for events that it hasn't read yet. Subscriptions are deleted, if they are inactive for an hour. Use wsgId of this instance for the methods that require subscriptionId. See [[EventSubscriptionHandler]].
- * @beta
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.EventSubscription", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class EventSubscription extends WsgInstance {
@@ -300,14 +303,14 @@ export class EventSubscription extends WsgInstance {
 }
 
 /** Shared access signature token for getting [[IModelHubEvent]]s. It's used to authenticate for [[EventHandler.getEvent]]. To receive an instance call [[EventHandler.getSASToken]].
- * @beta
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.EventSAS", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class EventSAS extends BaseEventSAS {
 }
 
 /** Handler for managing [[EventSubscription]]s. Use [[EventHandler.Subscriptions]] to get an instance of this class.
- * @beta
+ * @public
  */
 export class EventSubscriptionHandler {
   private _handler: IModelBaseHandler;
@@ -342,7 +345,7 @@ export class EventSubscriptionHandler {
    * @param events Array of EventTypes to subscribe to.
    * @return Created EventSubscription instance.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
-   * @deprecated Use IModelHubEventType enum for `events` instead.
+   * @internal @deprecated Use IModelHubEventType enum for `events` instead.
    */
   public async create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, events: EventType[]): Promise<EventSubscription>; // eslint-disable-line @typescript-eslint/unified-signatures, deprecation/deprecation
   public async create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, events: IModelHubEventType[] | EventType[]) { // eslint-disable-line deprecation/deprecation
@@ -406,7 +409,7 @@ export class EventSubscriptionHandler {
 }
 
 /** Handler for receiving [[IModelHubEvent]]s. Use [[IModelClient.Events]] to get an instance of this class.
- * @beta
+ * @public
  */
 export class EventHandler extends EventBaseHandler {
   private _subscriptionHandler: EventSubscriptionHandler | undefined;

--- a/clients/imodelhub/src/imodelhub/EventsBase.ts
+++ b/clients/imodelhub/src/imodelhub/EventsBase.ts
@@ -12,7 +12,10 @@ import {
 } from "@bentley/itwin-client";
 import { IModelBaseHandler } from "./BaseHandler";
 
-/** Base class for event shared access signatures. */
+/**
+ * Base class for event shared access signatures.
+ * @public
+ */
 export abstract class BaseEventSAS extends WsgInstance {
   /** Base address for event requests. */
   @ECJsonTypeMap.propertyToJson("wsg", "properties.BaseAddress")
@@ -24,7 +27,7 @@ export abstract class BaseEventSAS extends WsgInstance {
 }
 
 /** Base type for all iModelHub global events
- * @beta
+ * @public
  */
 export abstract class IModelHubBaseEvent {
   /** Topic of this event. For [[IModelHubEvent]]s this is iModelId. */

--- a/clients/imodelhub/src/imodelhub/HubQuery.ts
+++ b/clients/imodelhub/src/imodelhub/HubQuery.ts
@@ -11,7 +11,7 @@ import { RequestQueryOptions, WsgQuery } from "@bentley/itwin-client";
 import { ArgumentCheck } from "./Errors";
 
 /** Query for instances with string based instance ids.
- * @beta
+ * @public
  */
 export class StringIdQuery extends WsgQuery {
   /** @internal */
@@ -45,7 +45,7 @@ export class StringIdQuery extends WsgQuery {
 }
 
 /** Query for instances with Guid based instance ids.
- * @beta
+ * @public
  */
 export class InstanceIdQuery extends WsgQuery {
   /** @internal */

--- a/clients/imodelhub/src/imodelhub/Locks.ts
+++ b/clients/imodelhub/src/imodelhub/Locks.ts
@@ -17,7 +17,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /**
  * [[Lock]] type describes the kind of object that is locked.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export enum LockType {
   /** Lock for the entire file. This is a global Lock that can only be taken with objectId 1. */
@@ -34,7 +34,7 @@ export enum LockType {
 
 /**
  * [[Lock]] level describes how restrictive the Lock is.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export enum LockLevel {
   /** Lock is not owned. */
@@ -60,7 +60,7 @@ function getLockInstanceId(lock: Lock): string | undefined {
 
 /**
  * Object for specifying options when sending [[Lock]]s update requests. See [[LockHandler.update]].
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export interface LockUpdateOptions {
   /** Return [[Lock]]s that could not be acquired. Conflicting Locks will be set to [[ConflictingLocksError.conflictingLocks]]. If unlimitedReporting is enabled and locksPerRequest value is high, some conflicting Locks could be missed. */
@@ -98,7 +98,7 @@ export class DefaultLockUpdateOptionsProvider {
 
 /**
  * Error for conflicting [[Lock]]s. It contains an array of Locks that failed to acquire. This is returned when calling [[LockHandler.update]] with [[LockUpdateOptions.deniedLocks]] set to true.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export class ConflictingLocksError extends IModelHubError {
   /** Locks that couldn't be updated due to other users owning them. */
@@ -144,7 +144,7 @@ export class ConflictingLocksError extends IModelHubError {
 
 /**
  * Base class for [[Lock]]s.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export class LockBase extends WsgInstance {
   /** Type of the Lock. It describes what kind of object is locked. */
@@ -174,7 +174,7 @@ export class LockBase extends WsgInstance {
 
 /**
  * Lock instance. When using pessimistic concurrency, locks ensure that only a single user can modify an object at a time.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.Lock", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class Lock extends LockBase {
@@ -185,7 +185,7 @@ export class Lock extends LockBase {
 
 /**
  * MultiLock: data about locks grouped by BriefcaseId, LockLevel and LockType.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.MultiLock", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class MultiLock extends LockBase {
@@ -195,7 +195,7 @@ export class MultiLock extends LockBase {
 
 /**
  * Query object for getting [[Lock]]s. You can use this to modify the [[LockHandler.get]] results.
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export class LockQuery extends WsgQuery {
   private _isMultiLockQuery = true;
@@ -337,7 +337,7 @@ export class LockQuery extends WsgQuery {
 /**
  * Handler for managing [[Lock]]s. Use [[IModelClient.Locks]] to get an instance of this class.
  * In most cases, you should use [ConcurrencyControl]($backend) methods instead. You can read more about concurrency control [here]($docs/learning/backend/concurrencycontrol).
- * @alpha Hide Lock API while focused on readonly viewing scenarios
+ * @internal
  */
 export class LockHandler {
   private _handler: IModelBaseHandler;

--- a/clients/imodelhub/src/imodelhub/Thumbnails.ts
+++ b/clients/imodelhub/src/imodelhub/Thumbnails.ts
@@ -16,12 +16,12 @@ import { InstanceIdQuery } from "./HubQuery";
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /** Thumbnail size. 'Small' is 400x250 PNG image and 'Large' is a 800x500 PNG image.
- * @beta
+ * @public
  */
 export type ThumbnailSize = "Small" | "Large";
 
 /** Base class for Thumbnails.
- * @alpha
+ * @public
  */
 export abstract class Thumbnail extends WsgInstance {
   @ECJsonTypeMap.propertyToJson("wsg", "instanceId")
@@ -29,19 +29,19 @@ export abstract class Thumbnail extends WsgInstance {
 }
 
 /** Small [[Thumbnail]] class. Small Thumbnail is a 400x250 PNG image.
- * @alpha
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.SmallThumbnail", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class SmallThumbnail extends Thumbnail { }
 
 /** Large [[Thumbnail]] class. Large Thumbnail is a 800x500 PNG image.
- * @alpha
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.LargeThumbnail", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class LargeThumbnail extends Thumbnail { }
 
 /** Tip [[Thumbnail]] download parameters. See [[ThumbnailHandler.download]]. Tip Thumbnail is generated for the periodically updated master file copy on iModelHub.
- * @alpha
+ * @public
  */
 export interface TipThumbnail {
   /** Id of the iModel's context ([[Project]] or [[Asset]]). */
@@ -52,7 +52,7 @@ export interface TipThumbnail {
 
 /**
  * Query object for getting [[Thumbnail]]s. You can use this to modify the [[ThumbnailHandler.get]] results.
- * @alpha
+ * @public
  */
 export class ThumbnailQuery extends InstanceIdQuery {
   /**
@@ -60,6 +60,7 @@ export class ThumbnailQuery extends InstanceIdQuery {
    * @param versionId Id of the version.
    * @returns This query.
    * @throws [[IModelHubClientError]] with [IModelHubStatus.UndefinedArgumentError]($bentley) or [IModelHubStatus.InvalidArgumentError]($bentley) if versionId is undefined or it is not a valid [GuidString]($bentley) value.
+   * @internal @deprecated
    */
   public byVersionId(versionId: GuidString) {
     ArgumentCheck.validGuid("versionId", versionId);
@@ -70,7 +71,7 @@ export class ThumbnailQuery extends InstanceIdQuery {
 
 /**
  * Handler for retrieving [[Thumbnail]]s. Use [[IModelClient.Thumbnails]] to get an instance of this class.
- * @alpha
+ * @public
  */
 export class ThumbnailHandler {
   private _handler: IModelBaseHandler;
@@ -113,7 +114,7 @@ export class ThumbnailHandler {
    * @param requestContext The client request context.
    *
    * @param url Url to download thumbnail.
-   * @return String for the PNG image that includes the base64 encoded array of the image bytes.
+   * @return String for the PNG image that includes the base64 encoded array of the image bytes
    */
   private async downloadThumbnail(requestContext: AuthorizedClientRequestContext, url: string): Promise<string> {
     requestContext.enter();

--- a/clients/imodelhub/src/imodelhub/Users.ts
+++ b/clients/imodelhub/src/imodelhub/Users.ts
@@ -15,7 +15,7 @@ import { ArgumentCheck } from "./Errors";
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /** Information about the user, allowing to identify them based on their id.
- * @alpha
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.UserInfo", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class HubUserInfo extends WsgInstance {
@@ -37,7 +37,7 @@ export class HubUserInfo extends WsgInstance {
 }
 
 /** Statistics of user created and owned instances on the iModel.
- * @alpha
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.UserInfo", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class UserStatistics extends HubUserInfo {
@@ -60,7 +60,7 @@ export class UserStatistics extends HubUserInfo {
 
 /**
  * Query object for getting User Statistics. You can use this to modify the [[UserStatisticsHandler.get]] results.
- * @alpha
+ * @public
  */
 export class UserStatisticsQuery extends WsgQuery {
   /** @internal */
@@ -70,7 +70,6 @@ export class UserStatisticsQuery extends WsgQuery {
   private _queriedByIds = false;
   /**
    * Constructor for UserStatisticsQuery.
-   * @internal
    */
   constructor() {
     super();
@@ -156,7 +155,7 @@ export class UserStatisticsQuery extends WsgQuery {
 
 /**
  * Handler for querying [[UserStatistics]]. Use [[UserInfoHandler.Statistics]] to get an instance of this class.
- * @alpha
+ * @public
  */
 export class UserStatisticsHandler {
   private _handler: IModelBaseHandler;
@@ -211,7 +210,7 @@ export class UserStatisticsHandler {
 }
 
 /** Query object for getting [[HubUserInfo]]. You can use this to modify the [[UserInfoHandler.get]] results.
- * @alpha
+ * @public
  */
 export class UserInfoQuery extends WsgQuery {
   private _queriedByIds = false;
@@ -266,7 +265,7 @@ export class UserInfoQuery extends WsgQuery {
 }
 
 /** Handler for querying [[HubUserInfo]]. Use [[IModelClient.Users]] to get an instance of this class.
- * @alpha
+ * @public
  */
 export class UserInfoHandler {
   private _handler: IModelBaseHandler;

--- a/clients/imodelhub/src/imodelhub/Versions.ts
+++ b/clients/imodelhub/src/imodelhub/Versions.ts
@@ -18,7 +18,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 
 /**
  * Named Version is a specific [[ChangeSet]] given a name to differentiate it from others. It can be used to represent some significant milestone for the iModel (e.g. a review version).
- * @beta
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "iModelScope.Version", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class Version extends WsgInstance {
@@ -49,18 +49,24 @@ export class Version extends WsgInstance {
   @ECJsonTypeMap.propertyToJson("wsg", "properties.Hidden")
   public hidden?: boolean;
 
-  /** Id of the [[SmallThumbnail]] of the named Version. */
+  /**
+   * Id of the [[SmallThumbnail]] of the named Version.
+   * @internal @deprecated
+   */
   @ECJsonTypeMap.propertyToJson("wsg", "relationshipInstances[HasThumbnail].relatedInstance[SmallThumbnail].instanceId")
   public smallThumbnailId?: GuidString;
 
-  /** Id of the [[LargeThumbnail]] of the named Version. */
+  /**
+   * Id of the [[LargeThumbnail]] of the named Version.
+   * @internal @deprecated
+   */
   @ECJsonTypeMap.propertyToJson("wsg", "relationshipInstances[HasThumbnail].relatedInstance[LargeThumbnail].instanceId")
   public largeThumbnailId?: GuidString;
 }
 
 /**
  * Query object for getting [[Version]]s. You can use this to modify the [[VersionHandler.get]] results.
- * @beta
+ * @public
  */
 export class VersionQuery extends InstanceIdQuery {
   /**
@@ -91,7 +97,7 @@ export class VersionQuery extends InstanceIdQuery {
    * Query will additionally select ids of [[Thumbnail]]s for given [[ThumbnailSize]]s.
    * @returns This query.
    * @throws [[IModelHubClientError]] with [IModelHubStatus.UndefinedArgumentError]($bentley) or [IModelHubStatus.InvalidArgumentError]($bentley) if sizes array is undefined or empty.
-   * @beta
+   * @internal @deprecated
    */
   public selectThumbnailId(...sizes: ThumbnailSize[]): this {
     ArgumentCheck.nonEmptyArray("sizes", sizes);
@@ -117,7 +123,7 @@ export class VersionQuery extends InstanceIdQuery {
 
 /**
  * Handler for managing [[Version]]s. Use [[IModelClient.Versions]] to get an instance of this class.
- * @beta
+ * @public
  */
 export class VersionHandler {
   private _handler: IModelBaseHandler;

--- a/clients/imodelhub/src/imodelhub/iModels.ts
+++ b/clients/imodelhub/src/imodelhub/iModels.ts
@@ -20,7 +20,7 @@ const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
  * HubIModel represents an iModel on iModelHub. Getting a valid HubIModel instance from iModelHub is required for majority of iModelHub method calls, as wsgId of this object needs to be passed as iModelId argument to those methods.
  *
  * For iModel representation in iModel.js, see [IModel]($common). For the file that is used for that iModel, see [BriefcaseDb]($backend).
- * @beta
+ * @public
  */
 @ECJsonTypeMap.classToJson("wsg", "ContextScope.iModel", { schemaPropertyName: "schemaName", classPropertyName: "className" })
 export class HubIModel extends WsgInstance {
@@ -68,7 +68,7 @@ export class HubIModel extends WsgInstance {
 }
 
 /** Initialization state of seed file. Can be queried with [[IModelHandler.getInitializationState]]. See [iModel creation]($docs/learning/iModelHub/iModels/CreateiModel.md).
- * @beta
+ * @public
  */
 export enum InitializationState {
   /** Initialization was successful. */
@@ -88,7 +88,7 @@ export enum InitializationState {
 }
 
 /** iModel type
- * @beta
+ * @public
  */
 export enum IModelType {
   /** iModel has no type. */
@@ -241,7 +241,7 @@ class SeedFileHandler {
 
 /**
  * Query object for getting [[HubIModel]] instances. You can use this to modify the [[IModelsHandler.get]] results.
- * @beta
+ * @public
  */
 export class IModelQuery extends InstanceIdQuery {
   /**
@@ -273,6 +273,7 @@ export class IModelQuery extends InstanceIdQuery {
    * @param type Type of the iModel.
    * @returns This query.
    * @throws [[IModelHubClientError]] with [IModelHubStatus.UndefinedArgumentError]($bentley) if iModelTemplate is undefined or empty.
+   * @internal
    */
   public byiModelTemplate(iModelTemplate: string) {
     ArgumentCheck.defined("iModelTemplate", iModelTemplate, true);
@@ -283,7 +284,7 @@ export class IModelQuery extends InstanceIdQuery {
 
 /**
  * Create an iModel by cloning another.
- * @beta
+ * @internal
  */
 export interface CloneIModelTemplate {
   /** Source iModel's Id. */
@@ -294,14 +295,14 @@ export interface CloneIModelTemplate {
 
 /**
  * Create an iModel from an empty file.
- * @beta
+ * @internal
  */
 export type EmptyIModelTemplate = "Empty";
 const iModelTemplateEmpty: EmptyIModelTemplate = "Empty";
 
 /**
  * Options used when creating an [[HubIModel]] with [[IModelHandler.create]] or [[IModelsHandler.create]].
- * @beta
+ * @public
  */
 export interface IModelCreateOptions {
   /** iModel seed file path. If not defined, iModel will be created from template. */
@@ -315,7 +316,10 @@ export interface IModelCreateOptions {
    * Default is 2 minutes.
    */
   timeOutInMilliseconds?: number;
-  /** Template used to create the seed file. Works only when path is not provided. Creates iModel from empty file by default. */
+  /**
+   * Template used to create the seed file. Works only when path is not provided. Creates iModel from empty file by default.
+   * @internal
+   */
   template?: CloneIModelTemplate | EmptyIModelTemplate;
 
   /** Type of iModel. */
@@ -364,7 +368,7 @@ export class DefaultIModelCreateOptionsProvider {
 /**
  * Handler for managing [[HubIModel]] instances. Use [[IModelHubClient.IModels]] to get an instance of this handler.
  * @note Use [[IModelHubClient.IModel]] for the preferred single iModel per context workflow.
- * @beta
+ * @public
  */
 export class IModelsHandler {
   private _handler: IModelBaseHandler;
@@ -451,7 +455,6 @@ export class IModelsHandler {
    * @param description Description of the iModel on the Hub.
    * @param iModelTemplate iModel template.
    * @param iModelType iModel type.
-   * @internal
    */
   private async createIModelInstance(requestContext: AuthorizedClientRequestContext, contextId: string, iModelName: string, description?: string, iModelTemplate?: string, iModelType?: IModelType, extent?: number[]): Promise<HubIModel> {
     requestContext.enter();
@@ -512,6 +515,7 @@ export class IModelsHandler {
    * @returns State of the seed file initialization.
    * @throws [[IModelHubError]] with [IModelHubStatus.FileDoesNotExist]($bentley) if the seed file was not found.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async getInitializationState(requestContext: AuthorizedClientRequestContext, iModelId: GuidString): Promise<InitializationState> {
     const seedFiles: SeedFile[] = await this._seedFileHandler.get(requestContext, iModelId, new SeedFileQuery().latest());
@@ -609,6 +613,7 @@ export class IModelsHandler {
    * @param createOptions Optional arguments for iModel creation.
    * @throws [[IModelHubError]] with [IModelHubStatus.UserDoesNotHavePermission]($bentley) if the user does not have CreateiModel permission.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async create(requestContext: AuthorizedClientRequestContext, contextId: string, name: string, createOptions?: IModelCreateOptions): Promise<HubIModel> {
     requestContext.enter();
@@ -685,6 +690,7 @@ export class IModelsHandler {
    * @param path Path to download the seed file to, including file name.
    * @param progressCallback Callback for tracking progress.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async download(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, path: string, progressCallback?: ProgressCallback): Promise<void> {
     requestContext.enter();
@@ -771,6 +777,7 @@ export class IModelHandler {
    * @throws [[IModelHubError]] with [IModelHubStatus.iModelDoesNotExist]$(bentley) if iModel does not exist.
    * @throws [[IModelHubError]] with [IModelHubStatus.FileDoesNotExist]($bentley) if the seed file was not found.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async getInitializationState(requestContext: AuthorizedClientRequestContext, contextId: string): Promise<InitializationState> {
     const imodel = await this.get(requestContext, contextId);
@@ -787,6 +794,7 @@ export class IModelHandler {
    * @param createOptions Optional arguments for iModel creation.
    * @throws [[IModelHubError]] with [IModelHubStatus.UserDoesNotHavePermission]($bentley) if the user does not have CreateiModel permission.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async create(requestContext: AuthorizedClientRequestContext, contextId: string, name: string, createOptions?: IModelCreateOptions): Promise<HubIModel> {
     requestContext.enter();
@@ -831,6 +839,7 @@ export class IModelHandler {
    * @param progressCallback Callback for tracking progress.
    * @throws [[IModelHubError]] with [IModelHubStatus.iModelDoesNotExist]$(bentley) if iModel does not exist.
    * @throws [Common iModelHub errors]($docs/learning/iModelHub/CommonErrors)
+   * @internal
    */
   public async download(requestContext: AuthorizedClientRequestContext, contextId: string, path: string, progressCallback?: ProgressCallback): Promise<void> {
     const imodel = await this.get(requestContext, contextId);

--- a/common/api/imodelhub-client.api.md
+++ b/common/api/imodelhub-client.api.md
@@ -52,16 +52,16 @@ export function addSelectContainerAccessKey(query: RequestQueryOptions): void;
 // @internal
 export function addSelectFileAccessKey(query: RequestQueryOptions): void;
 
-// @internal
+// @public
 export class AggregateResponseError extends Error {
     errors: ResponseError[];
 }
 
-// @alpha
+// @internal
 export class AllCodesDeletedEvent extends BriefcaseEvent {
 }
 
-// @alpha
+// @internal
 export class AllLocksDeletedEvent extends BriefcaseEvent {
 }
 
@@ -121,7 +121,7 @@ export enum BriefcaseAccessMode {
 export class BriefcaseDeletedEvent extends BriefcaseEvent {
 }
 
-// @beta
+// @public
 export abstract class BriefcaseEvent extends IModelHubEvent {
     briefcaseId: number;
     // @internal
@@ -147,7 +147,7 @@ export class BriefcaseQuery extends WsgQuery {
     selectDownloadUrl(): this;
 }
 
-// @beta
+// @public
 export class ChangeSet extends WsgInstance {
     applicationId?: string;
     applicationName?: string;
@@ -157,17 +157,21 @@ export class ChangeSet extends WsgInstance {
     briefcaseId?: number;
     changesType?: ChangesType;
     description?: string;
+    // @internal
     downloadUrl?: string;
     fileName?: string;
     fileSize?: string;
     get fileSizeNumber(): number;
     id?: string;
     index?: string;
+    // @internal
     isUploaded?: boolean;
     parentId?: string;
     pathname?: string;
     pushDate?: string;
+    // @internal @deprecated
     seedFileId?: GuidString;
+    // @internal
     uploadUrl?: string;
     userCreated?: string;
 }
@@ -183,16 +187,18 @@ export class ChangeSetCreatedEvent extends IModelHubGlobalEvent {
     fromJson(obj: any): void;
 }
 
-// @beta
+// @public
 export class ChangeSetHandler {
     // @internal
     constructor(handler: IModelBaseHandler, fileHandler?: FileHandler);
+    // @internal
     create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, changeSet: ChangeSet, path: string, progressCallback?: ProgressCallback): Promise<ChangeSet>;
+    // @internal
     download(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query: ChangeSetQuery, path: string, progressCallback?: ProgressCallback): Promise<ChangeSet[]>;
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query?: ChangeSetQuery): Promise<ChangeSet[]>;
     }
 
-// @beta
+// @public
 export class ChangeSetPostPushEvent extends BriefcaseEvent {
     changeSetId: string;
     changeSetIndex: string;
@@ -200,11 +206,11 @@ export class ChangeSetPostPushEvent extends BriefcaseEvent {
     fromJson(obj: any): void;
 }
 
-// @beta
+// @public
 export class ChangeSetPrePushEvent extends IModelHubEvent {
 }
 
-// @beta
+// @public
 export class ChangeSetQuery extends StringIdQuery {
     constructor();
     afterVersion(versionId: GuidString): this;
@@ -226,7 +232,7 @@ export class ChangeSetQuery extends StringIdQuery {
     selectDownloadUrl(): this;
 }
 
-// @beta
+// @public
 export enum ChangesType {
     Definition = 2,
     GlobalProperties = 32,
@@ -237,7 +243,7 @@ export enum ChangesType {
     ViewsAndModels = 16
 }
 
-// @alpha
+// @internal
 export class Checkpoint extends WsgInstance {
     createdDate?: string;
     downloadUrl?: string;
@@ -249,23 +255,22 @@ export class Checkpoint extends WsgInstance {
     state?: InitializationState;
 }
 
-// @beta
+// @internal
 export class CheckpointCreatedEvent extends IModelHubEvent {
     changeSetId: string;
     changeSetIndex: string;
-    // @internal
     fromJson(obj: any): void;
     versionId?: GuidString;
 }
 
-// @alpha
+// @internal
 export class CheckpointHandler {
     constructor(handler: IModelBaseHandler, fileHandler?: FileHandler);
     download(requestContext: AuthorizedClientRequestContext, checkpoint: Checkpoint, path: string, progressCallback?: ProgressCallback, cancelRequest?: CancelRequest): Promise<void>;
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query?: CheckpointQuery): Promise<Checkpoint[]>;
     }
 
-// @alpha
+// @internal
 export class CheckpointQuery extends WsgQuery {
     byChangeSetId(changeSetId: string): this;
     nearestCheckpoint(targetChangeSetId: string): this;
@@ -273,7 +278,7 @@ export class CheckpointQuery extends WsgQuery {
     selectDownloadUrl(): this;
 }
 
-// @alpha
+// @internal
 export class CheckpointV2 extends WsgInstance {
     changeSetId?: string;
     containerAccessKeyAccount?: string;
@@ -289,7 +294,7 @@ export class CheckpointV2 extends WsgInstance {
     state?: CheckpointV2State;
 }
 
-// @alpha
+// @internal
 export enum CheckpointV2ErrorId {
     // (undocumented)
     ApplyChangeSetError = 4,
@@ -305,17 +310,15 @@ export enum CheckpointV2ErrorId {
     UnknownError = 0
 }
 
-// @alpha
+// @internal
 export class CheckpointV2Handler {
     constructor(handler: IModelBaseHandler);
-    // @internal
     create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, checkpoint: CheckpointV2): Promise<CheckpointV2>;
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query?: CheckpointV2Query): Promise<CheckpointV2[]>;
-    // @internal
     update(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, checkpoint: CheckpointV2): Promise<CheckpointV2>;
 }
 
-// @alpha
+// @internal
 export class CheckpointV2Query extends WsgQuery {
     byChangeSetId(changeSetId: string): this;
     byState(state: CheckpointV2State): this;
@@ -324,20 +327,20 @@ export class CheckpointV2Query extends WsgQuery {
     selectFailureInfo(): this;
 }
 
-// @alpha
+// @internal
 export enum CheckpointV2State {
     Failed = 2,
     InProgress = 0,
     Successful = 1
 }
 
-// @beta
+// @internal
 export interface CloneIModelTemplate {
     changeSetId?: string;
     imodelId: string;
 }
 
-// @alpha
+// @internal
 export class CodeBase extends WsgInstance {
     briefcaseId?: number;
     codeScope?: string;
@@ -347,19 +350,17 @@ export class CodeBase extends WsgInstance {
     state?: CodeState;
 }
 
-// @alpha
+// @internal
 export class CodeEvent extends BriefcaseEvent {
     codeScope: string;
     codeSpecId: Id64String;
-    // @internal
     fromJson(obj: any): void;
     state: CodeState;
     values: string[];
 }
 
-// @alpha
+// @internal
 export class CodeHandler {
-    // @internal
     constructor(handler: IModelBaseHandler);
     deleteAll(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, briefcaseId: number): Promise<void>;
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query?: CodeQuery): Promise<HubCode[]>;
@@ -367,21 +368,19 @@ export class CodeHandler {
     update(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, codes: HubCode[], updateOptions?: CodeUpdateOptions): Promise<HubCode[]>;
     }
 
-// @alpha
+// @internal
 export class CodeQuery extends WsgQuery {
     constructor();
     byBriefcaseId(briefcaseId: number): this;
     byCodes(codes: HubCode[]): this;
     byCodeScope(codeScope: string): this;
     byCodeSpecId(codeSpecId: Id64String): this;
-    // @internal
     static defaultPageSize: number;
-    // @internal
     get isMultiCodeQuery(): boolean;
     unavailableCodes(briefcaseId: number): this;
 }
 
-// @alpha
+// @internal
 export class CodeSequence extends WsgInstance {
     codeScope?: string;
     codeSpecId?: Id64String;
@@ -392,20 +391,19 @@ export class CodeSequence extends WsgInstance {
     valuePattern?: string;
 }
 
-// @alpha
+// @internal
 export class CodeSequenceHandler {
-    // @internal
     constructor(handler: IModelBaseHandler);
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, sequence: CodeSequence): Promise<string>;
     }
 
-// @alpha
+// @internal
 export enum CodeSequenceType {
     LargestUsed = 0,
     NextAvailable = 1
 }
 
-// @alpha
+// @internal
 export enum CodeState {
     Available = 0,
     Reserved = 1,
@@ -413,7 +411,7 @@ export enum CodeState {
     Used = 2
 }
 
-// @alpha
+// @internal
 export interface CodeUpdateOptions {
     codesPerRequest?: number;
     continueOnConflict?: boolean;
@@ -421,21 +419,17 @@ export interface CodeUpdateOptions {
     unlimitedReporting?: boolean;
 }
 
-// @alpha
+// @internal
 export class ConflictingCodesError extends IModelHubError {
-    // @internal
     addCodes(error: IModelHubError): void;
     conflictingCodes?: HubCode[];
-    // @internal
     static fromError(error: IModelHubError): ConflictingCodesError | undefined;
 }
 
-// @alpha
+// @internal
 export class ConflictingLocksError extends IModelHubError {
-    // @internal
     addLocks(error: IModelHubError): void;
     conflictingLocks?: Lock[];
-    // @internal
     static fromError(error: IModelHubError): ConflictingLocksError | undefined;
 }
 
@@ -475,10 +469,10 @@ export class DefaultLockUpdateOptionsProvider {
     protected _defaultOptions: LockUpdateOptions;
 }
 
-// @beta
+// @internal
 export type EmptyIModelTemplate = "Empty";
 
-// @beta
+// @public
 export class EventHandler extends EventBaseHandler {
     // @internal
     constructor(handler: IModelBaseHandler);
@@ -488,26 +482,26 @@ export class EventHandler extends EventBaseHandler {
     get subscriptions(): EventSubscriptionHandler;
 }
 
-// @beta
+// @public
 export class EventSAS extends BaseEventSAS {
 }
 
-// @beta
+// @public
 export class EventSubscription extends WsgInstance {
     eventTypes?: IModelHubEventType[];
 }
 
-// @beta
+// @public
 export class EventSubscriptionHandler {
     constructor(handler: IModelBaseHandler);
     create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, events: IModelHubEventType[]): Promise<EventSubscription>;
-    // @deprecated
+    // @internal @deprecated
     create(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, events: EventType[]): Promise<EventSubscription>;
     delete(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, eventSubscriptionId: string): Promise<void>;
     update(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, subscription: EventSubscription): Promise<EventSubscription>;
 }
 
-// @beta @deprecated (undocumented)
+// @internal @deprecated (undocumented)
 export type EventType = "LockEvent" | "AllLocksDeletedEvent" | "ChangeSetPostPushEvent" | "ChangeSetPrePushEvent" | "CodeEvent" | "AllCodesDeletedEvent" | "BriefcaseDeletedEvent" | "iModelDeletedEvent" | "VersionEvent" | "CheckpointCreatedEvent";
 
 // @internal
@@ -584,12 +578,12 @@ export class HardiModelDeleteEvent extends IModelHubGlobalEvent {
 // @beta
 export type HttpRequestOptionsTransformer = (options: HttpRequestOptions) => void;
 
-// @alpha
+// @internal
 export class HubCode extends CodeBase {
     value?: string;
 }
 
-// @beta
+// @public
 export class HubIModel extends WsgInstance {
     createdDate?: string;
     description?: string;
@@ -604,7 +598,7 @@ export class HubIModel extends WsgInstance {
     userCreated?: string;
 }
 
-// @alpha
+// @public
 export class HubUserInfo extends WsgInstance {
     email?: string;
     firstName?: string;
@@ -634,7 +628,7 @@ export class IModelBankFileSystemContextClient implements ContextManagerClient {
     queryProjectByName(requestContext: AuthorizedClientRequestContext, projectName: string): Promise<Project>;
 }
 
-// @beta
+// @internal
 export class IModelBankHandler extends IModelBaseHandler {
     constructor(url: string, handler: FileHandler | undefined, keepAliveDuration?: number);
     // (undocumented)
@@ -643,7 +637,7 @@ export class IModelBankHandler extends IModelBaseHandler {
     protected getUrlSearchKey(): string;
 }
 
-// @beta
+// @public
 export class IModelBaseHandler extends WsgClient {
     // @internal
     constructor(keepAliveDuration?: number, fileHandler?: FileHandler);
@@ -655,40 +649,48 @@ export class IModelBaseHandler extends WsgClient {
     deleteInstance<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, relativeUrlPath: string, instance?: T, requestOptions?: WsgRequestOptions): Promise<void>;
     // (undocumented)
     protected _fileHandler: FileHandler | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     formatContextIdForUrl(contextId: string): string;
+    // @internal
     getAgent(): any;
+    // @internal
     getCustomRequestOptions(): CustomRequestOptions;
-    // (undocumented)
+    // @internal (undocumented)
     getFileHandler(): FileHandler | undefined;
     getInstances<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, typedConstructor: new () => T, relativeUrlPath: string, queryOptions?: RequestQueryOptions, httpRequestOptions?: HttpRequestOptions): Promise<T[]>;
     getInstancesChunk<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, url: string, chunkedQueryContext: ChunkedQueryContext | undefined, typedConstructor: new () => T, queryOptions?: RequestQueryOptions, httpRequestOptions?: HttpRequestOptions): Promise<T[]>;
+    // @internal
     protected getRelyingPartyUrl(): string;
+    // @internal
     getUrl(requestContext: ClientRequestContext): Promise<string>;
+    // @internal
     protected getUrlSearchKey(): string;
     postInstance<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, typedConstructor: new () => T, relativeUrlPath: string, instance: T, requestOptions?: WsgRequestOptions, httpRequestOptions?: HttpRequestOptions): Promise<T>;
     postInstances<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, typedConstructor: new () => T, relativeUrlPath: string, instances: T[], requestOptions?: WsgRequestOptions, httpRequestOptions?: HttpRequestOptions): Promise<T[]>;
     postQuery<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, typedConstructor: new () => T, relativeUrlPath: string, queryOptions: RequestQueryOptions, httpRequestOptions?: HttpRequestOptions): Promise<T[]>;
     // (undocumented)
     static readonly searchKey: string;
+    // @internal
     protected setupHttpOptions(options?: HttpRequestOptions): HttpRequestOptions;
+    // @internal
     protected setupOptionDefaults(options: RequestOptions): Promise<void>;
     // (undocumented)
     protected _url?: string;
+    // @beta
     use(func: HttpRequestOptionsTransformer): void;
 }
 
-// @beta
+// @public
 export abstract class IModelClient {
     constructor(baseHandler: IModelBaseHandler, fileHandler?: FileHandler, applicationVersion?: string);
     // @internal
     get briefcases(): BriefcaseHandler;
     get changeSets(): ChangeSetHandler;
-    // @alpha
+    // @internal
     get checkpoints(): CheckpointHandler;
-    // @alpha
+    // @internal
     get checkpointsV2(): CheckpointV2Handler;
-    // @alpha
+    // @internal
     get codes(): CodeHandler;
     get events(): EventHandler;
     get fileHandler(): FileHandler | undefined;
@@ -696,19 +698,19 @@ export abstract class IModelClient {
     get globalEvents(): GlobalEventHandler;
     // (undocumented)
     protected _handler: IModelBaseHandler;
+    // @beta
     get iModel(): IModelHandler;
     get iModels(): IModelsHandler;
-    // @alpha
+    // @internal
     get locks(): LockHandler;
     // @internal
     get permissions(): PermissionHandler | undefined;
     // @internal
     get requestOptions(): CustomRequestOptions;
     setFileHandler(fileHandler: FileHandler): void;
-    // @alpha
     get thumbnails(): ThumbnailHandler;
+    // @beta
     use(transformer: HttpRequestOptionsTransformer): void;
-    // @alpha
     get users(): UserInfoHandler;
     get versions(): VersionHandler;
 }
@@ -733,18 +735,19 @@ export interface IModelCloudEnvironment {
 export class IModelCreatedEvent extends IModelHubGlobalEvent {
 }
 
-// @beta
+// @public
 export interface IModelCreateOptions {
     description?: string;
     extent?: number[];
     iModelType?: IModelType;
     path?: string;
     progressCallback?: ProgressCallback;
+    // @internal
     template?: CloneIModelTemplate | EmptyIModelTemplate;
     timeOutInMilliseconds?: number;
 }
 
-// @beta
+// @public
 export class IModelDeletedEvent extends IModelHubEvent {
 }
 
@@ -762,22 +765,25 @@ export interface IModelFileSystemContextProps {
 export class IModelHandler {
     // @internal
     constructor(handler: IModelsHandler);
+    // @internal
     create(requestContext: AuthorizedClientRequestContext, contextId: string, name: string, createOptions?: IModelCreateOptions): Promise<HubIModel>;
     delete(requestContext: AuthorizedClientRequestContext, contextId: string): Promise<void>;
+    // @internal
     download(requestContext: AuthorizedClientRequestContext, contextId: string, path: string, progressCallback?: ProgressCallback): Promise<void>;
     get(requestContext: AuthorizedClientRequestContext, contextId: string): Promise<HubIModel>;
+    // @internal
     getInitializationState(requestContext: AuthorizedClientRequestContext, contextId: string): Promise<InitializationState>;
     update(requestContext: AuthorizedClientRequestContext, contextId: string, imodel: HubIModel): Promise<HubIModel>;
 }
 
-// @beta
+// @public
 export class IModelHubClient extends IModelClient {
     constructor(fileHandler?: FileHandler, iModelBaseHandler?: IModelBaseHandler, applicationVersion?: string);
     // @internal
     get permissions(): PermissionHandler;
 }
 
-// @beta
+// @public
 export class IModelHubClientError extends IModelHubError {
     // @internal
     static browser(): IModelHubClientError;
@@ -797,14 +803,14 @@ export class IModelHubClientError extends IModelHubError {
     static undefinedArgument(argumentName: string): IModelHubClientError;
 }
 
-// @beta
+// @public
 export enum IModelHubClientLoggerCategory {
     // @internal (undocumented)
     IModelBank = "imodelhub-client.iModelBank",
     IModelHub = "imodelhub-client.iModelHub"
 }
 
-// @beta
+// @public
 export class IModelHubError extends WsgError {
     // @internal
     constructor(errorNumber: number | HttpStatus, message?: string, getMetaData?: GetMetaDataFunction);
@@ -821,28 +827,29 @@ export class IModelHubError extends WsgError {
     static shouldRetry(error: any, response: any): boolean;
 }
 
-// @beta
+// @public
 export abstract class IModelHubEvent extends IModelHubBaseEvent {
     // @internal
     fromJson(obj: any): void;
     iModelId?: GuidString;
 }
 
-// @beta
+// @public
 export enum IModelHubEventType {
-    // @alpha
+    // @internal
     AllCodesDeletedEvent = "AllCodesDeletedEvent",
-    // @alpha
+    // @internal
     AllLocksDeletedEvent = "AllLocksDeletedEvent",
     // @internal
     BriefcaseDeletedEvent = "BriefcaseDeletedEvent",
     ChangeSetPostPushEvent = "ChangeSetPostPushEvent",
     ChangeSetPrePushEvent = "ChangeSetPrePushEvent",
+    // @internal
     CheckpointCreatedEvent = "CheckpointCreatedEvent",
-    // @alpha
+    // @internal
     CodeEvent = "CodeEvent",
     iModelDeletedEvent = "iModelDeletedEvent",
-    // @alpha
+    // @internal
     LockEvent = "LockEvent",
     VersionEvent = "VersionEvent"
 }
@@ -878,32 +885,36 @@ export enum IModelHubPermission {
     View = 64
 }
 
-// @beta
+// @public
 export class IModelQuery extends InstanceIdQuery {
+    // @internal
     byiModelTemplate(iModelTemplate: string): this;
     byiModelType(iModelType: IModelType): this;
     byName(name: string): this;
 }
 
-// @beta
+// @public
 export class IModelsHandler {
     // @internal
     constructor(handler: IModelBaseHandler, fileHandler?: FileHandler);
+    // @internal
     create(requestContext: AuthorizedClientRequestContext, contextId: string, name: string, createOptions?: IModelCreateOptions): Promise<HubIModel>;
     delete(requestContext: AuthorizedClientRequestContext, contextId: string, iModelId: GuidString): Promise<void>;
+    // @internal
     download(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, path: string, progressCallback?: ProgressCallback): Promise<void>;
     get(requestContext: AuthorizedClientRequestContext, contextId: string, query?: IModelQuery): Promise<HubIModel[]>;
+    // @internal
     getInitializationState(requestContext: AuthorizedClientRequestContext, iModelId: GuidString): Promise<InitializationState>;
     update(requestContext: AuthorizedClientRequestContext, contextId: string, imodel: HubIModel): Promise<HubIModel>;
     }
 
-// @beta
+// @public
 export enum IModelType {
     Library = 1,
     Undefined = 0
 }
 
-// @beta
+// @public
 export enum InitializationState {
     CodeTooLong = 5,
     Failed = 3,
@@ -914,7 +925,7 @@ export enum InitializationState {
     Successful = 0
 }
 
-// @beta
+// @public
 export class InstanceIdQuery extends WsgQuery {
     byId(id: GuidString): this;
     // @internal (undocumented)
@@ -923,16 +934,16 @@ export class InstanceIdQuery extends WsgQuery {
     getId(): string | undefined;
 }
 
-// @alpha
+// @public
 export class LargeThumbnail extends Thumbnail {
 }
 
-// @alpha
+// @internal
 export class Lock extends LockBase {
     objectId?: Id64String;
 }
 
-// @alpha
+// @internal
 export class LockBase extends WsgInstance {
     briefcaseId?: number;
     lockLevel?: LockLevel;
@@ -942,9 +953,8 @@ export class LockBase extends WsgInstance {
     seedFileId?: GuidString;
 }
 
-// @alpha
+// @internal
 export class LockEvent extends BriefcaseEvent {
-    // @internal
     fromJson(obj: any): void;
     lockLevel: LockLevel;
     lockType: LockType;
@@ -952,23 +962,22 @@ export class LockEvent extends BriefcaseEvent {
     releasedWithChangeSet?: string;
 }
 
-// @alpha
+// @internal
 export class LockHandler {
-    // @internal
     constructor(handler: IModelBaseHandler);
     deleteAll(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, briefcaseId: number): Promise<void>;
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query?: LockQuery): Promise<Lock[]>;
     update(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, locks: Lock[], updateOptions?: LockUpdateOptions): Promise<Lock[]>;
     }
 
-// @alpha
+// @internal
 export enum LockLevel {
     Exclusive = 2,
     None = 0,
     Shared = 1
 }
 
-// @alpha
+// @internal
 export class LockQuery extends WsgQuery {
     constructor();
     byBriefcaseId(briefcaseId: number): this;
@@ -978,14 +987,12 @@ export class LockQuery extends WsgQuery {
     byObjectId(objectId: Id64String): this;
     byReleasedWithChangeSet(changeSetId: string): this;
     byReleasedWithChangeSetIndex(changeSetIndex: number): this;
-    // @internal
     static defaultPageSize: number;
-    // @internal
     get isMultiLockQuery(): boolean;
     unavailableLocks(briefcaseId: number, lastChangeSetIndex: string): this;
 }
 
-// @alpha
+// @internal
 export enum LockType {
     CodeSpecs = 4,
     Db = 0,
@@ -994,7 +1001,7 @@ export enum LockType {
     Schemas = 3
 }
 
-// @alpha
+// @internal
 export interface LockUpdateOptions {
     continueOnConflict?: boolean;
     deniedLocks?: boolean;
@@ -1008,7 +1015,7 @@ export class MultiCode extends CodeBase {
     values?: string[];
 }
 
-// @alpha
+// @internal
 export class MultiLock extends LockBase {
     // (undocumented)
     objectIds?: Id64String[];
@@ -1069,7 +1076,7 @@ export class SeedFile extends WsgInstance {
     userUploaded?: string;
 }
 
-// @alpha
+// @public
 export class SmallThumbnail extends Thumbnail {
 }
 
@@ -1077,7 +1084,7 @@ export class SmallThumbnail extends Thumbnail {
 export class SoftiModelDeleteEvent extends IModelHubGlobalEvent {
 }
 
-// @beta
+// @public
 export class StringIdQuery extends WsgQuery {
     byId(id: string): this;
     // @internal (undocumented)
@@ -1088,13 +1095,13 @@ export class StringIdQuery extends WsgQuery {
     getId(): string | undefined;
 }
 
-// @alpha
+// @public
 export abstract class Thumbnail extends WsgInstance {
     // (undocumented)
     id?: GuidString;
 }
 
-// @alpha
+// @public
 export class ThumbnailHandler {
     // @internal
     constructor(handler: IModelBaseHandler);
@@ -1102,21 +1109,22 @@ export class ThumbnailHandler {
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, size: ThumbnailSize, query?: ThumbnailQuery): Promise<Thumbnail[]>;
     }
 
-// @alpha
+// @public
 export class ThumbnailQuery extends InstanceIdQuery {
+    // @internal @deprecated
     byVersionId(versionId: GuidString): this;
 }
 
-// @beta
+// @public
 export type ThumbnailSize = "Small" | "Large";
 
-// @alpha
+// @public
 export interface TipThumbnail {
     contextId: string;
     size: ThumbnailSize;
 }
 
-// @alpha
+// @public
 export class UserInfoHandler {
     // @internal
     constructor(handler: IModelBaseHandler);
@@ -1124,7 +1132,7 @@ export class UserInfoHandler {
     get statistics(): UserStatisticsHandler;
 }
 
-// @alpha
+// @public
 export class UserInfoQuery extends WsgQuery {
     byId(id: string): this;
     // @internal (undocumented)
@@ -1136,7 +1144,7 @@ export class UserInfoQuery extends WsgQuery {
     get isQueriedByIds(): boolean;
     }
 
-// @alpha
+// @public
 export class UserStatistics extends HubUserInfo {
     briefcasesCount?: number;
     lastChangeSetPushDate?: string;
@@ -1144,16 +1152,15 @@ export class UserStatistics extends HubUserInfo {
     pushedChangeSetsCount?: number;
 }
 
-// @alpha
+// @public
 export class UserStatisticsHandler {
     // @internal
     constructor(handler: IModelBaseHandler);
     get(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, query?: UserStatisticsQuery): Promise<UserStatistics[]>;
     }
 
-// @alpha
+// @public
 export class UserStatisticsQuery extends WsgQuery {
-    // @internal
     constructor();
     byId(id: string): this;
     // @internal (undocumented)
@@ -1170,7 +1177,7 @@ export class UserStatisticsQuery extends WsgQuery {
     selectPushedChangeSetsCount(): this;
     }
 
-// @beta
+// @public
 export class Version extends WsgInstance {
     changeSetId?: GuidString;
     createdDate?: string;
@@ -1178,13 +1185,15 @@ export class Version extends WsgInstance {
     hidden?: boolean;
     // (undocumented)
     id?: GuidString;
+    // @internal @deprecated
     largeThumbnailId?: GuidString;
     name?: string;
+    // @internal @deprecated
     smallThumbnailId?: GuidString;
     userCreated?: string;
 }
 
-// @beta
+// @public
 export class VersionEvent extends IModelHubEvent {
     changeSetId: string;
     // @internal
@@ -1193,7 +1202,7 @@ export class VersionEvent extends IModelHubEvent {
     versionName: string;
 }
 
-// @beta
+// @public
 export class VersionHandler {
     // @internal
     constructor(handler: IModelBaseHandler);
@@ -1202,11 +1211,12 @@ export class VersionHandler {
     update(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, version: Version): Promise<Version>;
 }
 
-// @beta
+// @public
 export class VersionQuery extends InstanceIdQuery {
     byChangeSet(changeSetId: string): this;
     byName(name: string): this;
     notHidden(): this;
+    // @internal @deprecated
     selectThumbnailId(...sizes: ThumbnailSize[]): this;
 }
 

--- a/common/api/summary/imodelhub-client.exports.csv
+++ b/common/api/summary/imodelhub-client.exports.csv
@@ -6,55 +6,55 @@ beta;addHeader(name: string, valueFactory: () => string): HttpRequestOptionsTran
 internal;addSelectApplicationData(query: RequestQueryOptions): void
 internal;addSelectContainerAccessKey(query: RequestQueryOptions): void
 internal;addSelectFileAccessKey(query: RequestQueryOptions): void
-internal;AggregateResponseError 
-alpha;AllCodesDeletedEvent 
-alpha;AllLocksDeletedEvent 
+public;AggregateResponseError 
+internal;AllCodesDeletedEvent 
+internal;AllLocksDeletedEvent 
 internal;ArgumentCheck
 internal;Briefcase 
 internal;BriefcaseAccessMode
 internal;BriefcaseDeletedEvent 
-beta;class BriefcaseEvent 
+public;class BriefcaseEvent 
 internal;BriefcaseHandler
 internal;BriefcaseQuery 
-beta;ChangeSet 
+public;ChangeSet 
 internal;ChangeSetCreatedEvent 
-beta;ChangeSetHandler
-beta;ChangeSetPostPushEvent 
-beta;ChangeSetPrePushEvent 
-beta;ChangeSetQuery 
-beta;ChangesType
-alpha;Checkpoint 
-beta;CheckpointCreatedEvent 
-alpha;CheckpointHandler
-alpha;CheckpointQuery 
-alpha;CheckpointV2 
-alpha;CheckpointV2ErrorId
-alpha;CheckpointV2Handler
-alpha;CheckpointV2Query 
-alpha;CheckpointV2State
-beta;CloneIModelTemplate
-alpha;CodeBase 
-alpha;CodeEvent 
-alpha;CodeHandler
-alpha;CodeQuery 
-alpha;CodeSequence 
-alpha;CodeSequenceHandler
-alpha;CodeSequenceType
-alpha;CodeState
-alpha;CodeUpdateOptions
-alpha;ConflictingCodesError 
-alpha;ConflictingLocksError 
+public;ChangeSetHandler
+public;ChangeSetPostPushEvent 
+public;ChangeSetPrePushEvent 
+public;ChangeSetQuery 
+public;ChangesType
+internal;Checkpoint 
+internal;CheckpointCreatedEvent 
+internal;CheckpointHandler
+internal;CheckpointQuery 
+internal;CheckpointV2 
+internal;CheckpointV2ErrorId
+internal;CheckpointV2Handler
+internal;CheckpointV2Query 
+internal;CheckpointV2State
+internal;CloneIModelTemplate
+internal;CodeBase 
+internal;CodeEvent 
+internal;CodeHandler
+internal;CodeQuery 
+internal;CodeSequence 
+internal;CodeSequenceHandler
+internal;CodeSequenceType
+internal;CodeState
+internal;CodeUpdateOptions
+internal;ConflictingCodesError 
+internal;ConflictingLocksError 
 internal;constructorFromEventType(type: IModelHubEventType): EventConstructor
 internal;ContextManagerClient
 internal;DefaultCodeUpdateOptionsProvider
 internal;DefaultIModelCreateOptionsProvider
 internal;DefaultLockUpdateOptionsProvider
-beta;EmptyIModelTemplate = "Empty"
-beta;EventHandler 
-beta;EventSAS 
-beta;EventSubscription 
-beta;EventSubscriptionHandler
-beta;EventType = "LockEvent" | "AllLocksDeletedEvent" | "ChangeSetPostPushEvent" | "ChangeSetPrePushEvent" | "CodeEvent" | "AllCodesDeletedEvent" | "BriefcaseDeletedEvent" | "iModelDeletedEvent" | "VersionEvent" | "CheckpointCreatedEvent"
+internal;EmptyIModelTemplate = "Empty"
+public;EventHandler 
+public;EventSAS 
+public;EventSubscription 
+public;EventSubscriptionHandler
+internal;EventType = "LockEvent" | "AllLocksDeletedEvent" | "ChangeSetPostPushEvent" | "ChangeSetPrePushEvent" | "CodeEvent" | "AllCodesDeletedEvent" | "BriefcaseDeletedEvent" | "iModelDeletedEvent" | "VersionEvent" | "CheckpointCreatedEvent"
 internal;GetEventOperationType
 internal;GlobalCheckpointCreatedEvent 
 internal;GlobalEventHandler 
@@ -63,63 +63,63 @@ internal;GlobalEventSubscription
 internal;GlobalEventSubscriptionHandler
 internal;HardiModelDeleteEvent 
 beta;HttpRequestOptionsTransformer = (options: HttpRequestOptions) => void
-alpha;HubCode 
-beta;HubIModel 
-alpha;HubUserInfo 
+internal;HubCode 
+public;HubIModel 
+public;HubUserInfo 
 internal;IModelBankClient 
 internal;IModelBankFileSystemContextClient 
-beta;IModelBankHandler 
-beta;IModelBaseHandler 
-beta;class IModelClient
+internal;IModelBankHandler 
+public;IModelBaseHandler 
+public;class IModelClient
 internal;IModelCloudEnvironment
 internal;IModelCreatedEvent 
-beta;IModelCreateOptions
-beta;IModelDeletedEvent 
+public;IModelCreateOptions
+public;IModelDeletedEvent 
 internal;IModelFileSystemContextProps
 beta;IModelHandler
-beta;IModelHubClient 
-beta;IModelHubClientError 
-beta;IModelHubClientLoggerCategory
-beta;IModelHubError 
-beta;class IModelHubEvent 
-beta;IModelHubEventType
+public;IModelHubClient 
+public;IModelHubClientError 
+public;IModelHubClientLoggerCategory
+public;IModelHubError 
+public;class IModelHubEvent 
+public;IModelHubEventType
 internal;class IModelHubGlobalEvent 
 internal;IModelHubPermission
-beta;IModelQuery 
-beta;IModelsHandler
-beta;IModelType
-beta;InitializationState
-beta;InstanceIdQuery 
-alpha;LargeThumbnail 
-alpha;Lock 
-alpha;LockBase 
-alpha;LockEvent 
-alpha;LockHandler
-alpha;LockLevel
-alpha;LockQuery 
-alpha;LockType
-alpha;LockUpdateOptions
+public;IModelQuery 
+public;IModelsHandler
+public;IModelType
+public;InitializationState
+public;InstanceIdQuery 
+public;LargeThumbnail 
+internal;Lock 
+internal;LockBase 
+internal;LockEvent 
+internal;LockHandler
+internal;LockLevel
+internal;LockQuery 
+internal;LockType
+internal;LockUpdateOptions
 internal;MultiCode 
-alpha;MultiLock 
+internal;MultiLock 
 internal;NamedVersionCreatedEvent 
 internal;ParseEvent(response: Response): IModelHubEvent
 internal;ParseGlobalEvent(response: Response, handler?: IModelBaseHandler, sasToken?: string): IModelHubGlobalEvent
 internal;PermissionHandler
 internal;SeedFile 
-alpha;SmallThumbnail 
+public;SmallThumbnail 
 internal;SoftiModelDeleteEvent 
-beta;StringIdQuery 
-alpha;class Thumbnail 
-alpha;ThumbnailHandler
-alpha;ThumbnailQuery 
-beta;ThumbnailSize = "Small" | "Large"
-alpha;TipThumbnail
-alpha;UserInfoHandler
-alpha;UserInfoQuery 
-alpha;UserStatistics 
-alpha;UserStatisticsHandler
-alpha;UserStatisticsQuery 
-beta;Version 
-beta;VersionEvent 
-beta;VersionHandler
-beta;VersionQuery 
+public;StringIdQuery 
+public;class Thumbnail 
+public;ThumbnailHandler
+public;ThumbnailQuery 
+public;ThumbnailSize = "Small" | "Large"
+public;TipThumbnail
+public;UserInfoHandler
+public;UserInfoQuery 
+public;UserStatistics 
+public;UserStatisticsHandler
+public;UserStatisticsQuery 
+public;Version 
+public;VersionEvent 
+public;VersionHandler
+public;VersionQuery 

--- a/common/changes/@bentley/analytical-backend/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/analytical-backend/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/analytical-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/backend-itwin-client/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/backend-itwin-client/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-itwin-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-itwin-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema2ts/node-14_2020-11-04-21-36.json
+++ b/common/changes/@bentley/ecschema2ts/node-14_2020-11-04-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema2ts",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema2ts",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/electron-manager/fix-mac-electron-crash_2021-01-25-18-11.json
+++ b/common/changes/@bentley/electron-manager/fix-mac-electron-crash_2021-01-25-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/electron-manager/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/electron-manager/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/express-server/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/express-server/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/express-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/express-server",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-webpack-tools/node-14_2020-11-04-21-36.json
+++ b/common/changes/@bentley/extension-webpack-tools/node-14_2020-11-04-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-webpack-tools",
+      "comment": "Update the version of node-sass to 4.14.1",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-webpack-tools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodel-bridge/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/imodel-bridge/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-bridge",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodel-bridge",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client-tests/iModelHubReleaseTags_2021-01-27-19-04.json
+++ b/common/changes/@bentley/imodelhub-client-tests/iModelHubReleaseTags_2021-01-27-19-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client-tests",
+  "email": "3297568+Animagne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client/iModelHubReleaseTags_2021-01-26-16-46.json
+++ b/common/changes/@bentley/imodelhub-client/iModelHubReleaseTags_2021-01-26-16-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "Updated iModelHub Client release tags",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client",
+  "email": "3297568+Animagne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/iModelHubReleaseTags_2021-01-27-19-04.json
+++ b/common/changes/@bentley/imodeljs-backend/iModelHubReleaseTags_2021-01-27-19-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "3297568+Animagne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/imodeljs-backend/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/node-14_2020-11-04-21-36.json
+++ b/common/changes/@bentley/imodeljs-common/node-14_2020-11-04-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/linear-referencing-backend/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/linear-referencing-backend/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/linear-referencing-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/linear-referencing-common/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/linear-referencing-common/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/linear-referencing-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/linear-referencing-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/physical-material-backend/node-14_2020-10-15-21-40.json
+++ b/common/changes/@bentley/physical-material-backend/node-14_2020-10-15-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/physical-material-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/physical-material-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/iModelHubReleaseTags_2021-01-27-19-04.json
+++ b/common/changes/@bentley/ui-framework/iModelHubReleaseTags_2021-01-27-19-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "3297568+Animagne@users.noreply.github.com"
+}

--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -26,7 +26,7 @@ schedules:
 jobs:
   - template: jobs/ci-core.yaml
     parameters:
-      name: Node_12
-      nodeVersion: 12.17.0
+      name: Node_14
+      nodeVersion: 14.x
       pool:
         vmImage: $(OS)

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -23,8 +23,16 @@ variables:
   - group: iModel.js Integration Test Users
 
 jobs:
-  - job: Node_12_x
+  - job: Node_14_x
     condition: succeeded()
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - template: templates/integration-test-steps.yaml
+        parameters:
+          Node_Version: 14.x
+  - job: Node_12_x
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     pool:
       vmImage: ubuntu-latest
     steps:

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -15,7 +15,7 @@ jobs:
   - template: ci-core.yaml
     parameters:
       name: Node_12
-      nodeVersion: 12.17.0
+      nodeVersion: 14.x
       pool:
         name: $(name)
         demands:

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -14,7 +14,7 @@ pr:
 jobs:
   - template: ci-core.yaml
     parameters:
-      name: Node_12
+      name: Node_14
       nodeVersion: 14.x
       pool:
         name: $(name)

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -29,3 +29,9 @@ jobs:
     nodeVersion: 10.x
     pool:
       demands: Agent.OS -equals $(platform)
+- template: ci-core.yaml
+  parameters:
+    name: Node_12
+    nodeVersion: 12.x
+    pool:
+      demands: Agent.OS -equals $(platform)

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -380,8 +380,26 @@ dependencies:
   yargs: 15.4.1
 lockfileVersion: 5.1
 packages:
-  /@azure/ms-rest-js/2.1.0:
+  /@azure/abort-controller/1.0.2:
     dependencies:
+      tslib: 2.1.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==
+  /@azure/core-auth/1.1.4:
+    dependencies:
+      '@azure/abort-controller': 1.0.2
+      tslib: 2.1.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-+j1embyH1jqf04AIfJPdLafd5SC1y6z1Jz4i+USR1XkTp6KM8P5u4/AjmWMVoEQdM/M29PJcRDZcCEWjK9S1bw==
+  /@azure/ms-rest-js/2.2.0:
+    dependencies:
+      '@azure/core-auth': 1.1.4
       '@types/node-fetch': 2.5.8
       '@types/tunnel': 0.0.1
       abort-controller: 3.0.0
@@ -394,10 +412,10 @@ packages:
       xml2js: 0.4.23
     dev: false
     resolution:
-      integrity: sha512-4BXLVImYRt+jcUmEJ5LUWglI8RBNVQndY6IcyvQ4U8O4kIXdmlRz3cJdA/RpXf5rKT38KOoTO2T6Z1f6Z1HDBg==
+      integrity: sha512-lmSqjNuqx/TmwXLpVs1acAExUhHGkHvXIdfyttNc3qlpcn6xoT8JqGFRVwvoh5rZKPfy84aSaXUEPf/gwfRZHg==
   /@azure/storage-blob/10.4.0:
     dependencies:
-      '@azure/ms-rest-js': 2.1.0
+      '@azure/ms-rest-js': 2.2.0
       events: 3.2.0
       tslib: 1.14.1
     dev: false
@@ -1674,7 +1692,7 @@ packages:
   /@bentley/react-scripts/3.4.6_48b17a5d78442b2ad165e79b3193b2e6:
     dependencies:
       '@babel/core': 7.9.0
-      '@bentley/webpack-tools-core': 2.10.6_webpack@4.42.0
+      '@bentley/webpack-tools-core': 2.11.0_webpack@4.42.0
       '@svgr/webpack': 4.3.3
       '@typescript-eslint/eslint-plugin': 2.34.0_b19fc4176cc1ce9aa077ffdbf5f88816
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.7.5
@@ -1750,12 +1768,15 @@ packages:
         optional: true
     resolution:
       integrity: sha512-lFxmClVnb6XoqPlB39YS/FfzwDfLytCrAo5pm8qrLuKQyM3dCKor1ov3F1UAMrDjX5DpB8UVfBodR/rPViNWTQ==
-  /@bentley/webpack-tools-core/2.10.6_webpack@4.42.0:
+  /@bentley/webpack-tools-core/2.11.0_webpack@4.42.0:
     dependencies:
       chalk: 3.0.0
       file-loader: 4.3.0_webpack@4.42.0
+      findup: 0.1.5
       fs-extra: 8.1.0
       glob: 7.1.6
+      lodash: 4.17.20
+      resolve: 1.19.0
       source-map-loader: 1.1.3_webpack@4.42.0
       webpack: 4.42.0_webpack@4.42.0
       webpack-filter-warnings-plugin: 1.2.1_webpack@4.42.0
@@ -1764,7 +1785,7 @@ packages:
     peerDependencies:
       webpack: 4.42.0
     resolution:
-      integrity: sha512-5axuRhrHBq9Co4ZsnQbJxNDkPSNSgoXcdsqPPpjeIh7tBSZPr2641OgfY3jEn93Z1h7IvRrzrSXu/bA9GfVGRA==
+      integrity: sha512-MNs2rry6EtZTstdAORrQ78MnxwiqSNFtjt+ozbRU3UaHTvVOQyHGBnuc1qi4dYXwOD/eNsYhySBDri+uo4CntA==
   /@cnakazawa/watch/1.0.4:
     dependencies:
       exec-sh: 0.3.4
@@ -2267,7 +2288,7 @@ packages:
   /@nodelib/fs.walk/1.2.6:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
-      fastq: 1.10.0
+      fastq: 1.10.1
     dev: false
     engines:
       node: '>= 8'
@@ -4240,7 +4261,7 @@ packages:
   /autoprefixer/8.6.5:
     dependencies:
       browserslist: 3.2.8
-      caniuse-lite: 1.0.30001179
+      caniuse-lite: 1.0.30001180
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 6.0.23
@@ -4252,7 +4273,7 @@ packages:
   /autoprefixer/9.8.6:
     dependencies:
       browserslist: 4.16.1
-      caniuse-lite: 1.0.30001179
+      caniuse-lite: 1.0.30001180
       colorette: 1.2.1
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -4824,16 +4845,16 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30001179
-      electron-to-chromium: 1.3.645
+      caniuse-lite: 1.0.30001180
+      electron-to-chromium: 1.3.647
     dev: false
     hasBin: true
     resolution:
       integrity: sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
   /browserslist/4.10.0:
     dependencies:
-      caniuse-lite: 1.0.30001179
-      electron-to-chromium: 1.3.645
+      caniuse-lite: 1.0.30001180
+      electron-to-chromium: 1.3.647
       node-releases: 1.1.70
       pkg-up: 3.1.0
     dev: false
@@ -4842,8 +4863,8 @@ packages:
       integrity: sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==
   /browserslist/4.11.1:
     dependencies:
-      caniuse-lite: 1.0.30001179
-      electron-to-chromium: 1.3.645
+      caniuse-lite: 1.0.30001180
+      electron-to-chromium: 1.3.647
       node-releases: 1.1.70
       pkg-up: 2.0.0
     dev: false
@@ -4852,9 +4873,9 @@ packages:
       integrity: sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==
   /browserslist/4.16.1:
     dependencies:
-      caniuse-lite: 1.0.30001179
+      caniuse-lite: 1.0.30001180
       colorette: 1.2.1
-      electron-to-chromium: 1.3.645
+      electron-to-chromium: 1.3.647
       escalade: 3.1.1
       node-releases: 1.1.70
     dev: false
@@ -4981,7 +5002,7 @@ packages:
       p-map: 4.0.0
       promise-inflight: 1.0.1
       rimraf: 3.0.2
-      ssri: 8.0.0
+      ssri: 8.0.1
       tar: 6.1.0
       unique-filename: 1.1.1
     dev: false
@@ -5106,16 +5127,16 @@ packages:
   /caniuse-api/3.0.0:
     dependencies:
       browserslist: 4.16.1
-      caniuse-lite: 1.0.30001179
+      caniuse-lite: 1.0.30001180
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
     resolution:
       integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
-  /caniuse-lite/1.0.30001179:
+  /caniuse-lite/1.0.30001180:
     dev: false
     resolution:
-      integrity: sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+      integrity: sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -6860,10 +6881,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.645:
+  /electron-to-chromium/1.3.647:
     dev: false
     resolution:
-      integrity: sha512-T7mYop3aDpRHIQaUYcmzmh6j9MAe560n6ukqjJMbVC6bVTau7dSpvB18bcsBPPtOSe10cKxhJFtlbEzLa0LL1g==
+      integrity: sha512-Or2Nu8TjkmSywY9hk85K/Y6il28hchlonITz30fkC87qvSNupQl29O12BzDDDTnUFlo6kEIFL2QGSpkZDMxH8g==
   /electron/11.2.1:
     dependencies:
       '@electron/get': 1.12.3
@@ -8145,12 +8166,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
-  /fastq/1.10.0:
+  /fastq/1.10.1:
     dependencies:
       reusify: 1.0.4
     dev: false
     resolution:
-      integrity: sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
+      integrity: sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==
   /faye-websocket/0.10.0:
     dependencies:
       websocket-driver: 0.6.5
@@ -9769,16 +9790,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==
-  /internal-slot/1.0.2:
+  /internal-slot/1.0.3:
     dependencies:
-      es-abstract: 1.17.7
+      get-intrinsic: 1.1.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==
+      integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
   /interpret/1.4.0:
     dev: false
     engines:
@@ -14075,7 +14096,7 @@ packages:
     dependencies:
       autoprefixer: 9.8.6
       browserslist: 4.16.1
-      caniuse-lite: 1.0.30001179
+      caniuse-lite: 1.0.30001180
       css-blank-pseudo: 0.1.4
       css-has-pseudo: 0.10.0
       css-prefers-color-scheme: 3.1.1
@@ -16556,14 +16577,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
-  /ssri/8.0.0:
+  /ssri/8.0.1:
     dependencies:
       minipass: 3.1.3
     dev: false
     engines:
       node: '>= 8'
     resolution:
-      integrity: sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+      integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   /stable/0.1.8:
     dev: false
     resolution:
@@ -16702,7 +16723,7 @@ packages:
       define-properties: 1.1.3
       es-abstract: 1.18.0-next.2
       has-symbols: 1.0.1
-      internal-slot: 1.0.2
+      internal-slot: 1.0.3
       regexp.prototype.flags: 1.3.1
       side-channel: 1.0.4
     dev: false
@@ -21279,7 +21300,6 @@ packages:
       integrity: sha512-3XrZTZsW2KwGdMCRF1ZOO/8o1u6lYBK+X1wGei44rEntXRNjIGunboKbw28TAv2lYei1BSC4GXftViLgJhNi4g==
       tarball: 'file:projects/webpack-tools-core.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@azure/storage-blob': 10.4.0
   '@babel/core': 7.7.4

--- a/core/backend-itwin-client/package.json
+++ b/core/backend-itwin-client/package.json
@@ -9,7 +9,7 @@
   "typings": "lib/backend-itwin-client",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/imodeljs-backend",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -877,7 +877,6 @@ export class BriefcaseManager {
     changeSet.id = changeSetToken.id;
     changeSet.parentId = changeSetToken.parentId;
     changeSet.changesType = changeSetToken.changeType === ChangesType.Schema ? ChangesType.Schema : changeType;
-    changeSet.seedFileId = db.iModelId;
     changeSet.fileSize = IModelJsFs.lstatSync(changeSetToken.pathname)!.size.toString();
     changeSet.description = description;
     if (changeSet.description.length >= 255) {

--- a/core/backend/src/test/integration/HubUtility.ts
+++ b/core/backend/src/test/integration/HubUtility.ts
@@ -429,7 +429,6 @@ export class HubUtility {
       changeSet.parentId = changeSetJson.parentId;
       changeSet.fileSize = changeSetJson.fileSize;
       changeSet.changesType = changeSetJson.changesType;
-      changeSet.seedFileId = briefcase.fileId;
       changeSet.briefcaseId = briefcase.briefcaseId;
 
       await IModelHost.iModelClient.changeSets.create(requestContext, briefcase.iModelId!, changeSet, changeSetPathname);

--- a/core/backend/src/test/integration/IModelWrite.test.ts
+++ b/core/backend/src/test/integration/IModelWrite.test.ts
@@ -52,7 +52,6 @@ function toHubLock(props: ConcurrencyControl.LockProps, briefcaseId: number): Lo
   lock.lockType = props.type;
   lock.objectId = props.objectId;
   // lock.releasedWithChangeSet =
-  // lock.seedFileId = concurrencyControl.iModel.briefcase.fileId!;
   return lock;
 }
 
@@ -157,7 +156,6 @@ describe("IModelWriteTest (#integration)", () => {
     codeSpecsLock.lockLevel = LockLevel.Exclusive;
     codeSpecsLock.lockType = LockType.CodeSpecs;
     codeSpecsLock.objectId = "0x1";
-    codeSpecsLock.seedFileId = model.iModelId;
     await model.pullAndMergeChanges(superRequestContext);
     codeSpecsLock.releasedWithChangeSet = model.changeSetId;
     const locks = await IModelHost.iModelClient.locks.update(superRequestContext, model.iModelId, [codeSpecsLock]);

--- a/core/electron-manager/package.json
+++ b/core/electron-manager/package.json
@@ -4,7 +4,7 @@
   "description": "iModel.js electron utilities",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/core/electron-manager/src/ElectronBackend.ts
+++ b/core/electron-manager/src/ElectronBackend.ts
@@ -98,9 +98,15 @@ export class ElectronBackend implements IpcSocketBackend {
         contextIsolation: true,
         sandbox: true,
       },
-      icon: this.appIconPath,
       ...options, // overrides everything above
     };
+
+    // opts.icon cannot be set to undefined, an invalid path, or a local file path
+    // when using the development server as it'd crash Electron on macOS/linux
+    // https://github.com/electron/electron/issues/27303#issuecomment-759501184
+    const icon = process.platform === "win32" && this.appIconPath;
+    if (icon)
+      opts.icon = this.appIconPath;
 
     this._mainWindow = new BrowserWindow(opts);
     ElectronRpcConfiguration.targetWindowId = this._mainWindow.id;

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/ExpressServer",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/core/imodel-bridge/package.json
+++ b/core/imodel-bridge/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/imodel-bridge",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "repository": {
     "type": "git",

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,6 +3,10 @@ publish: false
 ---
 # NextVersion
 
+## Add Node 14 support
+
+With Node 14 moving to LTS on October 27th, iModel.js has been updated to add support.  iModel.js now supports Node >10.16, 12.x, and 14.x.
+
 ## Custom particle effects
 
 The display system now makes it easy to implement [particle effects](https://en.wikipedia.org/wiki/Particle_system) using [decorators](../learning/frontend/ViewDecorations.md). Particle effects simulate phenomena like fire, smoke, snow, and rain by animating hundreds or thousands of small particles. The new [ParticleCollectionBuilder]($frontend) API allows such collections to be efficiently created and rendered.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,7 +4,7 @@
 
 Writing an iModel.js application requires the following software:
 
-- [Node.js](https://nodejs.org) (12.x LTS version)
+- [Node.js](https://nodejs.org) (14.x LTS version)
   - This provides the backend JavaScript runtime.
   - The installation also includes the `npm` command line tool.
 - [Git](https://git-scm.com/downloads)

--- a/docs/learning/iModelHub/Permissions.md
+++ b/docs/learning/iModelHub/Permissions.md
@@ -16,7 +16,7 @@ iModelHub uses 6 permissions:
 
 Permissions automatically included: _Read iModel_, _Modify iModel_
 
-Create iModel permission allows creating iModels. See [BriefcaseManager.create]($backend) and [IModelHandler.create]($imodelhub-client).
+Create iModel permission allows creating iModels. See [BriefcaseManager.create]($backend).
 
 ## Delete iModel
 

--- a/docs/learning/iModelHub/Versions.md
+++ b/docs/learning/iModelHub/Versions.md
@@ -20,16 +20,6 @@ After creating Named Version, its possible to query them by calling [VersionHand
 [[include:VersionHandler.get.example-code]]
 ```
 
-## Downloading Thumbnails
-
-Once a Named Version is created, iModelHub generates its [Thumbnail]($imodelhub-client) in the background. To get this Thumbnail, a Version query can be specified with [VersionQuery.selectThumbnailId]($imodelhub-client) or all Thumbnails can be queried through ThumbnailHandler.get.
-
-Thumbnail might not be immediately available after creating a Named Version, as generating it could take some time. If Thumbnail is not returned after creating Named Version, you can try querying it again later.
-
-``` ts
-[[include:VersionHandler.thumbnail.example-code]]
-```
-
-## detachChangeCache() depreciated
+## detachChangeCache() deprecated
 
 The only way to detach change cache is to close the connection. The api will be remove in future.

--- a/docs/learning/iModelHub/iModels/CreateiModel.md
+++ b/docs/learning/iModelHub/iModels/CreateiModel.md
@@ -1,11 +1,11 @@
 # iModel creation
 
-To start working with iModelHub an iModel for a [Project]($context-registry-client) has to be created. End users should usually create the iModel for a Project through iModelHub website. It's possible to use [BriefcaseManager.create]($backend) to create an empty iModel and upload it to iModelHub. It's also possible to upload an existing standalone iModel file through [IModelHandler.create]($imodelhub-client).
+To start working with iModelHub an iModel for a [Project]($context-registry-client) has to be created. End users should usually create the iModel for a Project through iModelHub website. It's also possible to use [BriefcaseManager.create]($backend) to create either an empty iModel or upload iModel from file.
 
 ## iModel initialization
 
 Once iModel is uploaded to iModelHub, it starts a backend initialization process, which prepares that iModel for use. Until initialization successfully finishes, no requests can be made to that iModel.
 
-iModel initialization is usually fast, especially for empty files. However, it is possible that iModel creation requests time out. If file is not initialized by the timeOutInMilliseconds specified in [IModelHandler.create]($imodelhub-client), creation task will be rejected. It could still get initialized in the future. You can use [IModelHandler.getInitializationState]($imodelhub-client) to check whether the file initialization is still in progress (InitializationState.Scheduled), or the initialization has completed (any other status).
+iModel initialization is usually fast, especially for empty files. However, it is possible that iModel creation requests time out. If file is not initialized by the time create request times out, it could still get initialized in the future. [InitializationState]($imodelhub-client) specifies whether the file initialization is still in progress (InitializationState.Scheduled), or the initialization has completed (any other status).
 
 When uploading an existing standalone iModel, different failure statuses represent most common issues with initialization. If initialization has failed with [InitializationState.Failed]($imodelhub-client), it's possible, that deleting and creating new iModel with the same seed file could succeed, but it isn't guaranteed.

--- a/domains/analytical/backend/package.json
+++ b/domains/analytical/backend/package.json
@@ -5,7 +5,7 @@
   "typings": "lib/analytical-backend",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/domains/linear-referencing/backend/package.json
+++ b/domains/linear-referencing/backend/package.json
@@ -5,7 +5,7 @@
   "typings": "lib/linear-referencing-backend",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/domains/linear-referencing/common/package.json
+++ b/domains/linear-referencing/common/package.json
@@ -5,7 +5,7 @@
   "typings": "lib/linear-referencing-common",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/domains/physical-material/backend/package.json
+++ b/domains/physical-material/backend/package.json
@@ -5,7 +5,7 @@
   "typings": "lib/physical-material-backend",
   "license": "MIT",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "scripts": {
     "compile": "npm run build",

--- a/example-code/snippets/src/clients/Versions.ts
+++ b/example-code/snippets/src/clients/Versions.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { Guid, GuidString } from "@bentley/bentleyjs-core";
-import { ChangeSet, IModelHubClient, SmallThumbnail, Version, VersionQuery } from "@bentley/imodelhub-client";
+import { ChangeSet, IModelHubClient, Version, VersionQuery } from "@bentley/imodelhub-client";
 import { AccessToken, AuthorizedClientRequestContext } from "@bentley/itwin-client";
 
 class MockAccessToken extends AccessToken {
@@ -42,20 +42,5 @@ export async function test2() {
   // __PUBLISH_EXTRACT_END__
 
   if (!allVersions || !versionByName)
-    return;
-}
-
-// enclosing function avoids compile errors and code analysis report.
-export async function test3() {
-  // __PUBLISH_EXTRACT_START__ VersionHandler.thumbnail.example-code
-  // Query Named Version with its Thumbnail Id
-  const thumbnailIdQuery: VersionQuery = new VersionQuery().byName("Version name").selectThumbnailId("Small");
-  const versionWithThumbnailId: Version[] = await imodelHubClient.versions.get(authorizedRequestContext, imodelId, thumbnailIdQuery);
-  // Download the Thumbnail
-  const thumbnail: SmallThumbnail = new SmallThumbnail();
-  thumbnail.id = versionWithThumbnailId[0].smallThumbnailId!;
-  const thumbnailContents: string = await imodelHubClient.thumbnails.download(authorizedRequestContext, imodelId, thumbnail);
-  // __PUBLISH_EXTRACT_END__
-  if (!thumbnailContents)
     return;
 }

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -9,7 +9,7 @@
     "build:extensions": "npm run build:loadingTestExtension",
     "build:loadingTestExtension": "extension-webpack-tools build -s ./src/common/extensions/loadingTestExtension/loadingTestExtension.ts -o ./lib/imjs_extensions/loadingTestExtension --sourceMap",
     "clean": "rimraf lib .rush/temp/package-deps*.json coverage",
-    "cover": "npm run test:chrome -- --cover && npm run test:electron -- --cover",
+    "cover": "npm run test:chrome && npm run test:electron",
     "docs": "",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run test:chrome && npm run test:electron",

--- a/full-stack-tests/imodelhub-client/src/imodelhub/ChangeSet.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/ChangeSet.test.ts
@@ -465,9 +465,7 @@ describe("iModelHub ChangeSetHandler", () => {
       new ChangeSetQuery().betweenChangeSets(changeSets[0].id!, changeSets[2].id));
     chai.expect(selectedChangeSets.length).to.be.equal(2);
     chai.expect(selectedChangeSets[0].id).to.be.equal(changeSets[1].id);
-    chai.expect(selectedChangeSets[0].seedFileId!.toString()).to.be.equal(changeSets[1].seedFileId!.toString());
     chai.expect(selectedChangeSets[1].id).to.be.equal(changeSets[2].id);
-    chai.expect(selectedChangeSets[1].seedFileId!.toString()).to.be.equal(changeSets[2].seedFileId!.toString());
   });
 
   it("should query between changeset (#iModelBank)", async () => {
@@ -489,11 +487,8 @@ describe("iModelHub ChangeSetHandler", () => {
       new ChangeSetQuery().betweenChangeSets(changeSets[2].id!));
     chai.expect(selectedChangeSets.length).to.be.equal(3);
     chai.expect(selectedChangeSets[0].id).to.be.equal(changeSets[0].id);
-    chai.expect(selectedChangeSets[0].seedFileId!.toString()).to.be.equal(changeSets[0].seedFileId!.toString());
     chai.expect(selectedChangeSets[1].id).to.be.equal(changeSets[1].id);
-    chai.expect(selectedChangeSets[1].seedFileId!.toString()).to.be.equal(changeSets[1].seedFileId!.toString());
     chai.expect(selectedChangeSets[2].id).to.be.equal(changeSets[2].id);
-    chai.expect(selectedChangeSets[2].seedFileId!.toString()).to.be.equal(changeSets[2].seedFileId!.toString());
   });
 
   it("should get version changesets (#iModelBank)", async () => {
@@ -521,7 +516,6 @@ describe("iModelHub ChangeSetHandler", () => {
       new ChangeSetQuery().getVersionChangeSets(versions[versions.length - 1].id!));
     chai.expect(selectedChangeSets.length).to.be.equal(1);
     chai.expect(selectedChangeSets[0].id).to.be.equal(changeSets[0].id);
-    chai.expect(selectedChangeSets[0].seedFileId!.toString()).to.be.equal(changeSets[0].seedFileId!.toString());
   });
 
   it("should get changesets after version (#iModelBank)", async () => {
@@ -549,7 +543,6 @@ describe("iModelHub ChangeSetHandler", () => {
       new ChangeSetQuery().afterVersion(versions[versions.length - 2].id!));
     chai.expect(selectedChangeSets.length).to.be.greaterThan(1);
     chai.expect(selectedChangeSets[0].id).to.be.equal(changeSets[2].id);
-    chai.expect(selectedChangeSets[0].seedFileId!.toString()).to.be.equal(changeSets[2].seedFileId!.toString());
   });
 
   it("should query changesets between versions (#iModelBank)", async () => {
@@ -581,9 +574,7 @@ describe("iModelHub ChangeSetHandler", () => {
       new ChangeSetQuery().betweenVersions(versions[0].id!, versions[2].id!));
     chai.expect(selectedChangeSets.length).to.be.equal(2);
     chai.expect(selectedChangeSets[0].id).to.be.equal(changeSets[1].id);
-    chai.expect(selectedChangeSets[0].seedFileId!.toString()).to.be.equal(changeSets[1].seedFileId!.toString());
     chai.expect(selectedChangeSets[1].id).to.be.equal(changeSets[2].id);
-    chai.expect(selectedChangeSets[1].seedFileId!.toString()).to.be.equal(changeSets[2].seedFileId!.toString());
   });
 
   it("should query changesets between version and changeset (#iModelBank)", async () => {
@@ -616,30 +607,6 @@ describe("iModelHub ChangeSetHandler", () => {
       new ChangeSetQuery().betweenVersionAndChangeSet(versions[versions.length - 1].id!, changeSets[1].id!));
     chai.expect(selectedChangeSets.length).to.be.equal(1);
     chai.expect(selectedChangeSets[0].id).to.be.equal(changeSets[1].id);
-    chai.expect(selectedChangeSets[0].seedFileId!.toString()).to.be.equal(changeSets[1].seedFileId!.toString());
-  });
-
-  it("should query changesets by seed file id (#iModelBank)", async () => {
-    if (TestConfig.enableMocks) {
-      const mockedChangeSets = utils.getMockChangeSets(briefcase).slice(0, 3);
-      utils.mockGetChangeSet(imodelId, true, `&$top=${ChangeSetQuery.defaultPageSize}`, ...mockedChangeSets);
-
-      const filter = `SeedFileId+eq+%27${mockedChangeSets[0].seedFileId!}%27`;
-
-      const requestPath = utils.createRequestUrl(ScopeType.iModel, imodelId, "ChangeSet",
-        `?$filter=${filter}&$top=${ChangeSetQuery.defaultPageSize}`);
-      ResponseBuilder.mockResponse(utils.IModelHubUrlMock.getUrl(), RequestType.Get, requestPath,
-        ResponseBuilder.generateGetResponse(mockedChangeSets[0]));
-    }
-    const changeSets: ChangeSet[] = await iModelClient.changeSets.get(requestContext, imodelId, new ChangeSetQuery().selectDownloadUrl());
-    chai.expect(changeSets.length).to.be.greaterThan(0);
-
-    const selectedChangeSets: ChangeSet[] = await iModelClient.changeSets.get(requestContext, imodelId,
-      new ChangeSetQuery().bySeedFileId(changeSets[0].seedFileId!));
-    chai.expect(selectedChangeSets.length).to.be.greaterThan(0);
-    selectedChangeSets.forEach((cs: ChangeSet) => {
-      chai.expect(cs.seedFileId!.toString()).to.be.equal(changeSets[0].seedFileId!.toString());
-    });
   });
 
   it("should query changesets application data", async () => {

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Locks.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Locks.test.ts
@@ -97,14 +97,12 @@ describe("iModelHubClient LockHandler (#iModelBank)", () => {
     utils.mockUpdateLocks(imodelId, [generatedLock]);
     let lock = (await iModelClient.locks.update(requestContext, imodelId, [generatedLock]))[0];
 
-    lock.seedFileId = briefcases[0].fileId!;
     lock.lockLevel = LockLevel.None;
     utils.mockUpdateLocks(imodelId, [lock]);
     lock = (await iModelClient.locks.update(requestContext, imodelId, [lock]))[0];
     chai.assert(lock);
     chai.expect(lock.lockLevel).equals(LockLevel.None);
 
-    lock.seedFileId = briefcases[0].fileId!;
     lock.lockLevel = LockLevel.Shared;
     lock.releasedWithChangeSet = changeSet.id;
     utils.mockUpdateLocks(imodelId, [lock]);

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Performance.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Performance.test.ts
@@ -186,7 +186,6 @@ describe.skip("iModelHub Performance tests", () => {
       lock.lockLevel = LockLevel.Shared;
       lock.lockType = LockType.Element;
       lock.objectId = Id64.fromString(j.toString());
-      lock.seedFileId = briefcase.fileId;
       j++;
       return lock;
     });

--- a/full-stack-tests/imodelhub-client/src/imodelhub/TestUtils.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/TestUtils.ts
@@ -570,11 +570,10 @@ export async function getLastLockObjectId(requestContext: AuthorizedClientReques
 }
 
 export function generateLock(briefcaseId?: number, objectId?: Id64String,
-  lockType?: LockType, lockLevel?: LockLevel, seedFileId?: GuidString,
+  lockType?: LockType, lockLevel?: LockLevel, _seedFileId?: GuidString,
   releasedWithChangeSet?: string, releasedWithChangeSetIndex?: string): Lock {
   const result = new Lock();
   result.briefcaseId = briefcaseId || 1;
-  result.seedFileId = seedFileId;
   result.objectId = Id64.fromJSON(objectId || "0x0");
   result.lockLevel = lockLevel || 1;
   result.lockType = lockType || 1;
@@ -594,7 +593,6 @@ function convertLocksToMultiLocks(locks: Lock[]): MultiLock[] {
       const multiLock = new MultiLock();
       multiLock.changeState = "new";
       multiLock.briefcaseId = lock.briefcaseId;
-      multiLock.seedFileId = lock.seedFileId;
       multiLock.releasedWithChangeSet = lock.releasedWithChangeSet;
       multiLock.releasedWithChangeSetIndex = lock.releasedWithChangeSetIndex;
       multiLock.lockLevel = lock.lockLevel;
@@ -659,7 +657,9 @@ export function generateVersion(name?: string, changesetId?: string, addInstance
   }
   result.changeSetId = changesetId === undefined || changesetId === null ? generateChangeSetId() : changesetId;
   result.name = name || `TestVersion-${result.changeSetId}`;
+  // eslint-disable-next-line deprecation/deprecation
   result.smallThumbnailId = smallThumbnailId;
+  // eslint-disable-next-line deprecation/deprecation
   result.largeThumbnailId = largeThumbnailId;
   result.hidden = hidden;
   return result;
@@ -814,7 +814,6 @@ export function getMockChangeSets(briefcase: Briefcase): ChangeSet[] {
     result.index = regexMatchValue[1]; // first regex group contains file index
     result.fileSize = fs.statSync(path.join(dir, file)).size.toString();
     result.briefcaseId = briefcase.briefcaseId;
-    result.seedFileId = briefcase.fileId;
     result.parentId = parentId;
     result.fileName = `${result.id}.cs`;
     parentId = result.id;

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Thumbnails.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Thumbnails.test.ts
@@ -137,6 +137,7 @@ describe("iModelHub ThumbnailHandler (#unit)", () => {
     it(`should get ${params.size}Thumbnail by version id`, async () => {
       for (let i = 0; i < 3; i++) {
         utils.mockGetThumbnailsByVersionId(imodelId, params.size, versions[i].id!, params.thumbnails[i]);
+        // eslint-disable-next-line deprecation/deprecation
         const actualThumbnail: Thumbnail = (await imodelHubClient.thumbnails.get(requestContext, imodelId, params.size, new ThumbnailQuery().byVersionId(versions[i].id!)))[0];
         chai.assert(!!actualThumbnail);
         chai.expect(actualThumbnail.id!.toString()).to.be.equal(params.thumbnails[i].id!.toString());

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Versions.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Versions.test.ts
@@ -52,6 +52,7 @@ async function createNamedVersionWithThumbnail(requestContext: AuthorizedClientR
   if (utils.getCloudEnv().isIModelHub) {
     // Wait for large thumbnail.
     for (let i = 0; i < 50; i++) {
+      // eslint-disable-next-line deprecation/deprecation
       const largeThumbnails = (await imodelClient.thumbnails.get(requestContext, imodelId, "Large", new ThumbnailQuery().byVersionId(version.id!)));
       if (largeThumbnails.length > 0)
         break;
@@ -224,32 +225,45 @@ describe("iModelHub VersionHandler", () => {
     let versions: Version[] = await iModelClient.versions.get(requestContext, imodelId2, new VersionQuery().byName(firstVersionName));
     chai.expect(versions.length).to.be.equal(1);
     const firstVersion = versions[0];
+    // eslint-disable-next-line deprecation/deprecation
     chai.expect(firstVersion.smallThumbnailId).to.be.undefined;
+    // eslint-disable-next-line deprecation/deprecation
     chai.expect(firstVersion.largeThumbnailId).to.be.undefined;
 
     const mockedSmallThumbnail = utils.generateThumbnail("Small");
     utils.mockGetThumbnailsByVersionId(imodelId2, "Small", firstVersion.id!, mockedSmallThumbnail);
+    // eslint-disable-next-line deprecation/deprecation
     const smallThumbnail: Thumbnail = (await iModelClient.thumbnails.get(requestContext, imodelId2, "Small", new ThumbnailQuery().byVersionId(firstVersion.id!)))[0];
 
     const mockedLargeThumbnail = utils.generateThumbnail("Large");
     utils.mockGetThumbnailsByVersionId(imodelId2, "Large", firstVersion.id!, mockedLargeThumbnail);
+    // eslint-disable-next-line deprecation/deprecation
     const largeThumbnail: Thumbnail = (await iModelClient.thumbnails.get(requestContext, imodelId2, "Large", new ThumbnailQuery().byVersionId(firstVersion.id!)))[0];
 
     mockedVersions = Array(1).fill(0).map(() => utils.generateVersion(undefined, undefined, true, mockedSmallThumbnail.id, mockedLargeThumbnail.id));
     mockGetVersionsByIdWithThumbnails(imodelId2, firstVersion.id!, ["Small", "Large"], ...mockedVersions);
+    // eslint-disable-next-line deprecation/deprecation
     versions = await iModelClient.versions.get(requestContext, imodelId2, new VersionQuery().byId(firstVersion.id!).selectThumbnailId("Small", "Large"));
     chai.expect(versions.length === 1);
+    // eslint-disable-next-line deprecation/deprecation
     chai.assert(!!versions[0].smallThumbnailId);
+    // eslint-disable-next-line deprecation/deprecation
     chai.expect(versions[0].smallThumbnailId!.toString()).to.be.equal(smallThumbnail.id!.toString());
+    // eslint-disable-next-line deprecation/deprecation
     chai.assert(!!versions[0].largeThumbnailId);
+    // eslint-disable-next-line deprecation/deprecation
     chai.expect(versions[0].largeThumbnailId!.toString()).to.be.equal(largeThumbnail.id!.toString());
 
     mockedVersions = Array(1).fill(0).map(() => utils.generateVersion(undefined, undefined, true, undefined, mockedLargeThumbnail.id));
     mockGetVersionsByNameWithThumbnails(imodelId2, firstVersion.name!, ["Large"], ...mockedVersions);
+    // eslint-disable-next-line deprecation/deprecation
     versions = await iModelClient.versions.get(requestContext, imodelId2, new VersionQuery().byName(firstVersion.name!).selectThumbnailId("Large"));
     chai.expect(versions.length === 1);
+    // eslint-disable-next-line deprecation/deprecation
     chai.expect(versions[0].smallThumbnailId).to.be.undefined;
+    // eslint-disable-next-line deprecation/deprecation
     chai.assert(!!versions[0].largeThumbnailId);
+    // eslint-disable-next-line deprecation/deprecation
     chai.expect(versions[0].largeThumbnailId!.toString()).to.be.equal(largeThumbnail.id!.toString());
 
     chai.expect(smallThumbnail.id!.toString()).to.be.not.equal(largeThumbnail.id!.toString());

--- a/rush.json
+++ b/rush.json
@@ -6,6 +6,7 @@
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,
   "ensureConsistentVersions": true,
+  "suppressNodeLtsWarning": true,
   "approvedPackagesPolicy": {
     "reviewCategories": [
       "frontend",

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.34.2",
   "pnpmVersion": "4.12.5",
-  "nodeSupportedVersionRange": ">=10.17.0 <13.0.0",
+  "nodeSupportedVersionRange": ">=10.17.0 <15.0.0",
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,
   "ensureConsistentVersions": true,

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -8,7 +8,7 @@
   },
   "version": "0.0.0",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "private": true,
   "scripts": {

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -8,7 +8,7 @@
   },
   "version": "1.8.0",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "private": true,
   "scripts": {

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -20,7 +20,7 @@
     "copy:assets": "cpx \"./node_modules/@bentley/icons-generic-webfont/dist/**/*\" ./build",
     "docs": "",
     "lint": "eslint -f visualstudio --config package.json --no-eslintrc ./src/**/*.ts 1>&2",
-    "start": "run-p start:webserver start:electron",
+    "start": "cross-env NODE_ENV=development run-p start:webserver start:electron",
     "start:electron": "electron ./lib/backend/DtaElectronMain.js",
     "start:webserver": "cross-env BROWSER=none USE_FULL_SOURCEMAP=true EXTEND_ESLINT=true react-scripts start",
     "start:backend": "node --max-http-header-size=16000 lib/backend/WebMain.js",

--- a/test-apps/presentation-test-app/package.json
+++ b/test-apps/presentation-test-app/package.json
@@ -8,7 +8,7 @@
   },
   "version": "0.0.0",
   "engines": {
-    "node": ">=10.17.0 <13.0"
+    "node": ">=10.17.0 <15.0"
   },
   "private": true,
   "scripts": {

--- a/ui/framework/src/ui-framework/clientservices/DefaultIModelServices.ts
+++ b/ui/framework/src/ui-framework/clientservices/DefaultIModelServices.ts
@@ -176,6 +176,7 @@ export class DefaultIModelServices implements IModelServices {
 
   private createVersionInfo(thisVersion: Version): VersionInfo {
     const createDate: Date = new Date(thisVersion.createdDate!);
+    // eslint-disable-next-line deprecation/deprecation
     const thisVersionInfo: VersionInfo = new VersionInfoImpl(thisVersion.name!, thisVersion.description!, createDate, thisVersion.changeSetId!, thisVersion.userCreated, thisVersion.smallThumbnailId!.toString(), thisVersion.largeThumbnailId!.toString());
     return thisVersionInfo;
   }


### PR DESCRIPTION
Node 14 has been moved to LTS as of [last week](https://nodejs.org/en/about/releases/).  Updated the versions iModel.js supports to include it and continue to support `>10.16` and 12.x.

I did put a note in the NextVersion.md warning about dropping support for Node 10 at iModel.js 3.0 due to it leaving LTS around that time, 2021-04-30.

Updated node-sass from 4.13.1 to 4.14.1 in order to support Node 14. However, with node-sass being deprecated shortly we should start investigating moving away from it and using dart sass instead (package name is `sass`).  It's a purely js implementation, instead of containing a native portion, which would be nice for compatibility reasons.