### PR TITLE
Allow all PopupProps to be passed in to FooterPopup

### DIFF
--- a/common/api/ui-ninezone.api.md
+++ b/common/api/ui-ninezone.api.md
@@ -12,6 +12,7 @@ import { Omit } from '@bentley/ui-core';
 import { OmitChildrenProp } from '@bentley/ui-core';
 import { Point } from '@bentley/ui-core';
 import { PointProps } from '@bentley/ui-core';
+import { PopupProps } from '@bentley/ui-core';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { Rectangle } from '@bentley/ui-core';
@@ -657,14 +658,8 @@ export enum FooterPopupContentType {
 export type FooterPopupDefaultProps = Pick<FooterPopupProps, "contentType">;
 
 // @beta
-export interface FooterPopupProps extends CommonProps {
-    children?: React.ReactNode;
+export interface FooterPopupProps extends Partial<PopupProps> {
     contentType: FooterPopupContentType;
-    isOpen?: boolean;
-    isPinned?: boolean;
-    onClose?: () => void;
-    onOutsideClick?: (e: MouseEvent) => void;
-    target?: HTMLElement | null;
 }
 
 // @beta

--- a/common/changes/@bentley/ui-ninezone/ui-footer-popup-props_2020-12-09-11-00.json
+++ b/common/changes/@bentley/ui-ninezone/ui-footer-popup-props_2020-12-09-11-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-ninezone",
+      "comment": "Allow all PopupProps to be passed in to FooterPopup.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-ninezone",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/ui/ninezone/src/ui-ninezone/footer/Popup.tsx
+++ b/ui/ninezone/src/ui-ninezone/footer/Popup.tsx
@@ -10,7 +10,7 @@ import "./Popup.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { RelativePosition } from "@bentley/ui-abstract";
-import { CommonProps, Popup } from "@bentley/ui-core";
+import { Popup, PopupProps } from "@bentley/ui-core";
 
 /** Available footer popup content types.
  * @beta
@@ -25,21 +25,9 @@ export enum FooterPopupContentType {
 /** Properties of [[FooterPopup]] component.
  * @beta
  */
-export interface FooterPopupProps extends CommonProps {
-  /** Popup content. */
-  children?: React.ReactNode;
-  /** Describes content type. */
+export interface FooterPopupProps extends Partial<PopupProps> {
+  /** Describes content type. Defaults to [[FooterPopupContentType.Dialog]]. */
   contentType: FooterPopupContentType;
-  /** Indicates if the popup is open. */
-  isOpen?: boolean;
-  /** Function called when the popup is closed. */
-  onClose?: () => void;
-  /** Function called when user clicks outside of the popup.  */
-  onOutsideClick?: (e: MouseEvent) => void;
-  /** Popup target. */
-  target?: HTMLElement | null;
-  /** Indicates if the popup is pinned. */
-  isPinned?: boolean;
 }
 
 /** Default properties of [[FooterPopup]] component.
@@ -68,9 +56,7 @@ export class FooterPopup extends React.PureComponent<FooterPopupProps> {
         showArrow
         showShadow={false}
         {...props}
-      >
-        {this.props.children}
-      </Popup>
+      />
     );
   }
 }


### PR DESCRIPTION
This PR exposes all `Popup` props in a `FooterPopup` component allowing advanced `FooterPopup` configuration.

Related to #199