### PR TITLE
Fix package publishing trigger

### DIFF
--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -56,5 +56,5 @@ jobs:
       parameters:
         NodeVersion: ${{ parameters.nodeVersion }}
     # The publish script identifies any new packages not previously published and tags the build
-    - ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT')) }}:
+    - ${{ if eq(variables['Agent.OS'], 'Windows_NT')) }}:
       - template: ../templates/publish.yaml

--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -56,5 +56,4 @@ jobs:
       parameters:
         NodeVersion: ${{ parameters.nodeVersion }}
     # The publish script identifies any new packages not previously published and tags the build
-    - ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
-      - template: ../templates/publish.yaml
+    - template: ../templates/publish.yaml

--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -56,5 +56,5 @@ jobs:
       parameters:
         NodeVersion: ${{ parameters.nodeVersion }}
     # The publish script identifies any new packages not previously published and tags the build
-    - ${{ if eq(variables['Agent.OS'], 'Windows_NT')) }}:
+    - ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
       - template: ../templates/publish.yaml

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -7,6 +7,8 @@ steps:
 - script: node common/scripts/install-run-rush.js publish --publish --pack --include-all
   displayName: rush publish pack
   workingDirectory: ${{ parameters.workingDir }}
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+
 
 - task: PythonScript@0
   displayName: Gather packages for release
@@ -113,9 +115,13 @@ steps:
        print ("All packages are up-to-date.")
 
     arguments: '$(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory) $(Build.SourceBranch)'
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: packages'
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/imodeljs/packages'
     ArtifactName: packages
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+


### PR DESCRIPTION
The conditional insertion is not working as intended so switching it to use a different set of conditions.  Introduced the regression in #251 that has lead to nightly releases to not be correctly published...