### PR TITLE
re-enable the ExtensionAdmin tests

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/ExtensionAdmin.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ExtensionAdmin.test.ts
@@ -7,7 +7,7 @@ import { assert } from "chai";
 import { ExternalServerExtensionLoader, IModelApp } from "@bentley/imodeljs-frontend";
 import { isElectronRenderer } from "@bentley/bentleyjs-core";
 
-describe.skip("ExtensionAdmin tests", () => {
+describe("ExtensionAdmin tests", () => {
   before(async () => IModelApp.startup());
   after(async () => IModelApp.shutdown());
 

--- a/full-stack-tests/core/webpack.config.js
+++ b/full-stack-tests/core/webpack.config.js
@@ -8,7 +8,7 @@ const glob = require("glob");
 const webpack = require("webpack");
 const raw = require("@bentley/config-loader/lib/IModelJsConfig").IModelJsConfig.init(true /*suppress error*/, true);
 
-// const { IModeljsLibraryExportsPlugin } = require('@bentley/webpack-tools-core');
+const { IModeljsLibraryExportsPlugin } = require('@bentley/webpack-tools-core');
 
 function createConfig(shouldInstrument) {
   const config = {
@@ -67,7 +67,7 @@ function createConfig(shouldInstrument) {
             IMODELJS_CORE_DIRNAME: JSON.stringify(path.join(__dirname, "../..")),
           }),
       }),
-      // new IModeljsLibraryExportsPlugin(),
+      new IModeljsLibraryExportsPlugin(),
     ]
   };
 


### PR DESCRIPTION
The tests were originally turned off due to the memory issues we were having on master.  We later figured out that they were due to the coverage reporting when webpack-ing.  That issue has been "fixed" by just disabling the instrumented bundle for the test suites, having nothing to do with this test.