### PR TITLE
Fix hilite silhouette ignoring line weight override

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-polyline-hilite_2020-12-10-22-06.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-polyline-hilite_2020-12-10-22-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix hilite silhouette ignoring weight overrides for polylines.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
+++ b/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
@@ -316,11 +316,12 @@ ${  computeHiliteColor}`;
 
 const computeHiliteOverrides = `
   vec4 value = getFirstFeatureRgba();
-  float flags = value.g * 256.0;
-  v_feature_hilited = kEmphFlag_Hilite * extractNthBit(flags, kOvrBit_Hilited) + kEmphFlag_Emphasize * extractNthBit(flags, kOvrBit_Emphasized);
+  float emphFlags = value.g * 256.0;
+  v_feature_hilited = kEmphFlag_Hilite * extractNthBit(emphFlags, kOvrBit_Hilited) + kEmphFlag_Emphasize * extractNthBit(emphFlags, kOvrBit_Emphasized);
 `;
 
 const computeHiliteOverridesWithWeight = `${computeHiliteOverrides}
+  float flags = value.r * 256.0;
   linear_feature_overrides = vec4(nthFeatureBitSet(flags, kOvrBit_Weight),
   value.a * 256.0,
   nthFeatureBitSet(flags, kOvrBit_LineCode),

--- a/core/frontend/src/render/webgl/glsl/Polyline.ts
+++ b/core/frontend/src/render/webgl/glsl/Polyline.ts
@@ -349,6 +349,6 @@ export function createPolylineHiliter(instanced: IsInstanced): ProgramBuilder {
   const builder = new ProgramBuilder(AttributeMap.findAttributeMap(TechniqueId.Polyline, IsInstanced.Yes === instanced), instanced ? ShaderBuilderFlags.InstancedVertexTable : ShaderBuilderFlags.VertexTable);
   addCommon(builder);
   addFrustum(builder);
-  addHiliter(builder);
+  addHiliter(builder, true);
   return builder;
 }


### PR DESCRIPTION
It would always draw the silhouette using the element's weight even when the symbology overrides specified a different weight.
Shader was checking the wrong flags.