### PR TITLE
computeProjectExtents test was mistakenly inserting into a template model

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/fix-project-extents-test_2020-11-05-13-52.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-project-extents-test_2020-11-05-13-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "36768600+scsewall@users.noreply.github.com"
+}

--- a/core/backend/src/test/standalone/IModel.test.ts
+++ b/core/backend/src/test/standalone/IModel.test.ts
@@ -2374,7 +2374,7 @@ describe("computeProjectExtents", () => {
   });
 
   it("should report outliers", () => {
-    const elemProps = imodel.elements.getElementProps<GeometricElement3dProps>({ id: "0x38", wantGeometry: true });
+    const elemProps = imodel.elements.getElementProps<GeometricElement3dProps>({ id: "0x39", wantGeometry: true });
     elemProps.id = Id64.invalid;
     const placement = Placement3d.fromJSON(elemProps.placement);
     const originalOrigin = placement.origin.clone();


### PR DESCRIPTION
Simply switch the "seed" element to one in a regular model.