### PR TITLE
Return the same promise for subsequent loads.

### DIFF
--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -330,7 +330,7 @@ describe("Custom FormatterSpecs", () => {
   });
 
   it("QuantityFormatter should register properly", async () => {
-    assert.isFalse(quantityFormatter.useImperialFormats);
+    assert.isTrue(quantityFormatter.useImperialFormats);
 
     const customFormatterParserSpecsProvider: FormatterParserSpecsProvider = {
       quantityTypeName: "DummyQuantity",


### PR DESCRIPTION
Keep a member variable for the different promises when loading FormatterSpec or ParserSpec. This will prevent subsequent calls to "load" to issue more than one promise.