### PR TITLE
Ignore device pixel ratio in tests

### DIFF
--- a/full-stack-tests/core/src/frontend/hub/PlanProjection.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/PlanProjection.test.ts
@@ -16,7 +16,13 @@ describe("Plan projections", () => {
   let mirukuru: IModelConnection;
 
   before(async () => {
-    await IModelApp.startup();
+    await IModelApp.startup({
+      renderSys: {
+        // Test wants to read the color of exactly one pixel, specified in CSS pixels. Ignore device pixel ratio.
+        dpiAwareViewports: false,
+      },
+    });
+
     mirukuru = await SnapshotConnection.openFile("planprojection.bim");
   });
 

--- a/full-stack-tests/core/src/frontend/standalone/BackgroundMap.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BackgroundMap.test.ts
@@ -16,7 +16,13 @@ describe("Background map", () => {
   let imodel: IModelConnection;
 
   before(async () => {
-    await IModelApp.startup();
+    await IModelApp.startup({
+      renderSys: {
+        // Test wants to read the color of exactly one pixel, specified in CSS pixels. Ignore device pixel ratio.
+        dpiAwareViewports: false,
+      },
+    });
+
     imodel = await SnapshotConnection.openFile("mirukuru.ibim");
   });
 


### PR DESCRIPTION
Specifically, tests that want to test the color of a single (CSS) pixel will fail when run in contexts when 1 CSS pixel != 1 device pixel.