### PR TITLE
Cancel requested animation frame in Panel component

### DIFF
--- a/common/changes/@bentley/ui-ninezone/ui-cancel-raf_2020-11-13-16-05.json
+++ b/common/changes/@bentley/ui-ninezone/ui-cancel-raf_2020-11-13-16-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-ninezone",
+      "comment": "Cancel requested animation frame in Panel component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-ninezone",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/ui/ninezone/src/test/Utils.ts
+++ b/ui/ninezone/src/test/Utils.ts
@@ -9,6 +9,9 @@ before(() => {
   window.requestAnimationFrame = (cb: FrameRequestCallback) => {
     return window.setTimeout(cb, 1);
   };
+  window.cancelAnimationFrame = (handle: number) => {
+    window.clearTimeout(handle);
+  };
 });
 
 /** @internal */

--- a/ui/ninezone/src/ui-ninezone/widget-panels/Panel.tsx
+++ b/ui/ninezone/src/ui-ninezone/widget-panels/Panel.tsx
@@ -375,22 +375,23 @@ export function useAnimatePanelWidgets(): {
           draft[widgetId] = widgetTransition.from;
         }
       }));
-
       setTransition("init");
     }
   }, [prepareTransition]);
   React.useEffect(() => {
     if (transition !== "init")
       return;
-    window.requestAnimationFrame(() => {
+    const handle = window.requestAnimationFrame(() => {
       setSizes((prev) => produce(prev, (draft) => {
         for (const [widgetId, widgetTransition] of widgetTransitions.current) {
           draft[widgetId] = widgetTransition.to;
         }
       }));
-
       setTransition("transition");
     });
+    return () => {
+      window.cancelAnimationFrame(handle);
+    };
   }, [transition]);
   const getRef = React.useCallback((widgetId: WidgetState["id"]) => {
     let ref = refs.current.get(widgetId);


### PR DESCRIPTION
Fix issue in Panel component where requested animation frame is not canceled, causing RAF callback (with setState) to execute after the component is unmounted.

Related warning in test environment: 
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```