### PR TITLE
Presentation: Unskip a test that was failing due to localization files not being found (fixed in addon)

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -130,6 +130,8 @@ export enum PresentationBackendNativeLoggerCategory {
     // (undocumented)
     ECPresentation_Connections = "ECPresentation.Connections",
     // (undocumented)
+    ECPresentation_Localization = "ECPresentation.Localization",
+    // (undocumented)
     ECPresentation_RulesEngine = "ECPresentation.RulesEngine",
     // (undocumented)
     ECPresentation_RulesEngine_Content = "ECPresentation.RulesEngine.Content",

--- a/common/changes/@bentley/presentation-backend/presentation-fix-test-failing-on-unix_2020-11-23-09-10.json
+++ b/common/changes/@bentley/presentation-backend/presentation-fix-test-failing-on-unix_2020-11-23-09-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Add `PresentationBackendNativeLoggerCategory.ECPresentation_Localization` for localization-related logs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -16,8 +16,8 @@
     "docs": "npm run extract",
     "extract": "betools extract --fileExt=ts --extractFrom=./src --recursive --out=../../generated-docs/extract",
     "lint": "eslint -f visualstudio --max-warnings 0 ./src/**/*.ts 1>&2",
-    "test": "cross-env NODE_ENV=development mocha --opts ./mocha.opts ./lib/**/*.js --grep \"#with-services\" --invert",
-    "test:integration": "mocha --opts ./mocha.opts ./lib/**/*.js --grep \"#with-services\"",
+    "test": "cross-env NODE_ENV=development mocha --opts ./mocha.opts \"./lib/**/*.js\" --grep \"#with-services\" --invert",
+    "test:integration": "mocha --opts ./mocha.opts \"./lib/**/*.js\" --grep \"#with-services\"",
     "cover": "npm run test"
   },
   "dependencies": {

--- a/full-stack-tests/presentation/src/IntegrationTests.ts
+++ b/full-stack-tests/presentation/src/IntegrationTests.ts
@@ -73,19 +73,23 @@ const initializeCommon = async (props: { backendTimeout?: number, useClientServi
   Logger.setLevelDefault(LogLevel.Warning);
   Logger.setLevel(PresentationBackendNativeLoggerCategory.ECObjects, LogLevel.Warning);
   Logger.setLevel(PresentationBackendNativeLoggerCategory.ECPresentation, LogLevel.Info);
+  Logger.setLevel(PresentationBackendNativeLoggerCategory.ECPresentation_Localization, LogLevel.Info);
   Logger.setLevel(PresentationBackendLoggerCategory.Package, LogLevel.Info);
   Logger.setLevel(PresentationFrontendLoggerCategory.Package, LogLevel.Info);
   Logger.setLevel(PresentationComponentsLoggerCategory.Package, LogLevel.Info);
 
+  const libDir = path.resolve("lib");
+  console.log(`Backend's lib directory path: ${libDir}`); // eslint-disable-line no-console
+
   const backendInitProps: PresentationBackendProps = {
     requestTimeout: props.backendTimeout ?? 0,
-    rulesetDirectories: ["lib/assets/rulesets"],
-    localeDirectories: ["lib/assets/locales"],
+    rulesetDirectories: [path.join(libDir, "assets", "rulesets")],
+    localeDirectories: [path.join(libDir, "assets", "locales")],
     activeLocale: "en-PSEUDO",
     taskAllocationsMap: {
       [RequestPriority.Max]: 1,
     },
-    cacheConfig: { mode: HierarchyCacheMode.Disk, directory: path.join("lib", "cache") },
+    cacheConfig: { mode: HierarchyCacheMode.Disk, directory: path.join(libDir, "cache") },
   };
   const frontendInitProps: PresentationFrontendProps = {
     activeLocale: "en-PSEUDO",

--- a/full-stack-tests/presentation/src/frontend/Content.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Content.test.ts
@@ -169,7 +169,7 @@ describe("Content", () => {
       }]);
     });
 
-    it.skip("gets paged distinct related content values", async () => {
+    it("gets paged distinct related content values", async () => {
       const ruleset: Ruleset = {
         id: Guid.createValue(),
         rules: [{
@@ -393,16 +393,25 @@ describe("Content", () => {
 
 });
 
-function findFieldByLabel(fields: Field[], label: string): Field | undefined {
+function findFieldByLabel(fields: Field[], label: string, allFields?: Field[]): Field | undefined {
+  const isTopLevel = (undefined === allFields);
+  if (!allFields)
+    allFields = new Array<Field>();
   for (const field of fields) {
     if (field.label === label)
       return field;
 
     if (field.isNestedContentField()) {
-      const nestedMatchingField = findFieldByLabel(field.nestedFields, label);
+      const nestedMatchingField = findFieldByLabel(field.nestedFields, label, allFields);
       if (nestedMatchingField)
         return nestedMatchingField;
     }
+
+    allFields.push(field);
+  }
+  if (isTopLevel) {
+    // eslint-disable-next-line no-console
+    console.error(`Field '${label}' not found. Available fields: [${allFields.map((f) => `"${f.label}"`).join(", ")}]`);
   }
   return undefined;
 }

--- a/presentation/backend/src/presentation-backend/BackendLoggerCategory.ts
+++ b/presentation/backend/src/presentation-backend/BackendLoggerCategory.ts
@@ -36,6 +36,7 @@ export enum PresentationBackendNativeLoggerCategory {
 
   ECPresentation = "ECPresentation",
   ECPresentation_Connections = "ECPresentation.Connections",
+  ECPresentation_Localization = "ECPresentation.Localization",
   ECPresentation_RulesEngine = "ECPresentation.RulesEngine",
   ECPresentation_RulesEngine_Content = "ECPresentation.RulesEngine.Content",
   ECPresentation_RulesEngine_Localization = "ECPresentation.RulesEngine.Localization",


### PR DESCRIPTION
We use active locale as 'en-PSEUDO' and the directory containing pseudo-localized strings is 'en-pseudo'. That's not an issue on Windows and Mac, but on Linux we need casing to match exactly for paths. The addon now tries ['en-pseudo', 'en-PSEUDO', 'EN-pseudo', 'EN-PSEUDO'].