### PR TITLE
Fix text z-fighting with background when log Z is disabled

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-blanking-regions-for-non-logarithmic-depth_2020-11-24-13-39.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-blanking-regions-for-non-logarithmic-depth_2020-11-24-13-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix text z-fighting with background when logarithmic depth buffer is disabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}


### PR DESCRIPTION
Second attempt as [original PR](https://github.com/imodeljs/imodeljs/pull/302) appears to be hosed; cannot get it to recognize new build attempts after flaky integration test failure.