### PR TITLE
Presentation: Allow specifying asset path overrides separately for 'common' and 'backend'

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -257,7 +257,10 @@ export interface PresentationManagerProps {
     id?: string;
     localeDirectories?: string[];
     mode?: PresentationManagerMode;
-    presentationAssetsRoot?: string;
+    presentationAssetsRoot?: string | {
+        backend: string;
+        common: string;
+    };
     rulesetDirectories?: string[];
     supplementalRulesetDirectories?: string[];
     taskAllocationsMap?: {

--- a/common/changes/@bentley/presentation-backend/presentation-separate-asset-path-overrides-for-common-and-backend_2020-11-12-09-23.json
+++ b/common/changes/@bentley/presentation-backend/presentation-separate-asset-path-overrides-for-common-and-backend_2020-11-12-09-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Allow specifying asset path overrides separately for 'presentation-common' and 'presentation-backend' packages",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -340,7 +340,7 @@
     },
     {
       "name": "chai-subset",
-      "allowedCategories": [ "frontend", "internal" ]
+      "allowedCategories": [ "backend", "frontend", "internal" ]
     },
     {
       "name": "chalk",

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -33,7 +33,7 @@
     "extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=../../generated-docs/extract",
     "extract-api": "betools extract-api --entry=presentation-backend",
     "lint": "eslint -f visualstudio --max-warnings 0 ./src/**/*.ts 1>&2",
-    "test": "mocha --opts ../mocha.opts \"./lib/test/**/*.test.js\"",
+    "test": "mocha --opts ../mocha.opts --file ./lib/test/index.test.js \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts --watch"
   },
   "peerDependencies": {
@@ -52,6 +52,7 @@
     "@types/chai": "^4.1.4",
     "@types/chai-as-promised": "^7",
     "@types/chai-jest-snapshot": "^1.3.0",
+    "@types/chai-subset": "1.3.1",
     "@types/deep-equal": "^1",
     "@types/faker": "^4.1.0",
     "@types/lolex": "^2.1.2",
@@ -63,6 +64,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
+    "chai-subset": "1.6.0",
     "cpx": "^1.5.0",
     "cross-env": "^5.1.4",
     "deep-equal": "^1",

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -118,20 +118,40 @@ export interface HybridCacheConfig extends HierarchyCacheConfigBase {
  */
 export interface PresentationManagerProps {
   /**
-   * A path override for presentation-backend's assets. Need to be overriden by application if
-   * it puts these assets someplace else than the default.
+   * Path overrides for presentation assets. Need to be overriden by application if it puts these assets someplace else than the default.
    *
-   * By default the root is determined using this algorithm:
-   * - if 'presentation-backend' is in node_modules, assume the directory structure is:
-   *   - assets/*\*\/*
-   *   - presentation-backend/{source_files}
-   *   which means the assets can be found through a relative path '../assets/' from the JS file being executed.
-   * - else, assume the backend is webpacked into a single file with assets next to it:
-   *   - assets/*\*\/*
-   *   - main.js
-   *   which means the assets can be found through a relative path './assets/' from the JS file being executed.
+   * By default paths to asset directories are determined during the call of [[Presentation.initialize]] using this algorithm:
+   *
+   * - for `presentation-backend` assets:
+   *
+   *   - if path of `.js` file that contains [[PresentationManager]] definition contains "presentation-backend", assume the package is in `node_modules` and the directory structure is:
+   *     - `assets/*\*\/*`
+   *     - `presentation-backend/{presentation-backend source files}`
+   *
+   *     which means the assets can be found through a relative path `../assets/` from the JS file being executed.
+   *
+   * - for `presentation-common` assets:
+   *
+   *   - if path of `.js` files of `presentation-common` package contain "presentation-common", assume the package is in `node_modules` and the directory structure is:
+   *     - `assets/*\*\/*`
+   *     - `presentation-common/{presentation-common source files}`
+   *
+   *     which means the assets can be found through a relative path `../assets/` from the package's source files.
+   *
+   * - in both cases, if we determine that source files are not in `node_modules`, assume the backend is webpacked into a single file with assets next to it:
+   *   - `assets/*\*\/*`
+   *   - `{source file being executed}.js`
+   *
+   *   which means the assets can be found through a relative path `./assets/` from the `{source file being executed}`.
+   *
+   * The overrides can be specified as a single path (when assets of both `presentation-backend` and `presentation-common` packages are merged into a single directory) or as an object with two separate paths for each package.
    */
-  presentationAssetsRoot?: string;
+  presentationAssetsRoot?: string | {
+    /** Path to `presentation-backend` assets */
+    backend: string;
+    /** Path to `presentation-common` assets */
+    common: string;
+  };
 
   /**
    * A list of directories containing application's presentation rulesets.
@@ -362,7 +382,7 @@ export class PresentationManager {
   };
 
   private setupRulesetDirectories(props?: PresentationManagerProps) {
-    const supplementalRulesetDirectories = [path.join(props?.presentationAssetsRoot ?? PRESENTATION_BACKEND_ASSETS_ROOT, "supplemental-presentation-rules")];
+    const supplementalRulesetDirectories = [path.join(getPresentationBackendAssetsRoot(props?.presentationAssetsRoot), "supplemental-presentation-rules")];
     if (props && props.supplementalRulesetDirectories) {
       props.supplementalRulesetDirectories.forEach((dir) => {
         if (-1 === supplementalRulesetDirectories.indexOf(dir))
@@ -888,7 +908,7 @@ const createContentDescriptorOverrides = (descriptorOrOverrides: Descriptor | De
 };
 
 const createLocaleDirectoryList = (props?: PresentationManagerProps) => {
-  const localeDirectories = [getLocalesDirectory(props?.presentationAssetsRoot ?? PRESENTATION_COMMON_ASSETS_ROOT)];
+  const localeDirectories = [getLocalesDirectory(getPresentationCommonAssetsRoot(props?.presentationAssetsRoot))];
   if (props && props.localeDirectories) {
     props.localeDirectories.forEach((dir) => {
       if (-1 === localeDirectories.indexOf(dir))
@@ -927,4 +947,20 @@ const createCacheConfig = (config?: HierarchyCacheConfig): IModelJsNative.ECPres
   if (config?.mode === HierarchyCacheMode.Memory)
     return config;
   return { mode: HierarchyCacheMode.Disk, directory: "" };
+};
+
+const getPresentationBackendAssetsRoot = (ovr?: string | { backend: string }) => {
+  if (typeof ovr === "string")
+    return ovr;
+  if (typeof ovr === "object")
+    return ovr.backend;
+  return PRESENTATION_BACKEND_ASSETS_ROOT;
+};
+
+const getPresentationCommonAssetsRoot = (ovr?: string | { common: string }) => {
+  if (typeof ovr === "string")
+    return ovr;
+  if (typeof ovr === "object")
+    return ovr.common;
+  return PRESENTATION_COMMON_ASSETS_ROOT;
 };

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -28,14 +28,14 @@ import {
 } from "@bentley/presentation-common/lib/test/_helpers/random";
 import { PRESENTATION_BACKEND_ASSETS_ROOT, PRESENTATION_COMMON_ASSETS_ROOT } from "../presentation-backend/Constants";
 import { NativePlatformDefinition, NativePlatformRequestTypes } from "../presentation-backend/NativePlatform";
-import { HierarchyCacheMode, HybridCacheConfig, PresentationManager, PresentationManagerMode, PresentationManagerProps } from "../presentation-backend/PresentationManager";
+import {
+  HierarchyCacheMode, HybridCacheConfig, PresentationManager, PresentationManagerMode, PresentationManagerProps,
+} from "../presentation-backend/PresentationManager";
 import { RulesetManagerImpl } from "../presentation-backend/RulesetManager";
 import { RulesetVariablesManagerImpl } from "../presentation-backend/RulesetVariablesManager";
 import { SelectionScopesHelper } from "../presentation-backend/SelectionScopesHelper";
 import { UpdatesTracker } from "../presentation-backend/UpdatesTracker";
 import { WithClientRequestContext } from "../presentation-backend/Utils";
-
-/* eslint-disable @typescript-eslint/promise-function-async */
 
 const deepEqual = require("deep-equal"); // eslint-disable-line @typescript-eslint/no-var-requires
 describe("PresentationManager", () => {
@@ -230,13 +230,49 @@ describe("PresentationManager", () => {
         addon.verifyAll();
       });
 
-      it("sets up presentation backend's supplemental ruleset directories using `presentationAssetsRoot` if supplied", () => {
+      it("sets up presentation backend's supplemental ruleset directories using `presentationAssetsRoot` as string if supplied", () => {
         const addonDirs = [path.join("/test", "supplemental-presentation-rules")];
         addon
           .setup((x) => x.setupSupplementalRulesetDirectories(addonDirs))
           .verifiable();
         using(new PresentationManager({ addon: addon.object, presentationAssetsRoot: "/test" }), (_pm: PresentationManager) => { });
         addon.verifyAll();
+      });
+
+      it("sets up presentation backend's supplemental ruleset directories using `presentationAssetsRoot.backend` if supplied", () => {
+        const addonDirs = [path.join("/backend-test", "supplemental-presentation-rules")];
+        addon
+          .setup((x) => x.setupSupplementalRulesetDirectories(addonDirs))
+          .verifiable();
+        using(new PresentationManager({ addon: addon.object, presentationAssetsRoot: { backend: "/backend-test", common: "/common-test" } }), (_pm: PresentationManager) => { });
+        addon.verifyAll();
+      });
+
+      it("sets up default locale directories", () => {
+        const constructorSpy = sinon.spy(IModelHost.platform, "ECPresentationManager");
+        using(new PresentationManager({}), (_manager) => { });
+        expect(constructorSpy).to.be.calledOnce;
+        expect(constructorSpy.firstCall.firstArg).to.containSubset({
+          localeDirectories: [getLocalesDirectory(PRESENTATION_COMMON_ASSETS_ROOT)],
+        });
+      });
+
+      it("sets up default locale directories using `presentationAssetsRoot` as string if supplied", () => {
+        const constructorSpy = sinon.spy(IModelHost.platform, "ECPresentationManager");
+        using(new PresentationManager({ presentationAssetsRoot: "/test" }), (_manager) => { });
+        expect(constructorSpy).to.be.calledOnce;
+        expect(constructorSpy.firstCall.firstArg).to.containSubset({
+          localeDirectories: [getLocalesDirectory("/test")],
+        });
+      });
+
+      it("sets up default locale directories using `presentationAssetsRoot.common` if supplied", () => {
+        const constructorSpy = sinon.spy(IModelHost.platform, "ECPresentationManager");
+        using(new PresentationManager({ presentationAssetsRoot: { backend: "/backend-test", common: "/common-test" } }), (_manager) => { });
+        expect(constructorSpy).to.be.calledOnce;
+        expect(constructorSpy.firstCall.firstArg).to.containSubset({
+          localeDirectories: [getLocalesDirectory("/common-test")],
+        });
       });
 
       it("sets up active locale if supplied", () => {
@@ -472,7 +508,7 @@ describe("PresentationManager", () => {
     it("registers ruleset if `rulesetOrId` is a ruleset", async () => {
       const ruleset = await createRandomRuleset();
       addonMock
-        .setup((x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()))
+        .setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()))
         .returns(async () => ({ result: "{}" }))
         .verifiable(moq.Times.once());
       addonMock
@@ -486,7 +522,7 @@ describe("PresentationManager", () => {
     it("doesn't register ruleset if `rulesetOrId` is a string", async () => {
       const rulesetId = faker.random.word();
       addonMock
-        .setup((x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()))
+        .setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()))
         .returns(async () => ({ result: "{}" }))
         .verifiable(moq.Times.once());
       addonMock
@@ -509,7 +545,7 @@ describe("PresentationManager", () => {
       };
       const diagnosticsListener = sinon.spy();
       addonMock
-        .setup((x) => x.handleRequest(moq.It.isAny(), moq.It.is((reqStr) => sinon.match(diagnosticOptions).test(JSON.parse(reqStr).params.diagnostics))))
+        .setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.is((reqStr) => sinon.match(diagnosticOptions).test(JSON.parse(reqStr).params.diagnostics))))
         .returns(async () => ({ result: "{}", diagnostics: diagnosticsResult }))
         .verifiable(moq.Times.once());
       await manager.getNodesCount({ requestContext: ClientRequestContext.current, imodel: imodelMock.object, rulesetOrId: "ruleset", diagnostics: { ...diagnosticOptions, listener: diagnosticsListener } });
@@ -528,7 +564,7 @@ describe("PresentationManager", () => {
       using(new PresentationManager({ addon: nativePlatformMock.object, enableSchemasPreload: true }), (_) => {
         const context = new ClientRequestContext();
         BriefcaseDb.onOpened.raiseEvent(context, imodelMock.object);
-        nativePlatformMock.verify((x) => x.forceLoadSchemas(moq.It.isAny()), moq.Times.once());
+        nativePlatformMock.verify(async (x) => x.forceLoadSchemas(moq.It.isAny()), moq.Times.once());
       });
     });
 
@@ -1225,7 +1261,7 @@ describe("PresentationManager", () => {
           prev: {},
           rulesetOrId: "test",
         });
-        nativePlatformMock.verify((x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()), moq.Times.never());
+        nativePlatformMock.verify(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()), moq.Times.never());
         expect(result).to.deep.eq([]);
       });
 
@@ -1241,7 +1277,7 @@ describe("PresentationManager", () => {
           expandedNodeKeys: [],
         };
         await expect(manager.compareHierarchies(options)).to.eventually.be.rejected;
-        nativePlatformMock.verify((x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()), moq.Times.never());
+        nativePlatformMock.verify(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAny()), moq.Times.never());
       });
 
       it("uses manager's `activeLocale` for comparison", async () => {
@@ -1313,7 +1349,7 @@ describe("PresentationManager", () => {
 
     });
 
-    describe("loadHierarhcy", () => {
+    describe("loadHierarchy", () => {
 
       it("[deprecated] requests hierarchy load", async () => {
         // what the addon receives

--- a/presentation/backend/src/test/index.test.ts
+++ b/presentation/backend/src/test/index.test.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import * as chai from "chai";
+import chaiSubset from "chai-subset";
+
+// configure chai
+chai.use(chaiSubset);


### PR DESCRIPTION
Allow overriding asset path directories for 'presentation-backend' and 'presentation-common' separately for cases when consumers want to use non-default paths, but don't want to merge assets into a single directory