### PR TITLE
Account for aspect ratio skew in core decorations.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/exaggerated-view-decorations_2020-12-15-16-13.json
+++ b/common/changes/@bentley/imodeljs-frontend/exaggerated-view-decorations_2020-12-15-16-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Account for aspect ratio skew in core decorations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "65233531+bbastings@users.noreply.github.com"
+}

--- a/core/frontend/src/AccuDraw.ts
+++ b/core/frontend/src/AccuDraw.ts
@@ -1691,7 +1691,9 @@ export class AccuDraw {
     const rMatrix = (!this.flags.animateRotation || 0.0 === this._percentChanged) ? this.axes.toMatrix3d() : this.lastAxes.toMatrix3d();
     const origin = new Point3d(); // Compass origin is adjusted by active z-lock...
     this.getCompassPlanePoint(origin, vp);
-    const scale = vp.pixelsFromInches(this._compassSizeInches) * vp.getPixelSizeAtPoint(origin);
+    // NOTE: AccuDraw should probably be disabled for exaggerated views, for now put a limit on compass y scale...
+    const scale = vp.pixelsFromInches(this._compassSizeInches / vp.view.getAspectRatioSkew()) * vp.getPixelSizeAtPoint(origin);
+
     rMatrix.transposeInPlace();
     rMatrix.scaleColumns(scale, scale, scale, rMatrix);
     return Transform.createRefs(origin, rMatrix);

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -3510,24 +3510,26 @@ export class ScreenViewport extends Viewport {
 
     builder.setSymbology(color, colorFill, 1);
 
+    const skew = context.viewport.view.getAspectRatioSkew();
     const radius = (2.5 * aperture) * context.viewport.getPixelSizeAtPoint(hit.snapPoint);
     const rMatrix = Matrix3d.createRigidHeadsUp(hit.normal);
-    const ellipse = Arc3d.createScaledXYColumns(hit.snapPoint, rMatrix, radius, radius, AngleSweep.create360());
+    const ellipse = Arc3d.createScaledXYColumns(hit.snapPoint, rMatrix, radius, radius / skew, AngleSweep.create360());
 
     builder.addArc(ellipse, true, true);
     builder.addArc(ellipse, false, false);
 
-    const length = (0.6 * radius);
+    const lengthX = (0.6 * radius);
+    const lengthY = lengthX / skew;
     const normal = Vector3d.create();
 
     ellipse.vector0.normalize(normal);
-    const pt1 = hit.snapPoint.plusScaled(normal, length);
-    const pt2 = hit.snapPoint.plusScaled(normal, -length);
+    const pt1 = hit.snapPoint.plusScaled(normal, lengthX);
+    const pt2 = hit.snapPoint.plusScaled(normal, -lengthX);
     builder.addLineString([pt1, pt2]);
 
     ellipse.vector90.normalize(normal);
-    const pt3 = hit.snapPoint.plusScaled(normal, length);
-    const pt4 = hit.snapPoint.plusScaled(normal, -length);
+    const pt3 = hit.snapPoint.plusScaled(normal, lengthY);
+    const pt4 = hit.snapPoint.plusScaled(normal, -lengthY);
     builder.addLineString([pt3, pt4]);
 
     context.addDecorationFromBuilder(builder);

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -338,9 +338,10 @@ export abstract class ViewManip extends ViewTool {
     }
 
     const pixelSize = context.viewport.getPixelSizeAtPoint(origin);
+    const skew = context.viewport.view.getAspectRatioSkew();
     const radius = this._depthPreview.pickRadius * pixelSize;
     const rMatrix = Matrix3d.createRigidHeadsUp(normal);
-    const ellipse = Arc3d.createScaledXYColumns(origin, rMatrix, radius, radius, AngleSweep.create360());
+    const ellipse = Arc3d.createScaledXYColumns(origin, rMatrix, radius, radius / skew, AngleSweep.create360());
     const colorBase = (this._depthPreview.isDefaultDepth ? ColorDef.red : (DepthPointSource.Geometry === this._depthPreview.source ? ColorDef.green : context.viewport.hilite.color));
     const colorLine = EditManipulator.HandleUtils.adjustForBackgroundColor(colorBase, cursorVp).withTransparency(50);
     const colorFill = colorLine.withTransparency(200);


### PR DESCRIPTION
Surface normal decoration from locate HitDetail, view tool depth point indicator, and AccuDraw compass now check for an exaggerated view.