### PR TITLE
Cherry pick: Fix random ui-components test failure (#216)

### DIFF
--- a/common/changes/@bentley/ui-components/ui-fix-test-failure_2020-11-11-17-52.json
+++ b/common/changes/@bentley/ui-components/ui-fix-test-failure_2020-11-11-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-core/ui-fix-test-failure_2020-11-11-17-52.json
+++ b/common/changes/@bentley/ui-core/ui-fix-test-failure_2020-11-11-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Clear FocusTrap timeout on unmount.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/ui/components/src/test/editors/EditorContainer.test.tsx
+++ b/ui/components/src/test/editors/EditorContainer.test.tsx
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { mount, shallow } from "enzyme";
 import * as React from "react";
 import sinon from "sinon";
-import { EditorContainer, PropertyUpdatedArgs } from "../../ui-components/editors/EditorContainer";
+import { EditorContainer } from "../../ui-components/editors/EditorContainer";
 import TestUtils from "../TestUtils";
 import { SpecialKey, StandardEditorNames } from "@bentley/ui-abstract";
 import { cleanup, fireEvent, render } from "@testing-library/react";
@@ -48,16 +48,13 @@ describe("<EditorContainer />", () => {
   it("calls onCommit for Enter", async () => {
     const propertyRecord = TestUtils.createPrimitiveStringProperty("Test1", "my value");
     const spyOnCommit = sinon.spy();
-    function handleCommit(_commit: PropertyUpdatedArgs): void {
-      spyOnCommit();
-    }
-    const wrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={handleCommit} onCancel={() => { }} />);
+    const wrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={spyOnCommit} onCancel={() => { }} />);
     const inputNode = wrapper.container.querySelector("input");
     expect(inputNode).not.to.be.null;
 
     fireEvent.keyDown(inputNode as HTMLElement, { key: SpecialKey.Enter });
     await TestUtils.flushAsyncOperations();
-    expect(spyOnCommit.calledOnce).to.be.true;
+    sinon.assert.calledOnce(spyOnCommit);
   });
 
   it("calls onCancel for Escape", async () => {
@@ -69,7 +66,7 @@ describe("<EditorContainer />", () => {
 
     fireEvent.keyDown(inputNode as HTMLElement, { key: SpecialKey.Escape });
     await TestUtils.flushAsyncOperations();
-    expect(spyOnCancel.calledOnce).to.be.true;
+    sinon.assert.calledOnce(spyOnCancel);
   });
 
   it("calls onCancel for Cancel button in popup", async () => {
@@ -87,32 +84,26 @@ describe("<EditorContainer />", () => {
     okButton.first().simulate("click");
     await TestUtils.flushAsyncOperations();
 
-    expect(spyOnCancel.calledOnce).to.be.true;
+    sinon.assert.calledOnce(spyOnCancel);
     wrapper.unmount();
   });
 
   it("calls onCommit for Tab", async () => {
     const propertyRecord = TestUtils.createPrimitiveStringProperty("Test1", "my value");
     const spyOnCommit = sinon.spy();
-    function handleCommit(_commit: PropertyUpdatedArgs): void {
-      spyOnCommit();
-    }
-    const wrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={handleCommit} onCancel={() => { }} />);
+    const wrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={spyOnCommit} onCancel={() => { }} />);
     const inputNode = wrapper.container.querySelector("input");
     expect(inputNode).not.to.be.null;
 
     fireEvent.keyDown(inputNode as HTMLElement, { key: SpecialKey.Tab });
     await TestUtils.flushAsyncOperations();
-    expect(spyOnCommit.calledOnce).to.be.true;
+
+    sinon.assert.calledOnce(spyOnCommit);
   });
 
   it("processes other input node events", () => {
     const propertyRecord = TestUtils.createPrimitiveStringProperty("Test1", "my value");
-    const spyOnCommit = sinon.spy();
-    function handleCommit(_commit: PropertyUpdatedArgs): void {
-      spyOnCommit();
-    }
-    const wrapper = mount(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={handleCommit} onCancel={() => { }} />);
+    const wrapper = mount(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={() => { }} onCancel={() => { }} />);
     const inputNode = wrapper.find("input");
     expect(inputNode.length).to.eq(1);
 
@@ -120,7 +111,7 @@ describe("<EditorContainer />", () => {
     inputNode.simulate("click");
     inputNode.simulate("contextMenu");
 
-    const renderedWrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={handleCommit} onCancel={() => { }} />);
+    const renderedWrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={() => { }} onCancel={() => { }} />);
     const renderedInputNode = renderedWrapper.container.querySelector("input");
     fireEvent.keyDown(renderedInputNode as HTMLElement, { key: SpecialKey.ArrowLeft });
     wrapper.unmount();

--- a/ui/core/src/ui-core/focustrap/FocusTrap.tsx
+++ b/ui/core/src/ui-core/focustrap/FocusTrap.tsx
@@ -18,7 +18,7 @@ function isFocusable(element: HTMLElement): boolean {
     return false;
 
   // istanbul ignore next
-  if (element.classList && element.classList.contains ("core-focus-trap-ignore-initial"))
+  if (element.classList && element.classList.contains("core-focus-trap-ignore-initial"))
     return false;
 
   if (element.tabIndex > 0 || (element.tabIndex === 0 && element.getAttribute("tabIndex") !== null)) {
@@ -148,6 +148,7 @@ export function FocusTrap(props: FocusTrapProps) {
   const initialFocusElement = React.useRef<Element | null>(null);
   const focusContainer = React.useRef<HTMLDivElement | null>(null);
   const isInitialMount = React.useRef(true);
+  const timeoutRef = React.useRef<number | undefined>();
 
   // Run on initial mount and when dependencies change. which could happen often.
   React.useEffect(() => {
@@ -162,7 +163,7 @@ export function FocusTrap(props: FocusTrapProps) {
         initialFocusElement.current = getInitialFocusElement(focusContainer.current, props.initialFocusElement);
         if (initialFocusElement.current) {
           // delay setting focus immediately because in some browsers other focus events happen when popup is initially opened.
-          setTimeout(() => {
+          timeoutRef.current = window.setTimeout(() => {
             attemptFocus((initialFocusElement.current as HTMLElement), true);
           }, 60);
         }
@@ -173,6 +174,7 @@ export function FocusTrap(props: FocusTrapProps) {
   // Return function to run only when FocusTrap is unmounted to restore focus
   React.useEffect(() => {
     return () => {
+      window.clearTimeout(timeoutRef.current);
       if (restoreFocusElement.current)
         (restoreFocusElement.current as HTMLElement).focus({ preventScroll: true });
     };


### PR DESCRIPTION
* Use sinon assertions for better failure logging.

* Clear FocusTrap timeout.

* Rush change.

Co-authored-by: Caleb Shafer <31107829+calebmshafer@users.noreply.github.com>
Co-authored-by: bsteinbk <65047615+bsteinbk@users.noreply.github.com>