### PR TITLE
Improve IModelTransformer's projectExtents handling

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -2745,7 +2745,10 @@ export class IModelHostConfiguration {
 // @beta
 export class IModelImporter {
     constructor(targetDb: IModelDb, options?: IModelImportOptions);
-    autoExtendProjectExtents: boolean;
+    autoExtendProjectExtents: boolean | {
+        excludeOutliers: boolean;
+    };
+    computeProjectExtents(): void;
     deleteElement(elementId: Id64String): void;
     deleteRelationship(relationshipProps: RelationshipProps): void;
     readonly doNotUpdateElementIds: Set<string>;
@@ -2771,7 +2774,9 @@ export class IModelImporter {
 
 // @beta
 export interface IModelImportOptions {
-    autoExtendProjectExtents?: boolean;
+    autoExtendProjectExtents?: boolean | {
+        excludeOutliers: boolean;
+    };
 }
 
 // @public

--- a/common/changes/@bentley/imodeljs-backend/IModelImporter-computeProjectExtents_2020-11-06-21-50.json
+++ b/common/changes/@bentley/imodeljs-backend/IModelImporter-computeProjectExtents_2020-11-06-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Improve projectExtents handling for IModelTransformer and IModelImporter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "36768600+scsewall@users.noreply.github.com"
+}

--- a/core/backend/src/IModelTransformer.ts
+++ b/core/backend/src/IModelTransformer.ts
@@ -675,6 +675,7 @@ export class IModelTransformer extends IModelExportHandler {
     this.processDeferredElements();
     this.detectElementDeletes();
     this.detectRelationshipDeletes();
+    this.importer.computeProjectExtents();
   }
 
   /** Export changes from the source iModel and import the transformed entities into the target iModel.
@@ -690,6 +691,7 @@ export class IModelTransformer extends IModelExportHandler {
     await this.exporter.exportChanges(requestContext, startChangeSetId);
     requestContext.enter();
     this.processDeferredElements();
+    this.importer.computeProjectExtents();
   }
 }
 

--- a/core/backend/src/IModelTransformer.ts
+++ b/core/backend/src/IModelTransformer.ts
@@ -662,7 +662,9 @@ export class IModelTransformer extends IModelExportHandler {
     this.processDeferredElements();
   }
 
-  /** Export everything from the source iModel and import the transformed entities into the target iModel. */
+  /** Export everything from the source iModel and import the transformed entities into the target iModel.
+   * @note [[processSchemas]] is not called automatically since the target iModel may want a different collection of schemas.
+   */
   public processAll(): void {
     this.initFromExternalSourceAspects();
     this.exporter.exportCodeSpecs();


### PR DESCRIPTION
- Compute the projectExtents at the end rather than checking during import of each element
- Add option for *outliers* to be excluded from the projectExtents computation
- Log warnings if certain projectExtents issues are detected