### PR TITLE
Downgrade ci to 12.17.0 due to MacOS issue

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -27,6 +27,6 @@ jobs:
   - template: jobs/ci-core.yaml
     parameters:
       name: Node_12
-      nodeVersion: 12.x
+      nodeVersion: 12.17.0
       pool:
         vmImage: $(OS)


### PR DESCRIPTION
There's an issue with the imodeljs-native addon on MacOS for versions of Node greater than 12.17.  Downgrade until we can get a fix in.