### PR TITLE
Backport: Fix enum editor in grid layout - DR issue. (#252)

### DIFF
--- a/common/changes/@bentley/ui-components/fixEnumEditorInGridLayout_2020-11-18-01-45.json
+++ b/common/changes/@bentley/ui-components/fixEnumEditorInGridLayout_2020-11-18-01-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Revert width change to EnumEditor component instead set width to auto only for docked tool settings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/fixEnumEditorInGridLayout_2020-11-18-01-45.json
+++ b/common/changes/@bentley/ui-framework/fixEnumEditorInGridLayout_2020-11-18-01-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Revert width change to EnumEditor component instead set width to auto only for docked tool settings. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/components/src/ui-components/editors/EnumEditor.scss
+++ b/ui/components/src/ui-components/editors/EnumEditor.scss
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 .components-enum-editor {
-  width:            auto;
+  width:            100%;
   height:           100%;
   margin:           0;
   min-height:       23px;

--- a/ui/framework/src/ui-framework/uiprovider/DefaultDialogGridContainer.scss
+++ b/ui/framework/src/ui-framework/uiprovider/DefaultDialogGridContainer.scss
@@ -204,3 +204,10 @@ div.nz-toolSettings-docked .uifw-default-editor:last-child {
   margin-bottom: 0;
   align-self: center;
 }
+
+/* Override the GridLayout case where width is 100% */
+div.nz-toolSettings-docked {
+  select.uicore-inputs-select.components-cell-editor.components-enum-editor {
+    width: auto;
+  }
+}


### PR DESCRIPTION
* Revert change to EnumEditor style and fix a more specific way for horizontal tool settings.