### PR TITLE
Remove the file requirement for the slow ci pr triggers

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -1,24 +1,27 @@
 # iModel.js CI Build
+#
+# This build is used to validate all fork-based PRs and run on a schedule to provide the build status in the README.
+#
+# It runs on the Hosted Azure Pipelines machines which are slow building the code in the repo, especially the test-apps
+# which require several webpacking steps. Due to the time it takes to run, these are only used in a limited number of cases.
+#
+# The main CI build used is the ./jobs/fast-ci.yaml due to it running on a set of faster machines. However, those are currently
+# only available to members of the iModel.js GitHub Organization for security reasons. This may change in the future but for now
+# the limitation will exist.
+#
+# This build is not automatically queued for fork-based PRs and needs to be manually triggered by using a comment trigger in the PR.
+# Anyone in the iModel.js Org can trigger this pipeline by adding this comment,
+#   `/azp run imodeljs.imodeljs`
 
 trigger: none
-
-pr:
-  drafts: false
-  branches:
-    include:
-    - master
-    - releases/*
-  paths:
-    include:
-    - common/config/azure-pipelines/ci.yaml
 
 schedules:
   - cron: "0 5 * * *"
     displayName: Daily midnight build
     branches:
       include:
-      - master
-      - releases/*
+        - master
+        - releases/*
 
 jobs:
   - template: jobs/ci-core.yaml


### PR DESCRIPTION
This fixes the issue we're running into in #186. The PR triggers are preventing the pipeline from being triggered by a comment.  According to this [GitHub issue](https://github.com/MicrosoftDocs/azure-devops-docs/issues/4206), when the PR triggers do not match the PR you're trying to trigger it on the comment triggers won't work correctly.

I still need to write-up the steps for reviewing fork-based PRs, I'll do that shortly, but did add some comments to the ci.yaml itself about when it's used and why.