### PR TITLE
Fix text z-fighting with background when log-Z is disabled

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-blanking-regions-for-non-logarithmic-depth_2020-11-24-13-39.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-blanking-regions-for-non-logarithmic-depth_2020-11-24-13-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix text z-fighting with background when logarithmic depth buffer is disabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}


### PR DESCRIPTION
In vertex shader we adjust `v_eyeSpace` to push it backward, which is fine for discard tests. But does nothing to address z-fighting if we are not writing depth in fragment shader. In that case, use `glPolygontOffset` to allow the depth test to fix the z-fighting.
Issue arose in OpenCities Planner because they disable the logarithmic depth buffer.