### PR TITLE
Presentation: Include actual primary class ids for related content fields

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1213,6 +1213,8 @@ export interface NavigationRuleBase extends RuleBase {
 // @public
 export class NestedContentField extends Field {
     constructor(category: CategoryDescription, name: string, label: string, description: TypeDescription, isReadonly: boolean, priority: number, contentClassInfo: ClassInfo, pathToPrimaryClass: RelationshipPath, nestedFields: Field[], editor?: EditorDescription, autoExpand?: boolean, renderer?: RendererDescription);
+    // @alpha (undocumented)
+    actualPrimaryClassIds: Id64String[];
     autoExpand?: boolean;
     // @alpha (undocumented)
     clone(): NestedContentField;
@@ -1232,6 +1234,8 @@ export class NestedContentField extends Field {
 
 // @public
 export interface NestedContentFieldJSON extends BaseFieldJSON {
+    // @alpha (undocumented)
+    actualPrimaryClassIds?: Id64String[];
     // (undocumented)
     autoExpand?: boolean;
     // (undocumented)

--- a/common/changes/@bentley/presentation-common/presentation-include-actual-primary-class-ids-for-nested-content-fields_2020-12-02-11-49.json
+++ b/common/changes/@bentley/presentation-common/presentation-include-actual-primary-class-ids-for-nested-content-fields_2020-12-02-11-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Include actual primary class ids for nested content fields",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/src/frontend/Content.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Content.test.ts
@@ -3,11 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { Guid, Id64 } from "@bentley/bentleyjs-core";
+import { Guid, Id64, Id64String } from "@bentley/bentleyjs-core";
 import { IModelConnection, SnapshotConnection } from "@bentley/imodeljs-frontend";
 import {
-  ContentSpecificationTypes, Descriptor, DisplayValueGroup, Field, FieldDescriptor, InstanceKey, KeySet, PresentationError, PresentationStatus,
-  RelationshipDirection, Ruleset, RuleTypes,
+  ContentSpecificationTypes, DefaultContentDisplayTypes, Descriptor, DisplayValueGroup, Field, FieldDescriptor, InstanceKey, KeySet,
+  NestedContentField, PresentationError, PresentationStatus, RelationshipDirection, Ruleset, RuleTypes,
 } from "@bentley/presentation-common";
 import { Presentation } from "@bentley/presentation-frontend";
 import { initialize, terminate } from "../IntegrationTests";
@@ -351,6 +351,273 @@ describe("Content", () => {
 
   });
 
+  describe("Class descriptor", () => {
+
+    it("creates base class descriptor usable for subclasses", async () => {
+      const classHierarchy = await ECClassHierarchy.create(imodel);
+      const createRuleset = (schemaName: string, className: string): Ruleset => ({
+        id: Guid.createValue(),
+        rules: [{
+          ruleType: RuleTypes.Content,
+          specifications: [{
+            specType: ContentSpecificationTypes.ContentInstancesOfSpecificClasses,
+            classes: {
+              schemaName,
+              classNames: [className],
+            },
+            handleInstancesPolymorphically: true,
+            handlePropertiesPolymorphically: true,
+          }],
+        }],
+      });
+
+      const descriptorGeometricElement = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: createRuleset("BisCore", "GeometricElement"),
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet(),
+      });
+      const allExpectedGeometricElementProperties = [
+        "<0",
+        "<100",
+        "<Infinity",
+        "0-100",
+        "0-1000",
+        "0-Infinity",
+        "Category",
+        "Code",
+        "Color",
+        "Country",
+        "Model",
+        "Movies",
+        "Negative Numbers",
+        "Special Characters",
+        "Sports Stars",
+        "Star Wars",
+        "True-False",
+        "True-False #2",
+        "User Label",
+        [
+          "Btu/(lbm·Δ°R) [btu per pound mass per delta degree rankine]",
+        ],
+        [
+          "Btu/lb [Btu per pound mass]",
+        ],
+        [
+          "cSt",
+          "ft2 s",
+        ],
+        [
+          "Acres",
+          "cm2",
+          "ft ft",
+          "ft mi",
+          "ft2",
+          "ha",
+          "in ft",
+          "in m",
+          "in mi",
+          "in2",
+          "km2",
+          "m km",
+          "m m",
+          "m2",
+          "mi2",
+          "mm km",
+          "thousand ft2",
+        ],
+        [
+          "ft^(1/3)/s [ft^(1/3)/s]",
+        ],
+        [
+          "$ [dollar]",
+        ],
+        [
+          "KA [kiloampere]",
+        ],
+        [
+          "email",
+          "full URL",
+          "mailto",
+          "without http",
+          "without www",
+        ],
+        [
+          "in/deg [inch per degree]",
+        ],
+        [
+          "ft³/(ft²·min) [Foot cubed per foot squared per minute]",
+        ],
+        [
+          "1/Bar [1/Bar]",
+          "Untitled",
+        ],
+        [
+          "mm⁶ [millimeter to the sixth]",
+        ],
+        [
+          "µin [microinch]",
+        ],
+        [
+          "lb/ft [pound per foot]",
+        ],
+        [
+          "lm/ft² [lumen per foot squared]",
+        ],
+        [
+          "lm [lumen]",
+        ],
+        [
+          "KV [kilovolt]",
+        ],
+        [
+          "N·m/deg [newton meter per degree]",
+        ],
+        [
+          "Btu/(lb-mol·Δ°R) [btu per pound mole per delta degree rankine]",
+        ],
+        [
+          "(in·lbf)/(s·in·°F) [inch pound force per second inch fahrenheit]",
+        ],
+        [
+          "lbf/in [pound force per inch]",
+        ],
+        [
+          "µg/L [micrograms per liter]",
+        ],
+        [
+          "lbf·ft² [pound force foot squared]",
+        ],
+        [
+          "µg [microgram]",
+        ],
+        [
+          "ft³/lb-mol [foot cubed per pound mole]",
+        ],
+        [
+          "kmol/s [kilomole per second]",
+        ],
+        [
+          "lb-mol/ft³ [pound mole per foot cubed]",
+        ],
+        [
+          "cycle/sec [cycle per second]",
+        ],
+        [
+          "quadrants [quadrants]",
+        ],
+        [
+          "ft⁴ [foot to the fourth]",
+        ],
+        [
+          "p/ft² [person per foot squared]",
+        ],
+        [
+          "1/mile [1/mile]",
+        ],
+        [
+          "1/tn(short) [one per short ton]",
+        ],
+        [
+          "1/Δ°R [reciprocal delta degree rankine]",
+        ],
+        [
+          "grf/(h·ft²·inHg) [Grain mass per hour per foot squared per inch Mercury conventional]",
+        ],
+        [
+          "1/ million gal",
+        ],
+        [
+          "ft^(1/2)/s [ft^(1/2)/s]",
+        ],
+        [
+          "Gallon per minute per square root pounds per inch squared",
+        ],
+        [
+          "delta degree Kelvin per meter",
+        ],
+        [
+          "Delta celsius",
+        ],
+        [
+          "one per kilowat",
+        ],
+        [
+          "foot squared hour delta degree Fahrenheit per Btu",
+        ],
+        [
+          "kg/kW h",
+        ],
+        [
+          "1/Btu",
+        ],
+        [
+          "days",
+        ],
+        [
+          "ft3/lm",
+        ],
+        [
+          "acre ft/day",
+          "acre ft/h",
+          "acre ft/min",
+          "acre in/h",
+          "acre in/min",
+          "ft3/day",
+          "ft3/min",
+          "ft3/s",
+          "gal(imp)/day",
+          "gal(imp)/s",
+          "gal/s",
+          "gpd/capita",
+          "L/min",
+          "m3/min",
+          "million gal(impl)/day",
+          "ML/day",
+        ],
+        [
+          "thousand gal",
+        ],
+        [
+          "Angle",
+          "Area",
+          "Distance",
+          "Volume",
+        ],
+        [
+          "$óúrçè Fílê Ñâmé",
+          "$óúrçè Fílê Páth",
+        ],
+      ];
+      expect(getFieldLabels(descriptorGeometricElement!)).to.deep.eq(allExpectedGeometricElementProperties);
+
+      // sanity check - ensure filtering the fields by the class we used for request doesn't filter out anything
+      const fieldsGeometricElement = filterFieldsByClass(descriptorGeometricElement!.fields, await classHierarchy.getClassInfo("BisCore", "GeometricElement"));
+      expect(getFieldLabels(fieldsGeometricElement)).to.deep.eq(allExpectedGeometricElementProperties);
+
+      // request properties of Generic.PhysicalObject and ensure it's matches our filtered result of `descriptorGeometricElement`
+      const descriptorPhysicalObject = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: createRuleset("Generic", "PhysicalObject"),
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet(),
+      });
+      const fieldsPhysicalObject = filterFieldsByClass(descriptorGeometricElement!.fields, await classHierarchy.getClassInfo("Generic", "PhysicalObject"));
+      expect(getFieldLabels(fieldsPhysicalObject)).to.deep.eq(getFieldLabels(descriptorPhysicalObject!));
+
+      // request properties of PCJ_TestSchema.TestClass and ensure it's matches our filtered result of `descriptorGeometricElement`
+      const descriptorTestClass = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: createRuleset("PCJ_TestSchema", "TestClass"),
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet(),
+      });
+      const fieldsTestClass = filterFieldsByClass(descriptorGeometricElement!.fields, await classHierarchy.getClassInfo("PCJ_TestSchema", "TestClass"));
+      expect(getFieldLabels(fieldsTestClass)).to.deep.eq(getFieldLabels(descriptorTestClass!));
+    });
+
+  });
+
   describe("when request in the backend exceeds the backend timeout time", () => {
 
     let raceStub: sinon.SinonStub<[Iterable<unknown>], Promise<unknown>>;
@@ -392,6 +659,132 @@ describe("Content", () => {
   });
 
 });
+
+type FieldLabels = Array<string | FieldLabels>;
+function getFieldLabels(fields: Descriptor | Field[]): FieldLabels {
+  if (fields instanceof Descriptor)
+    fields = fields.fields;
+
+  return fields.map((f) => {
+    if (f.isNestedContentField())
+      return getFieldLabels(f.nestedFields);
+    return f.label;
+  }).sort((lhs, rhs) => {
+    if (typeof lhs === "string" && typeof rhs === "string")
+      return lhs.localeCompare(rhs);
+    if (typeof lhs === "string")
+      return -1;
+    if (typeof rhs === "string")
+      return 1;
+    return 0;
+  });
+}
+
+interface ECClassInfo {
+  id: Id64String;
+  baseClassIds: Id64String[];
+  derivedClassIds: Id64String[];
+}
+
+function cloneFilteredNestedContentField(field: NestedContentField, filterClassInfo: ECClassInfo) {
+  const clone = field.clone();
+  clone.nestedFields = filterNestedContentFieldsByClass(clone.nestedFields, filterClassInfo);
+  return clone;
+}
+function filterNestedContentFieldsByClass(fields: Field[], classInfo: ECClassInfo) {
+  let filteredFields = new Array<Field>();
+  fields.forEach((f) => {
+    if (f.isNestedContentField() && f.actualPrimaryClassIds.some((id) => classInfo.id === id || classInfo.derivedClassIds.includes(id))) {
+      const clone = cloneFilteredNestedContentField(f, classInfo);
+      if (clone.nestedFields.length > 0)
+        filteredFields.push(clone);
+    } else {
+      filteredFields.push(f);
+    }
+  });
+  return filteredFields;
+}
+function filterFieldsByClass(fields: Field[], classInfo: ECClassInfo) {
+  let filteredFields = new Array<Field>();
+  fields.forEach((f) => {
+    if (f.isNestedContentField()) {
+      // always include nested content field if its `actualPrimaryClassIds` contains either id of given class itself or one of its derived class ids
+      // note: nested content fields might have more nested fields inside them and these deeply nested fields might not apply for given class - for
+      // that we need to clone the field and pick only property fields and nested fields that apply.
+      const appliesForGivenClass = f.actualPrimaryClassIds.some((id) => classInfo.id === id || classInfo.derivedClassIds.includes(id));
+      if (appliesForGivenClass) {
+        const clone = cloneFilteredNestedContentField(f, classInfo);
+        if (clone.nestedFields.length > 0)
+          filteredFields.push(clone);
+      }
+    } else if (f.isPropertiesField()) {
+      // always include the field is at least one property in the field belongs to either base or derived class of given class
+      const appliesForGivenClass = f.properties.some((p) => {
+        const propertyClassId = p.property.classInfo.id;
+        return propertyClassId === classInfo.id
+          || classInfo.baseClassIds.includes(propertyClassId)
+          || classInfo.derivedClassIds.includes(propertyClassId);
+      });
+      if (appliesForGivenClass)
+        filteredFields.push(f);
+    } else {
+      filteredFields.push(f);
+    }
+  });
+  return filteredFields;
+}
+
+class ECClassHierarchy {
+  private constructor(private _imodel: IModelConnection, private _baseClasses: Map<Id64String, Id64String[]>, private _derivedClasses: Map<Id64String, Id64String[]>) {
+  }
+  public static async create(imodel: IModelConnection) {
+    const baseClassHierarchy = new Map();
+    const derivedClassHierarchy = new Map();
+
+    const query = "SELECT SourceECInstanceId AS ClassId, TargetECInstanceId AS BaseClassId FROM meta.ClassHasBaseClasses";
+    for await (const row of imodel.query(query)) {
+      const { classId, baseClassId } = row;
+
+      const baseClasses = baseClassHierarchy.get(classId);
+      if (baseClasses)
+        baseClasses.push(baseClassId);
+      else
+        baseClassHierarchy.set(classId, [baseClassId]);
+
+      const derivedClasses = derivedClassHierarchy.get(baseClassId);
+      if (derivedClasses)
+        derivedClasses.push(classId);
+      else
+        derivedClassHierarchy.set(baseClassId, [classId]);
+    }
+
+    return new ECClassHierarchy(imodel, baseClassHierarchy, derivedClassHierarchy);
+  }
+  private getAllBaseClassIds(classId: Id64String) {
+    const baseClassIds = this._baseClasses!.get(classId) ?? [];
+    return baseClassIds.reduce<Id64String[]>((arr, id) => {
+      arr.push(id, ...this.getAllBaseClassIds(id));
+      return arr;
+    }, []);
+  }
+  private getAllDerivedClassIds(baseClassId: Id64String) {
+    const derivedClassIds = this._derivedClasses!.get(baseClassId) ?? [];
+    return derivedClassIds.reduce<Id64String[]>((arr, id) => {
+      arr.push(id, ...this.getAllDerivedClassIds(id));
+      return arr;
+    }, []);
+  }
+  public async getClassInfo(schemaName: string, className: string) {
+    const classQuery = `SELECT c.ECInstanceId FROM meta.ECClassDef c JOIN meta.ECSchemaDef s ON s.ECInstanceId = c.Schema.Id WHERE c.Name = ? AND s.Name = ?`;
+    const result = await this._imodel.queryRows(classQuery, [className, schemaName]);
+    const { id } = result.rows[0];
+    return {
+      id,
+      baseClassIds: this.getAllBaseClassIds(id),
+      derivedClassIds: this.getAllDerivedClassIds(id),
+    };
+  }
+}
 
 function findFieldByLabel(fields: Field[], label: string, allFields?: Field[]): Field | undefined {
   const isTopLevel = (undefined === allFields);

--- a/presentation/backend/src/test/PresentationManager.test.snap
+++ b/presentation/backend/src/test/PresentationManager.test.snap
@@ -863,6 +863,7 @@ Object {
       },
     },
     Object {
+      "actualPrimaryClassIds": Array [],
       "autoExpand": true,
       "category": Object {
         "description": "Voluptates minima eos recusandae temporibus laboriosam est at.",
@@ -1208,6 +1209,7 @@ Object {
       },
     },
     Object {
+      "actualPrimaryClassIds": Array [],
       "autoExpand": false,
       "category": Object {
         "description": "Est ipsum eveniet eius quis expedita cum.",

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -137,7 +137,7 @@ export class PresentationRpcInterface extends RpcInterface {
   public static readonly interfaceName = "PresentationRpcInterface"; // eslint-disable-line @typescript-eslint/naming-convention
 
   /** The semantic version of the interface. */
-  public static interfaceVersion = "2.6.0";
+  public static interfaceVersion = "2.6.1";
 
   /*===========================================================================================
     NOTE: Any add/remove/change to the methods below requires an update of the interface version.

--- a/presentation/common/src/presentation-common/content/Fields.ts
+++ b/presentation/common/src/presentation-common/content/Fields.ts
@@ -6,6 +6,7 @@
  * @module Content
  */
 
+import { Id64String } from "@bentley/bentleyjs-core";
 import { ClassInfo, ClassInfoJSON, RelatedClassInfo, RelationshipPath, RelationshipPathJSON, StrippedRelationshipPath } from "../EC";
 import { PresentationError, PresentationStatus } from "../Error";
 import { CategoryDescription, CategoryDescriptionJSON } from "./Category";
@@ -44,6 +45,8 @@ export interface PropertiesFieldJSON extends BaseFieldJSON {
 export interface NestedContentFieldJSON extends BaseFieldJSON {
   contentClassInfo: ClassInfoJSON;
   pathToPrimaryClass: RelationshipPathJSON;
+  /** @alpha */
+  actualPrimaryClassIds?: Id64String[];
   autoExpand?: boolean;
   nestedFields: FieldJSON[];
 }
@@ -344,6 +347,8 @@ export class NestedContentField extends Field {
   public contentClassInfo: ClassInfo;
   /** Relationship path to [Primary class]($docs/learning/presentation/Content/Terminology#primary-class) */
   public pathToPrimaryClass: RelationshipPath;
+  /** @alpha */
+  public actualPrimaryClassIds: Id64String[];
   /** Contained nested fields */
   public nestedFields: Field[];
   /** Flag specifying whether field should be expanded */
@@ -383,6 +388,7 @@ export class NestedContentField extends Field {
     this.pathToPrimaryClass = pathToPrimaryClass;
     this.nestedFields = nestedFields;
     this.autoExpand = autoExpand;
+    this.actualPrimaryClassIds = [];
   }
 
   /** @alpha */
@@ -401,6 +407,7 @@ export class NestedContentField extends Field {
       this.autoExpand,
       this.renderer,
     );
+    clone.actualPrimaryClassIds = this.actualPrimaryClassIds;
     clone.rebuildParentship(this.parent);
     return clone;
   }
@@ -420,6 +427,7 @@ export class NestedContentField extends Field {
       ...super.toJSON(),
       contentClassInfo: this.contentClassInfo,
       pathToPrimaryClass: this.pathToPrimaryClass,
+      actualPrimaryClassIds: this.actualPrimaryClassIds,
       nestedFields: this.nestedFields.map((field: Field) => field.toJSON()),
       autoExpand: this.autoExpand,
     };
@@ -446,6 +454,7 @@ export class NestedContentField extends Field {
         .filter((nestedField): nestedField is Field => !!nestedField),
       contentClassInfo: ClassInfo.fromJSON(json.contentClassInfo),
       pathToPrimaryClass: json.pathToPrimaryClass.map(RelatedClassInfo.fromJSON),
+      actualPrimaryClassIds: json.actualPrimaryClassIds ?? [],
       autoExpand: json.autoExpand,
     });
   }

--- a/presentation/common/src/test/_helpers/random/Content.ts
+++ b/presentation/common/src/test/_helpers/random/Content.ts
@@ -98,6 +98,7 @@ export const createRandomNestedFieldJSON = (category?: CategoryDescriptionJSON |
   } as StructTypeDescription,
   contentClassInfo: createRandomECClassInfoJSON(),
   pathToPrimaryClass: createRandomRelationshipPathJSON(),
+  actualPrimaryClassIds: faker.random.boolean() ? undefined : [],
   nestedFields: [createRandomPrimitiveFieldJSON(category)],
   autoExpand: faker.random.boolean(),
 });

--- a/presentation/common/src/test/content/Descriptor.test.snap
+++ b/presentation/common/src/test/content/Descriptor.test.snap
@@ -88,7 +88,8 @@ Object {
       },
     },
     Object {
-      "autoExpand": true,
+      "actualPrimaryClassIds": Array [],
+      "autoExpand": false,
       "category": Object {
         "description": "Deserunt blanditiis rerum.",
         "expand": true,
@@ -117,17 +118,17 @@ Object {
             "priority": 35900,
           },
           "editor": Object {
-            "name": "Response",
+            "name": "Frozen",
           },
           "isReadonly": true,
-          "label": "Ball networks",
-          "name": "Buckinghamshire",
-          "priority": 6880,
+          "label": "Inverse",
+          "name": "sensor",
+          "priority": 81188,
           "renderer": Object {
             "name": "custom_renderer",
           },
           "type": Object {
-            "typeName": "geometry",
+            "typeName": "binary",
             "valueFormat": "Primitive",
           },
         },
@@ -485,10 +486,10 @@ exports[`Descriptor fromJSON creates valid Descriptor from valid JSON without ca
 Object {
   "categories": Array [
     Object {
-      "description": "Illum voluptas totam repellat rerum iste omnis qui dolores doloremque.",
+      "description": "Voluptas totam repellat rerum iste omnis qui dolores doloremque.",
       "expand": false,
-      "label": "Handmade synergies",
-      "name": "monitor",
+      "label": "scalable index Automotive",
+      "name": "Producer",
       "parent": undefined,
       "priority": 76873,
     },
@@ -532,10 +533,10 @@ Object {
   "fields": Array [
     Object {
       "category": Object {
-        "description": "Illum voluptas totam repellat rerum iste omnis qui dolores doloremque.",
+        "description": "Voluptas totam repellat rerum iste omnis qui dolores doloremque.",
         "expand": false,
-        "label": "Handmade synergies",
-        "name": "monitor",
+        "label": "scalable index Automotive",
+        "name": "Producer",
         "parent": undefined,
         "priority": 76873,
       },
@@ -597,6 +598,7 @@ Object {
       },
     },
     Object {
+      "actualPrimaryClassIds": Array [],
       "autoExpand": true,
       "category": Object {
         "description": "Quia et perferendis est distinctio dicta autem aut.",
@@ -625,16 +627,18 @@ Object {
             "parent": undefined,
             "priority": 44488,
           },
-          "editor": undefined,
-          "isReadonly": true,
-          "label": "Robust Gorgeous synergy",
-          "name": "auxiliary",
-          "priority": 20037,
+          "editor": Object {
+            "name": "microchip",
+          },
+          "isReadonly": false,
+          "label": "primary",
+          "name": "Jewelery",
+          "priority": 92023,
           "renderer": Object {
             "name": "custom_renderer",
           },
           "type": Object {
-            "typeName": "mediumint",
+            "typeName": "time",
             "valueFormat": "Primitive",
           },
         },
@@ -1074,7 +1078,8 @@ Object {
       },
     },
     Object {
-      "autoExpand": true,
+      "actualPrimaryClassIds": Array [],
+      "autoExpand": false,
       "category": Object {
         "description": "Aspernatur ex quia.",
         "expand": true,
@@ -1104,16 +1109,18 @@ Object {
             "parent": undefined,
             "priority": 22923,
           },
-          "editor": undefined,
+          "editor": Object {
+            "name": "Digitized",
+          },
           "isReadonly": true,
-          "label": "robust Licensed",
-          "name": "Lodge",
-          "priority": 81713,
+          "label": "Ergonomic Soft Chicken SAS",
+          "name": "Path",
+          "priority": 61491,
           "renderer": Object {
             "name": "custom_renderer",
           },
           "type": Object {
-            "typeName": "boolean",
+            "typeName": "serial",
             "valueFormat": "Primitive",
           },
         },

--- a/presentation/common/src/test/content/Fields.test.snap
+++ b/presentation/common/src/test/content/Fields.test.snap
@@ -28,12 +28,12 @@ Object {
 exports[`Field fromJSON creates valid Field from valid JSON with categories 1`] = `
 Object {
   "category": Object {
-    "description": "Exercitationem voluptatum beatae minus molestiae iusto.",
-    "expand": true,
-    "label": "virtual",
-    "name": "Music",
+    "description": "Nihil ut soluta et dolores modi aliquam consequuntur dolorem doloremque.",
+    "expand": false,
+    "label": "Handmade Division",
+    "name": "empower",
     "parent": undefined,
-    "priority": 99622,
+    "priority": 97563,
   },
   "editor": undefined,
   "isReadonly": true,
@@ -79,6 +79,7 @@ Object {
 
 exports[`Field fromJSON creates valid NestedContentField from valid JSON 1`] = `
 Object {
+  "actualPrimaryClassIds": Array [],
   "autoExpand": true,
   "category": Object {
     "description": "Tempora consequuntur quam eveniet distinctio quos labore corporis neque distinctio.",
@@ -100,18 +101,18 @@ Object {
   "nestedFields": Array [
     Object {
       "category": Object {
-        "description": "Dicta rerum nisi quos et recusandae quia.",
-        "expand": true,
-        "label": "Borders transition salmon",
-        "name": "Plains",
+        "description": "Et dicta rerum nisi quos et recusandae.",
+        "expand": false,
+        "label": "Maryland CSS",
+        "name": "Personal Loan Account",
         "parent": undefined,
-        "priority": 15985,
+        "priority": 17378,
       },
       "editor": undefined,
       "isReadonly": false,
-      "label": "Total middleware parse",
-      "name": "back-end",
-      "priority": 50694,
+      "label": "program",
+      "name": "neural",
+      "priority": 61605,
       "renderer": Object {
         "name": "custom_renderer",
       },
@@ -227,6 +228,7 @@ Object {
 
 exports[`NestedContentField fromJSON creates valid NestedContentField from valid JSON 1`] = `
 Object {
+  "actualPrimaryClassIds": Array [],
   "autoExpand": true,
   "category": Object {
     "description": "Est fugit nisi occaecati ea eos maiores distinctio.",
@@ -250,10 +252,10 @@ Object {
   "nestedFields": Array [
     Object {
       "category": Object {
-        "description": "Omnis rerum perferendis optio voluptatibus maiores.",
+        "description": "Optio voluptatibus maiores.",
         "expand": true,
-        "label": "COM Producer",
-        "name": "Personal Loan Account",
+        "label": "Wisconsin interface calculate",
+        "name": "Designer",
         "parent": undefined,
         "priority": 3086,
       },
@@ -336,110 +338,109 @@ Object {
 
 exports[`NestedContentField fromJSON creates valid NestedContentField from valid JSON with categories 1`] = `
 Object {
+  "actualPrimaryClassIds": Array [],
   "autoExpand": true,
   "category": Object {
-    "description": "Sequi tempore consequuntur hic et repellat veritatis soluta.",
+    "description": "Quaerat omnis delectus porro.",
     "expand": true,
-    "label": "Vietnam",
-    "name": "program",
+    "label": "Gloves wireless input",
+    "name": "Netherlands",
     "parent": undefined,
-    "priority": 4276,
+    "priority": 15292,
   },
   "contentClassInfo": Object {
-    "id": "0x4e7b000000ae07",
-    "label": "navigating",
-    "name": "International",
+    "id": "0xaf930000002175",
+    "label": "optical Rustic Metal Chicken",
+    "name": "Steel",
   },
-  "editor": Object {
-    "name": "Crossing",
-  },
+  "editor": undefined,
   "isReadonly": false,
-  "label": "1080p Towels",
-  "name": "Argentina",
+  "label": "Associate",
+  "name": "Frozen",
   "nestedFields": Array [
     Object {
       "category": Object {
-        "description": "Sequi tempore consequuntur hic et repellat veritatis soluta.",
+        "description": "Quaerat omnis delectus porro.",
         "expand": true,
-        "label": "Vietnam",
-        "name": "program",
+        "label": "Gloves wireless input",
+        "name": "Netherlands",
         "parent": undefined,
-        "priority": 4276,
+        "priority": 15292,
       },
       "editor": Object {
-        "name": "Borders",
+        "name": "Marketing",
       },
-      "isReadonly": false,
-      "label": "Product multi-tasking Refined Metal Car",
-      "name": "parse",
-      "priority": 76738,
+      "isReadonly": true,
+      "label": "Avon PNG",
+      "name": "connecting",
+      "priority": 77864,
       "renderer": Object {
         "name": "custom_renderer",
       },
       "type": Object {
-        "typeName": "tinyint",
+        "typeName": "set",
         "valueFormat": "Primitive",
       },
     },
   ],
   "pathToPrimaryClass": Array [
     Object {
-      "isForwardRelationship": false,
+      "isForwardRelationship": true,
       "isPolymorphicRelationship": false,
       "isPolymorphicTargetClass": true,
       "relationshipInfo": Object {
-        "id": "0x171d2000000c72a",
-        "label": "forecast cyan",
-        "name": "dynamic",
+        "id": "0x152e0000000860a",
+        "label": "Implemented",
+        "name": "application",
       },
       "sourceClassInfo": Object {
-        "id": "0x2c13000000d9f5",
-        "label": "Sao Tome and Principe Dynamic primary",
-        "name": "hacking",
+        "id": "0xae07000000c095",
+        "label": "Bacon architectures Fresh",
+        "name": "azure",
       },
       "targetClassInfo": Object {
-        "id": "0x16c82000000a1ea",
-        "label": "user-centric application Gorgeous",
-        "name": "Georgia",
+        "id": "0x16476000000376c",
+        "label": "Manat Practical Intranet",
+        "name": "Sao Tome and Principe",
       },
     },
     Object {
       "isForwardRelationship": true,
-      "isPolymorphicRelationship": false,
+      "isPolymorphicRelationship": true,
       "isPolymorphicTargetClass": false,
       "relationshipInfo": Object {
-        "id": "0x1db8000000ca36",
-        "label": "PNG lavender Fish",
-        "name": "PNG",
+        "id": "0xc9cf0000010bc6",
+        "label": "Future sensor",
+        "name": "Small Metal Mouse",
       },
       "sourceClassInfo": Object {
-        "id": "0x36fb000000d839",
-        "label": "Denar Small Metal Mouse Personal Loan Account",
-        "name": "El Salvador Colon US Dollar",
+        "id": "0x900b00000171d2",
+        "label": "sticky",
+        "name": "incubate",
       },
       "targetClassInfo": Object {
-        "id": "0x1199f0000005966",
-        "label": "auxiliary connecting",
-        "name": "Shore",
+        "id": "0x37f9000001569a",
+        "label": "El Salvador Colon US Dollar",
+        "name": "Customer",
       },
     },
   ],
-  "priority": 81712,
+  "priority": 64071,
   "renderer": Object {
     "name": "custom_renderer",
   },
   "type": Object {
     "members": Array [
       Object {
-        "label": "Libyan Dinar",
-        "name": "Metal",
+        "label": "Soft",
+        "name": "Virginia",
         "type": Object {
-          "typeName": "varchar",
+          "typeName": "datetime",
           "valueFormat": "Primitive",
         },
       },
     ],
-    "typeName": "Sleek Soft Salad",
+    "typeName": "Sleek Soft Fish",
     "valueFormat": "Struct",
   },
 }
@@ -447,6 +448,7 @@ Object {
 
 exports[`NestedContentField fromJSON creates valid NestedContentField from valid serialized JSON 1`] = `
 Object {
+  "actualPrimaryClassIds": Array [],
   "autoExpand": true,
   "category": Object {
     "description": "Et rerum saepe odio quidem incidunt blanditiis.",
@@ -470,10 +472,10 @@ Object {
   "nestedFields": Array [
     Object {
       "category": Object {
-        "description": "Et soluta fuga sint enim voluptatem consequatur quis ipsam.",
+        "description": "Soluta fuga sint enim voluptatem consequatur quis ipsam.",
         "expand": false,
-        "label": "Shoes e-business Applications",
-        "name": "Armenia",
+        "label": "Chief Street",
+        "name": "Handmade Steel Fish",
         "parent": undefined,
         "priority": 68447,
       },
@@ -596,12 +598,12 @@ Object {
 exports[`PropertiesField fromJSON creates valid PropertiesField from valid JSON with categories 1`] = `
 Object {
   "category": Object {
-    "description": "Architecto mollitia in natus nostrum deserunt rerum sapiente nihil impedit.",
+    "description": "Et architecto mollitia in natus nostrum.",
     "expand": true,
-    "label": "Ergonomic Granite Mouse redundant",
-    "name": "Kentucky",
+    "label": "Sleek Concrete Cheese",
+    "name": "hardware",
     "parent": undefined,
-    "priority": 86204,
+    "priority": 59125,
   },
   "editor": Object {
     "name": "Massachusetts",


### PR DESCRIPTION
The descriptor now tells what actual source classes the related content fields are related to. This allows requesting descriptor for a base class and then determine properties for any of its base classes without having to request another descriptor.

In the future we might want to provide some utilities similar to what's in the added test.

Addon PR: 130264