### PR TITLE
Cherry-pick 2.7.5 and 2.7.6 changelogs

### DIFF
--- a/clients/backend-application-insights/CHANGELOG.json
+++ b/clients/backend-application-insights/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/backend-application-insights-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/backend-application-insights-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/backend-application-insights-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/backend-application-insights/CHANGELOG.md
+++ b/clients/backend-application-insights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/backend-application-insights-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/backend-application-insights/CHANGELOG.md
+++ b/clients/backend-application-insights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/backend-application-insights-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/context-registry/CHANGELOG.json
+++ b/clients/context-registry/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/context-registry-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/context-registry-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/context-registry-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/context-registry/CHANGELOG.md
+++ b/clients/context-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/context-registry-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/context-registry/CHANGELOG.md
+++ b/clients/context-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/context-registry-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/extension/CHANGELOG.json
+++ b/clients/extension/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/extension-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/extension-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/extension-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/extension/CHANGELOG.md
+++ b/clients/extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/extension-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/extension/CHANGELOG.md
+++ b/clients/extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/extension-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/forms-data-management/CHANGELOG.json
+++ b/clients/forms-data-management/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/forms-data-management-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/forms-data-management-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/forms-data-management-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/forms-data-management/CHANGELOG.md
+++ b/clients/forms-data-management/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/forms-data-management-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/forms-data-management/CHANGELOG.md
+++ b/clients/forms-data-management/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/forms-data-management-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/frontend-application-insights/CHANGELOG.json
+++ b/clients/frontend-application-insights/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/frontend-application-insights-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/frontend-application-insights-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/frontend-application-insights-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/frontend-application-insights/CHANGELOG.md
+++ b/clients/frontend-application-insights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/frontend-application-insights-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/frontend-application-insights/CHANGELOG.md
+++ b/clients/frontend-application-insights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/frontend-application-insights-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/frontend-authorization/CHANGELOG.json
+++ b/clients/frontend-authorization/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/frontend-authorization-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/frontend-authorization-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/frontend-authorization-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/frontend-authorization/CHANGELOG.md
+++ b/clients/frontend-authorization/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/frontend-authorization-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/frontend-authorization/CHANGELOG.md
+++ b/clients/frontend-authorization/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/frontend-authorization-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/imodelhub/CHANGELOG.json
+++ b/clients/imodelhub/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodelhub-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodelhub-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodelhub-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/imodelhub/CHANGELOG.md
+++ b/clients/imodelhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodelhub-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/imodelhub/CHANGELOG.md
+++ b/clients/imodelhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodelhub-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - Added hidden property and filter notHidden named Versions
 - Lock event parsing fix
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/clients/itwin/CHANGELOG.json
+++ b/clients/itwin/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/itwin-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/itwin-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/itwin-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/clients/itwin/CHANGELOG.md
+++ b/clients/itwin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/itwin-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/itwin/CHANGELOG.md
+++ b/clients/itwin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/itwin-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/product-settings/CHANGELOG.json
+++ b/clients/product-settings/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/product-settings-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/product-settings-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/product-settings-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/clients/product-settings/CHANGELOG.md
+++ b/clients/product-settings/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/product-settings-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/product-settings/CHANGELOG.md
+++ b/clients/product-settings/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/product-settings-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/projectshare/CHANGELOG.json
+++ b/clients/projectshare/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/projectshare-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/projectshare-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/projectshare-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/clients/projectshare/CHANGELOG.md
+++ b/clients/projectshare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/projectshare-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/projectshare/CHANGELOG.md
+++ b/clients/projectshare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/projectshare-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/rbac/CHANGELOG.json
+++ b/clients/rbac/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/rbac-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/rbac-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/rbac-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/clients/rbac/CHANGELOG.md
+++ b/clients/rbac/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/rbac-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/rbac/CHANGELOG.md
+++ b/clients/rbac/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/rbac-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/reality-data/CHANGELOG.json
+++ b/clients/reality-data/CHANGELOG.json
@@ -20,6 +20,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/reality-data-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/reality-data-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/reality-data-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/clients/reality-data/CHANGELOG.md
+++ b/clients/reality-data/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/reality-data-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/reality-data/CHANGELOG.md
+++ b/clients/reality-data/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/reality-data-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -13,6 +13,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 ### Updates
 
 - Add support for OPC point clouds in Reality Data widget.
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/clients/telemetry/CHANGELOG.json
+++ b/clients/telemetry/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/telemetry-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/telemetry-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/telemetry-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/clients/telemetry/CHANGELOG.md
+++ b/clients/telemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/telemetry-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/telemetry/CHANGELOG.md
+++ b/clients/telemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/telemetry-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/clients/usage-logging/CHANGELOG.json
+++ b/clients/usage-logging/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/usage-logging-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/usage-logging-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/usage-logging-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/clients/usage-logging/CHANGELOG.md
+++ b/clients/usage-logging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/usage-logging-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/clients/usage-logging/CHANGELOG.md
+++ b/clients/usage-logging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/usage-logging-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
 
 _Version update only_
 

--- a/common/changes/@bentley/analytical-backend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/analytical-backend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/analytical-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/backend-application-insights-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/backend-application-insights-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-application-insights-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-application-insights-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/backend-itwin-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/backend-itwin-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-itwin-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-itwin-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/backend-webpack-tools/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/backend-webpack-tools/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-webpack-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-webpack-tools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/bentleyjs-core/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/bentleyjs-core/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/bentleyjs-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/bentleyjs-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/build-tools/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/build-tools/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/build-tools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/certa/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/certa/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/certa",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/certa",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/config-loader/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/config-loader/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/config-loader",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/config-loader",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/context-registry-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/context-registry-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/context-registry-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/context-registry-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema-locaters/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ecschema-locaters/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema-locaters",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema-locaters",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema-metadata/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ecschema-metadata/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema-metadata",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema-metadata",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema2ts/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ecschema2ts/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema2ts",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema2ts",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/electron-manager/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/electron-manager/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/eslint-plugin/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/eslint-plugin/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/eslint-plugin",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/express-server/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/express-server/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/express-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/express-server",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-cli/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/extension-cli/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-cli",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/extension-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-webpack-tools/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/extension-webpack-tools/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-webpack-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-webpack-tools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/forms-data-management-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/forms-data-management-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/forms-data-management-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/forms-data-management-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/frontend-application-insights-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/frontend-application-insights-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-application-insights-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-application-insights-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/frontend-authorization-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/frontend-authorization-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-authorization-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-authorization-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/frontend-devtools/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/frontend-devtools/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-devtools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-devtools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/geometry-core/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/geometry-core/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/geonames-extension/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/geonames-extension/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geonames-extension",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geonames-extension",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/hypermodeling-frontend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/hypermodeling-frontend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/hypermodeling-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/hypermodeling-frontend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodel-bridge/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodel-bridge/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-bridge",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodel-bridge",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client-tests/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodelhub-client-tests/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client-tests",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodelhub-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodeljs-backend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodeljs-common/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodeljs-frontend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-i18n/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodeljs-i18n/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-i18n",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-i18n",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-markup/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodeljs-markup/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-markup",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-quantity/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/imodeljs-quantity/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-quantity",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-quantity",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/itwin-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/itwin-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/itwin-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/linear-referencing-backend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/linear-referencing-backend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/linear-referencing-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/linear-referencing-common/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/linear-referencing-common/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/linear-referencing-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/linear-referencing-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/logger-config/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/logger-config/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/logger-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/logger-config",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/map-layers/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/map-layers/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/map-layers",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/map-layers",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/oidc-signin-tool/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/oidc-signin-tool/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/oidc-signin-tool",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/oidc-signin-tool",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/orbitgt-core/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/orbitgt-core/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/orbitgt-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/orbitgt-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/perf-tools/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/perf-tools/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/perf-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/perf-tools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/physical-material-backend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/physical-material-backend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/physical-material-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/physical-material-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-backend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/presentation-backend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/presentation-common/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/presentation-components/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-frontend/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/presentation-frontend/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-testing/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/presentation-testing/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-testing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-testing",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/product-settings-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/product-settings-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/product-settings-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/product-settings-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/projectshare-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/projectshare-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/projectshare-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/projectshare-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/rbac-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/rbac-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/rbac-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/rbac-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/reality-data-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/reality-data-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/reality-data-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/reality-data-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/rpcinterface-full-stack-tests/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/rpcinterface-full-stack-tests/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/rpcinterface-full-stack-tests",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/telemetry-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/telemetry-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/telemetry-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/telemetry-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-abstract/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ui-abstract/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-abstract",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-abstract",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-components/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ui-components/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-core/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ui-core/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ui-framework/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-ninezone/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/ui-ninezone/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-ninezone",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-ninezone",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/usage-logging-client/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/usage-logging-client/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/usage-logging-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/usage-logging-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/webgl-compatibility/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/webgl-compatibility/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webgl-compatibility",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/webpack-tools-core/2-8-0-changelogs_2020-11-23-18-21.json
+++ b/common/changes/@bentley/webpack-tools-core/2-8-0-changelogs_2020-11-23-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webpack-tools-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webpack-tools-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/core/backend-itwin-client/CHANGELOG.json
+++ b/core/backend-itwin-client/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/backend-itwin-client_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/backend-itwin-client_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/backend-itwin-client_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/backend-itwin-client/CHANGELOG.md
+++ b/core/backend-itwin-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/backend-itwin-client
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/backend-itwin-client/CHANGELOG.md
+++ b/core/backend-itwin-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/backend-itwin-client
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/backend/CHANGELOG.json
+++ b/core/backend/CHANGELOG.json
@@ -50,6 +50,24 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodeljs-backend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "Update to @bentley/imodeljs-native@2.7.9"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodeljs-backend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodeljs-backend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-backend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -23,6 +23,18 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Elemeent CRUD perf test fixed
 - Add IModelTileRpcInterface.queryVersionInfo().
 - ConcurrencyManager documentation
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+### Updates
+
+- Update to @bentley/imodeljs-native@2.7.9
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-backend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/bentley/CHANGELOG.json
+++ b/core/bentley/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/bentleyjs-core_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/bentleyjs-core_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/bentleyjs-core_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/bentley/CHANGELOG.md
+++ b/core/bentley/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/bentleyjs-core
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/bentley/CHANGELOG.md
+++ b/core/bentley/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/bentleyjs-core
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/common/CHANGELOG.json
+++ b/core/common/CHANGELOG.json
@@ -32,6 +32,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodeljs-common_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodeljs-common_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodeljs-common_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/common/CHANGELOG.md
+++ b/core/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-common
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -17,6 +17,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Add IModelTileRpcInterface.queryVersionInfo().
 - Add support for OPC point clouds in Reality Data widget.
 - Added color mix to thematic display for background map terrain and point clouds
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/core/common/CHANGELOG.md
+++ b/core/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-common
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/ecschema-locaters/CHANGELOG.json
+++ b/core/ecschema-locaters/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ecschema-locaters_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ecschema-locaters_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ecschema-locaters_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/ecschema-locaters/CHANGELOG.md
+++ b/core/ecschema-locaters/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ecschema-locaters
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/ecschema-locaters/CHANGELOG.md
+++ b/core/ecschema-locaters/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ecschema-locaters
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/ecschema-metadata/CHANGELOG.json
+++ b/core/ecschema-metadata/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ecschema-metadata_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ecschema-metadata_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ecschema-metadata_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/ecschema-metadata/CHANGELOG.md
+++ b/core/ecschema-metadata/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ecschema-metadata
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/ecschema-metadata/CHANGELOG.md
+++ b/core/ecschema-metadata/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ecschema-metadata
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/electron-manager/CHANGELOG.json
+++ b/core/electron-manager/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/electron-manager_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/electron-manager_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/electron-manager_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/electron-manager/CHANGELOG.md
+++ b/core/electron-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/electron-manager
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/electron-manager/CHANGELOG.md
+++ b/core/electron-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/electron-manager
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/express-server/CHANGELOG.json
+++ b/core/express-server/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/express-server_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/express-server_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/express-server_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/express-server/CHANGELOG.md
+++ b/core/express-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/express-server
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/express-server/CHANGELOG.md
+++ b/core/express-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/express-server
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/frontend-devtools/CHANGELOG.json
+++ b/core/frontend-devtools/CHANGELOG.json
@@ -20,6 +20,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/frontend-devtools_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/frontend-devtools_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/frontend-devtools_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/frontend-devtools/CHANGELOG.md
+++ b/core/frontend-devtools/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/frontend-devtools
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -13,6 +13,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 ### Updates
 
 - Add tool to detach reality models.
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/core/frontend-devtools/CHANGELOG.md
+++ b/core/frontend-devtools/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/frontend-devtools
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/frontend/CHANGELOG.json
+++ b/core/frontend/CHANGELOG.json
@@ -5,7 +5,13 @@
       "version": "2.8.1",
       "tag": "@bentley/imodeljs-frontend_v2.8.1",
       "date": "Tue, 03 Nov 2020 00:33:56 GMT",
-      "comments": {}
+      "comments": {
+        "none": [
+          {
+            "comment": "disable frontend Bentley telemetry in iModelBank use case"
+          }
+        ]
+      }
     },
     {
       "version": "2.8.0",
@@ -83,7 +89,7 @@
       "comments": {
         "none": [
           {
-            "comment": "disable frontend Bentley telemetry in iModelBank use case"
+            "comment": "Reduce threshold for ecef validation."
           }
         ]
       }

--- a/core/frontend/CHANGELOG.json
+++ b/core/frontend/CHANGELOG.json
@@ -5,13 +5,7 @@
       "version": "2.8.1",
       "tag": "@bentley/imodeljs-frontend_v2.8.1",
       "date": "Tue, 03 Nov 2020 00:33:56 GMT",
-      "comments": {
-        "none": [
-          {
-            "comment": "disable frontend Bentley telemetry in iModelBank use case"
-          }
-        ]
-      }
+      "comments": {}
     },
     {
       "version": "2.8.0",
@@ -72,6 +66,24 @@
           },
           {
             "comment": "added IModelApp.translateErrorNumber"
+          }
+        ]
+      }
+    },
+    {
+      "version": "2.7.6",
+      "tag": "@bentley/imodeljs-frontend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodeljs-frontend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {
+        "none": [
+          {
+            "comment": "disable frontend Bentley telemetry in iModelBank use case"
           }
         ]
       }

--- a/core/frontend/CHANGELOG.md
+++ b/core/frontend/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Change Log - @bentley/imodeljs-frontend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
 
-### Updates
-
-- disable frontend Bentley telemetry in iModelBank use case
+_Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
@@ -32,6 +30,18 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Add support for OPC point clouds in Reality Data widget.
 - Added color mix to thematic display for background map terrain and point clouds
 - added IModelApp.translateErrorNumber
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+### Updates
+
+- disable frontend Bentley telemetry in iModelBank use case
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/core/frontend/CHANGELOG.md
+++ b/core/frontend/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log - @bentley/imodeljs-frontend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
 
-_Version update only_
+### Updates
+
+- disable frontend Bentley telemetry in iModelBank use case
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
@@ -41,7 +43,7 @@ Fri, 23 Oct 2020 16:23:50 GMT
 
 ### Updates
 
-- disable frontend Bentley telemetry in iModelBank use case
+- Reduce threshold for ecef validation.
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/core/geometry/CHANGELOG.json
+++ b/core/geometry/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/geometry-core_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/geometry-core_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/geometry-core_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/geometry/CHANGELOG.md
+++ b/core/geometry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/geometry-core
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - New methods PolyfaceQuery.buildAverageNormals and .buildPerFaceNormals
 - Fix bugs in integrated spirals with nonzero start radius
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/core/geometry/CHANGELOG.md
+++ b/core/geometry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/geometry-core
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/hypermodeling/CHANGELOG.json
+++ b/core/hypermodeling/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/hypermodeling-frontend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/hypermodeling-frontend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/hypermodeling-frontend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/hypermodeling/CHANGELOG.md
+++ b/core/hypermodeling/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/hypermodeling-frontend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/hypermodeling/CHANGELOG.md
+++ b/core/hypermodeling/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/hypermodeling-frontend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/i18n/CHANGELOG.json
+++ b/core/i18n/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodeljs-i18n_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodeljs-i18n_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodeljs-i18n_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/i18n/CHANGELOG.md
+++ b/core/i18n/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-i18n
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/i18n/CHANGELOG.md
+++ b/core/i18n/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-i18n
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/imodel-bridge/CHANGELOG.json
+++ b/core/imodel-bridge/CHANGELOG.json
@@ -20,6 +20,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodel-bridge_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodel-bridge_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodel-bridge_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/imodel-bridge/CHANGELOG.md
+++ b/core/imodel-bridge/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodel-bridge
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/imodel-bridge/CHANGELOG.md
+++ b/core/imodel-bridge/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodel-bridge
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -11,6 +11,16 @@ Tue, 03 Nov 2020 00:33:56 GMT
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/logger-config/CHANGELOG.json
+++ b/core/logger-config/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/logger-config_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/logger-config_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/logger-config_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/logger-config/CHANGELOG.md
+++ b/core/logger-config/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/logger-config
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/logger-config/CHANGELOG.md
+++ b/core/logger-config/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/logger-config
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/markup/CHANGELOG.json
+++ b/core/markup/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodeljs-markup_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodeljs-markup_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodeljs-markup_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/markup/CHANGELOG.md
+++ b/core/markup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-markup
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/markup/CHANGELOG.md
+++ b/core/markup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-markup
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/orbitgt/CHANGELOG.json
+++ b/core/orbitgt/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/orbitgt-core_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/orbitgt-core_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/orbitgt-core_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/core/orbitgt/CHANGELOG.md
+++ b/core/orbitgt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/orbitgt-core
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/orbitgt/CHANGELOG.md
+++ b/core/orbitgt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/orbitgt-core
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/quantity/CHANGELOG.json
+++ b/core/quantity/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodeljs-quantity_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodeljs-quantity_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodeljs-quantity_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/core/quantity/CHANGELOG.md
+++ b/core/quantity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-quantity
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/core/quantity/CHANGELOG.md
+++ b/core/quantity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodeljs-quantity
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/core/webgl-compatibility/CHANGELOG.json
+++ b/core/webgl-compatibility/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/webgl-compatibility_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/webgl-compatibility_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/webgl-compatibility_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/core/webgl-compatibility/CHANGELOG.md
+++ b/core/webgl-compatibility/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/webgl-compatibility
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
 
 _Version update only_
 

--- a/core/webgl-compatibility/CHANGELOG.md
+++ b/core/webgl-compatibility/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/webgl-compatibility
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/domains/analytical/backend/CHANGELOG.json
+++ b/domains/analytical/backend/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/analytical-backend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/analytical-backend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/analytical-backend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/domains/analytical/backend/CHANGELOG.md
+++ b/domains/analytical/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/analytical-backend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/domains/analytical/backend/CHANGELOG.md
+++ b/domains/analytical/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/analytical-backend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/domains/linear-referencing/backend/CHANGELOG.json
+++ b/domains/linear-referencing/backend/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/linear-referencing-backend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/linear-referencing-backend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/linear-referencing-backend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/domains/linear-referencing/backend/CHANGELOG.md
+++ b/domains/linear-referencing/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/linear-referencing-backend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/domains/linear-referencing/backend/CHANGELOG.md
+++ b/domains/linear-referencing/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/linear-referencing-backend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/domains/linear-referencing/common/CHANGELOG.json
+++ b/domains/linear-referencing/common/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/linear-referencing-common_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/linear-referencing-common_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/linear-referencing-common_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/domains/linear-referencing/common/CHANGELOG.md
+++ b/domains/linear-referencing/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/linear-referencing-common
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/domains/linear-referencing/common/CHANGELOG.md
+++ b/domains/linear-referencing/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/linear-referencing-common
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/domains/physical-material/backend/CHANGELOG.json
+++ b/domains/physical-material/backend/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/physical-material-backend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/physical-material-backend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/physical-material-backend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/domains/physical-material/backend/CHANGELOG.md
+++ b/domains/physical-material/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/physical-material-backend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/domains/physical-material/backend/CHANGELOG.md
+++ b/domains/physical-material/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/physical-material-backend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/extensions/geonames/CHANGELOG.json
+++ b/extensions/geonames/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/geonames-extension_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/geonames-extension_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/geonames-extension_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/extensions/geonames/CHANGELOG.md
+++ b/extensions/geonames/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/geonames-extension
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/extensions/geonames/CHANGELOG.md
+++ b/extensions/geonames/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/geonames-extension
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/extensions/map-layers/CHANGELOG.json
+++ b/extensions/map-layers/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/map-layers_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/map-layers_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/map-layers_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/extensions/map-layers/CHANGELOG.md
+++ b/extensions/map-layers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/map-layers
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - Introduced the concept of named/unamed groups and made sure the SubLayers tree view remained consistent with the display (i.e disabling children of non-visible unnamed groups)
 - Added optional wms autentication
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/extensions/map-layers/CHANGELOG.md
+++ b/extensions/map-layers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/map-layers
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/full-stack-tests/imodelhub-client/CHANGELOG.json
+++ b/full-stack-tests/imodelhub-client/CHANGELOG.json
@@ -26,6 +26,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/imodelhub-client-tests_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/imodelhub-client-tests_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/imodelhub-client-tests_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/full-stack-tests/imodelhub-client/CHANGELOG.md
+++ b/full-stack-tests/imodelhub-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodelhub-client-tests
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -15,6 +15,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Fix randomly failing test
 - Added tests for notHidden versions
 - Lock event parsing fix
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/full-stack-tests/imodelhub-client/CHANGELOG.md
+++ b/full-stack-tests/imodelhub-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/imodelhub-client-tests
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/full-stack-tests/rpc-interface/CHANGELOG.json
+++ b/full-stack-tests/rpc-interface/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/rpcinterface-full-stack-tests_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/rpcinterface-full-stack-tests_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/rpcinterface-full-stack-tests_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/full-stack-tests/rpc-interface/CHANGELOG.md
+++ b/full-stack-tests/rpc-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/rpcinterface-full-stack-tests
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - Add tests for deprecated PresentationRpcInterface endpoints and new IModelReadRpcInterface.getGeometryContainment method
 - Remove the unused variables from the template.env
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/full-stack-tests/rpc-interface/CHANGELOG.md
+++ b/full-stack-tests/rpc-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/rpcinterface-full-stack-tests
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/presentation/backend/CHANGELOG.json
+++ b/presentation/backend/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/presentation-backend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/presentation-backend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/presentation-backend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/presentation/backend/CHANGELOG.md
+++ b/presentation/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-backend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/presentation/backend/CHANGELOG.md
+++ b/presentation/backend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-backend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - Add ability to get per-request diagnostic logs by specifying `diagnostics` options in RPC request
 - Allow computing selection of removed elements. Simply ignore ids that are not found.
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/presentation/common/CHANGELOG.json
+++ b/presentation/common/CHANGELOG.json
@@ -35,6 +35,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/presentation-common_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/presentation-common_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/presentation-common_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/presentation/common/CHANGELOG.md
+++ b/presentation/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-common
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/presentation/common/CHANGELOG.md
+++ b/presentation/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-common
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -18,6 +18,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Do not duplicate nodes when traversing from node that merges multiple instances from the 'many' side of relationship
 - Add support for specifying "*" and property overrides in `RelatedPropertiesSpecification.properties`
 - Ruleset creation fails for (0, 0) 2D point
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/presentation/components/CHANGELOG.json
+++ b/presentation/components/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/presentation-components_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/presentation-components_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/presentation-components_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/presentation/components/CHANGELOG.md
+++ b/presentation/components/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-components
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/presentation/components/CHANGELOG.md
+++ b/presentation/components/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-components
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/presentation/frontend/CHANGELOG.json
+++ b/presentation/frontend/CHANGELOG.json
@@ -20,6 +20,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/presentation-frontend_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/presentation-frontend_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/presentation-frontend_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/presentation/frontend/CHANGELOG.md
+++ b/presentation/frontend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-frontend
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/presentation/frontend/CHANGELOG.md
+++ b/presentation/frontend/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-frontend
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -13,6 +13,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 ### Updates
 
 - Do not request transient elements' content
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/presentation/testing/CHANGELOG.json
+++ b/presentation/testing/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/presentation-testing_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/presentation-testing_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/presentation-testing_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/presentation/testing/CHANGELOG.md
+++ b/presentation/testing/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-testing
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/presentation/testing/CHANGELOG.md
+++ b/presentation/testing/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/presentation-testing
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/backend-webpack/CHANGELOG.json
+++ b/tools/backend-webpack/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/backend-webpack-tools_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/backend-webpack-tools_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/backend-webpack-tools_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/backend-webpack/CHANGELOG.md
+++ b/tools/backend-webpack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/backend-webpack-tools
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/backend-webpack/CHANGELOG.md
+++ b/tools/backend-webpack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/backend-webpack-tools
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/build/CHANGELOG.json
+++ b/tools/build/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/build-tools_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/build-tools_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/build-tools_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/build/CHANGELOG.md
+++ b/tools/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/build-tools
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/build/CHANGELOG.md
+++ b/tools/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/build-tools
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/certa/CHANGELOG.json
+++ b/tools/certa/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/certa_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/certa_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/certa_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/certa/CHANGELOG.md
+++ b/tools/certa/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/certa
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/certa/CHANGELOG.md
+++ b/tools/certa/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/certa
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/config-loader/CHANGELOG.json
+++ b/tools/config-loader/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/config-loader_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/config-loader_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/config-loader_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/config-loader/CHANGELOG.md
+++ b/tools/config-loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/config-loader
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/config-loader/CHANGELOG.md
+++ b/tools/config-loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/config-loader
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/ecschema2ts/CHANGELOG.json
+++ b/tools/ecschema2ts/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ecschema2ts_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ecschema2ts_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ecschema2ts_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/ecschema2ts/CHANGELOG.md
+++ b/tools/ecschema2ts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ecschema2ts
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/ecschema2ts/CHANGELOG.md
+++ b/tools/ecschema2ts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ecschema2ts
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/eslint-plugin/CHANGELOG.json
+++ b/tools/eslint-plugin/CHANGELOG.json
@@ -20,6 +20,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/eslint-plugin_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/eslint-plugin_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/eslint-plugin_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/eslint-plugin/CHANGELOG.md
+++ b/tools/eslint-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/eslint-plugin
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -13,6 +13,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 ### Updates
 
 - Added jsdoc ESLint rule for UI packages
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:01 GMT

--- a/tools/eslint-plugin/CHANGELOG.md
+++ b/tools/eslint-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/eslint-plugin
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/extension-cli/CHANGELOG.json
+++ b/tools/extension-cli/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/extension-cli_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/extension-cli_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/extension-cli_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/extension-cli/CHANGELOG.md
+++ b/tools/extension-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/extension-cli
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/extension-cli/CHANGELOG.md
+++ b/tools/extension-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/extension-cli
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/extension-webpack/CHANGELOG.json
+++ b/tools/extension-webpack/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/extension-webpack-tools_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/extension-webpack-tools_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/extension-webpack-tools_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:01 GMT",

--- a/tools/extension-webpack/CHANGELOG.md
+++ b/tools/extension-webpack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/extension-webpack-tools
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/extension-webpack/CHANGELOG.md
+++ b/tools/extension-webpack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/extension-webpack-tools
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/oidc-signin-tool/CHANGELOG.json
+++ b/tools/oidc-signin-tool/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/oidc-signin-tool_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/oidc-signin-tool_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/oidc-signin-tool_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/tools/oidc-signin-tool/CHANGELOG.md
+++ b/tools/oidc-signin-tool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/oidc-signin-tool
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/oidc-signin-tool/CHANGELOG.md
+++ b/tools/oidc-signin-tool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/oidc-signin-tool
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/perf-tools/CHANGELOG.json
+++ b/tools/perf-tools/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/perf-tools_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/perf-tools_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/perf-tools_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/tools/perf-tools/CHANGELOG.md
+++ b/tools/perf-tools/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/perf-tools
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/perf-tools/CHANGELOG.md
+++ b/tools/perf-tools/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/perf-tools
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
 
 _Version update only_
 

--- a/tools/webpack-core/CHANGELOG.json
+++ b/tools/webpack-core/CHANGELOG.json
@@ -14,6 +14,18 @@
       "comments": {}
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/webpack-tools-core_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/webpack-tools-core_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/webpack-tools-core_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/tools/webpack-core/CHANGELOG.md
+++ b/tools/webpack-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/webpack-tools-core
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/tools/webpack-core/CHANGELOG.md
+++ b/tools/webpack-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/webpack-tools-core
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -9,6 +9,16 @@ _Version update only_
 
 ## 2.8.0
 Fri, 23 Oct 2020 17:04:02 GMT
+
+_Version update only_
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
 
 _Version update only_
 

--- a/ui/abstract/CHANGELOG.json
+++ b/ui/abstract/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ui-abstract_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ui-abstract_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:50 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ui-abstract_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/ui/abstract/CHANGELOG.md
+++ b/ui/abstract/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-abstract
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - Add definitions used to define DateTime component options.
 - Added jsdoc ESLint rule for UI packages
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:50 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/ui/abstract/CHANGELOG.md
+++ b/ui/abstract/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-abstract
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/ui/components/CHANGELOG.json
+++ b/ui/components/CHANGELOG.json
@@ -35,6 +35,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ui-components_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ui-components_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ui-components_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/ui/components/CHANGELOG.md
+++ b/ui/components/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-components
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/ui/components/CHANGELOG.md
+++ b/ui/components/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-components
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -18,6 +18,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Update all editors to be controlled components.
 - PropertyGrid: Fix component not updating on data provider change
 - Added jsdoc ESLint rule for UI packages
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/ui/core/CHANGELOG.json
+++ b/ui/core/CHANGELOG.json
@@ -32,6 +32,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ui-core_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ui-core_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ui-core_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/ui/core/CHANGELOG.md
+++ b/ui/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-core
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -17,6 +17,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Revert changes made to limit focus trap to contents only. Use class now to ignore unwanted focus target.
 - Add missing semicolons to .scss files.
 - Added jsdoc ESLint rule for UI packages
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/ui/core/CHANGELOG.md
+++ b/ui/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-core
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/ui/framework/CHANGELOG.json
+++ b/ui/framework/CHANGELOG.json
@@ -26,6 +26,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ui-framework_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ui-framework_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ui-framework_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/ui/framework/CHANGELOG.md
+++ b/ui/framework/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-framework
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/ui/framework/CHANGELOG.md
+++ b/ui/framework/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-framework
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -15,6 +15,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - ModelsTree: Handle GraphicalPartition3d similar to PhysicalPartition - it should not be displayed if there's a 'GraphicalPartition3d.Model.Content' attribute in JsonProperties
 - Added jsdoc ESLint rule for UI packages
 - Upgraded react-split-pane to 0.1.92
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT

--- a/ui/ninezone/CHANGELOG.json
+++ b/ui/ninezone/CHANGELOG.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "version": "2.7.6",
+      "tag": "@bentley/ui-ninezone_v2.7.6",
+      "date": "Wed, 11 Nov 2020 16:28:23 GMT",
+      "comments": {}
+    },
+    {
+      "version": "2.7.5",
+      "tag": "@bentley/ui-ninezone_v2.7.5",
+      "date": "Fri, 23 Oct 2020 16:23:51 GMT",
+      "comments": {}
+    },
+    {
       "version": "2.7.4",
       "tag": "@bentley/ui-ninezone_v2.7.4",
       "date": "Mon, 19 Oct 2020 17:57:02 GMT",

--- a/ui/ninezone/CHANGELOG.md
+++ b/ui/ninezone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-ninezone
 
-This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:27:53 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT

--- a/ui/ninezone/CHANGELOG.md
+++ b/ui/ninezone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @bentley/ui-ninezone
 
-This log was last generated on Tue, 03 Nov 2020 00:33:56 GMT and should not be manually modified.
+This log was last generated on Mon, 23 Nov 2020 18:20:22 GMT and should not be manually modified.
 
 ## 2.8.1
 Tue, 03 Nov 2020 00:33:56 GMT
@@ -14,6 +14,16 @@ Fri, 23 Oct 2020 17:04:02 GMT
 
 - Allow to expand collapsed panel with unitialized size.
 - Added jsdoc ESLint rule for UI packages
+
+## 2.7.6
+Wed, 11 Nov 2020 16:28:23 GMT
+
+_Version update only_
+
+## 2.7.5
+Fri, 23 Oct 2020 16:23:51 GMT
+
+_Version update only_
 
 ## 2.7.4
 Mon, 19 Oct 2020 17:57:02 GMT


### PR DESCRIPTION
This is one in a series of PRs to fix all of our changelogs on the release branches to make sure `master` and all future release branches are on the same set of logs.