### PR TITLE
Presentation: Stop using settings service in full stack tests

### DIFF
--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -34,6 +34,7 @@
     "@bentley/presentation-frontend": "2.10.0-dev.13",
     "@bentley/presentation-components": "2.10.0-dev.13",
     "@bentley/presentation-testing": "2.10.0-dev.13",
+    "@bentley/product-settings-client": "2.10.0-dev.13",
     "@bentley/ui-core": "2.10.0-dev.13",
     "@bentley/ui-components": "2.10.0-dev.13",
     "@bentley/ui-abstract": "2.10.0-dev.13",


### PR DESCRIPTION
We use specific namespace+settingId for storing favorites in user settings service. Problem is that there was a race condition when multiple presentation-full-stack-tests were run in parallel - one test could overwrite settings that were set up by another. This PR stops us from using the settings service completely.