### PR TITLE
Fix bug in date picker seen when daylight savings ends

### DIFF
--- a/common/changes/@bentley/ui-components/fixDatePickerForDaylightSavings_2020-11-17-19-08.json
+++ b/common/changes/@bentley/ui-components/fixDatePickerForDaylightSavings_2020-11-17-19-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Fix calendar logic to avoid duplicate day numbers when day light saving ends, producing a 25hr day.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/components/src/ui-components/datepicker/DatePicker.tsx
+++ b/ui/components/src/ui-components/datepicker/DatePicker.tsx
@@ -114,15 +114,15 @@ export function DatePicker(props: DatePickerProps) {
   const [focusedDay, setFocusedDay] = React.useState(selectedDay);
   const days = React.useMemo(() => {
     const msFirstDayOfMonth = new Date(displayedYear, displayedMonthIndex, 1).getTime();
-    const offsetToFirst = new Date(msFirstDayOfMonth).getDay();
-    const msFirstDayOfWeek = msFirstDayOfMonth - (offsetToFirst * MILLISECONDS_PER_DAY);
+    let offsetToFirst = new Date(msFirstDayOfMonth).getDay();
+    if (0 === offsetToFirst)
+      offsetToFirst = 7;
 
     const daysInMonth: Date[] = [];
-    let runningTickCount = msFirstDayOfWeek;
     // generate 6 weeks of dates
     for (let i = 0; i < 42; i++) {
-      daysInMonth.push(new Date(runningTickCount));
-      runningTickCount += MILLISECONDS_PER_DAY;
+      const adjustedDay = 1 + i - offsetToFirst;
+      daysInMonth.push(new Date(displayedYear, displayedMonthIndex, adjustedDay));
     }
     return daysInMonth;
   }, [displayedMonthIndex, displayedYear]);

--- a/ui/components/src/ui-components/datepicker/DatePicker.tsx
+++ b/ui/components/src/ui-components/datepicker/DatePicker.tsx
@@ -14,8 +14,6 @@ import { UiComponents } from "../UiComponents";
 
 import "./DatePicker.scss";
 
-const MILLISECONDS_PER_DAY = 86400000;
-
 function isSameDay(a: Date, b: Date) {
   return (
     a &&


### PR DESCRIPTION
Fix calendar logic to avoid duplicate day numbers when day light saving ends, producing a 25hr day.