### PR TITLE
InspectElementTool optionally copies to clipboard.

### DIFF
--- a/common/changes/@bentley/frontend-devtools/inspect-element-copy-to-clipboard_2020-12-10-19-17.json
+++ b/common/changes/@bentley/frontend-devtools/inspect-element-copy-to-clipboard_2020-12-10-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-devtools",
+      "comment": "InspectElementTool optionally copies output to clipboard.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-devtools",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend-devtools/src/tools/InspectElementTool.ts
+++ b/core/frontend-devtools/src/tools/InspectElementTool.ts
@@ -210,6 +210,10 @@ export class InspectElementTool extends PrimitiveTool {
     if (undefined !== modal)
       this._modal = modal;
 
+    const doCopy = args.getBoolean("c");
+    if (undefined !== doCopy)
+      this._doCopy = doCopy;
+
     return this.run();
   }
 }


### PR DESCRIPTION
We already had a "copy" argument but we never hooked it up. Very annoying when output is verbose and you want to copy-paste it elsewhere.