### PR TITLE
New method: async version of sweeping a linestring to a mesh. (bp #388)

### DIFF
--- a/common/api/geometry-core.api.md
+++ b/common/api/geometry-core.api.md
@@ -4089,6 +4089,13 @@ export class PolyfaceData {
 export class PolyfaceQuery {
     static announceDuplicateFacetIndices(polyface: Polyface, announceCluster: (clusterFacetIndices: number[]) => void): void;
     static announceSweepLinestringToConvexPolyfaceXY(linestringPoints: GrowableXYZArray, polyface: Polyface, announce: AnnounceDrapePanel): any;
+    // @internal
+    static asyncAnnounceSweepLinestringToConvexPolyfaceXY(linestringPoints: GrowableXYZArray, polyface: Polyface, announce: AnnounceDrapePanel): Promise<number>;
+    static asyncSweepLinestringToFacetsXYReturnChains(linestringPoints: GrowableXYZArray, polyface: Polyface): Promise<LineString3d[]>;
+    // @internal
+    static get asyncWorkLimit(): number;
+    // @internal
+    static awaitBlockCount: number;
     static boundaryEdges(source: Polyface | PolyfaceVisitor | undefined, includeDanglers?: boolean, includeMismatch?: boolean, includeNull?: boolean): CurveCollection | undefined;
     static boundaryOfVisibleSubset(polyface: IndexedPolyface, visibilitySelect: 0 | 1 | 2, vectorToEye: Vector3d, sideAngleTolerance?: Angle): CurveCollection | undefined;
     static buildAverageNormals(polyface: IndexedPolyface, toleranceAngle?: Angle): void;
@@ -4112,6 +4119,8 @@ export class PolyfaceQuery {
     static partitionFacetIndicesByVertexConnectedComponent(polyface: Polyface | PolyfaceVisitor): number[][];
     static partitionFacetIndicesByVisibilityVector(polyface: Polyface | PolyfaceVisitor, vectorToEye: Vector3d, sideAngleTolerance: Angle): number[][];
     static reorientVertexOrderAroundFacetsForConsistentOrientation(mesh: IndexedPolyface): boolean;
+    // @internal
+    static setAsyncWorkLimit(value: number): number;
     static setSingleEdgeVisibility(polyface: IndexedPolyface, facetIndex: number, vertexIndex: number, value: boolean): void;
     static sumFacetAreas(source: Polyface | PolyfaceVisitor | undefined): number;
     static sumFacetSecondAreaMomentProducts(source: Polyface | PolyfaceVisitor, origin: Point3d): Matrix4d;

--- a/common/changes/@bentley/geometry-core/EDLLineStringDrapeContext_2020-12-09-15-19.json
+++ b/common/changes/@bentley/geometry-core/EDLLineStringDrapeContext_2020-12-09-15-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "Async version of asyncSweepLinestringToFacetsXYReturnChains",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "69321059+EarlinLutz@users.noreply.github.com"
+}

--- a/core/geometry/src/polyface/IndexedPolyfaceVisitor.ts
+++ b/core/geometry/src/polyface/IndexedPolyfaceVisitor.ts
@@ -10,7 +10,7 @@ import { Point2d } from "../geometry3d/Point2dVector2d";
 import { PolyfaceData } from "./PolyfaceData";
 import { IndexedPolyface, Polyface, PolyfaceVisitor } from "./Polyface";
 import { Geometry } from "../Geometry";
-
+/* eslint-disable @bentley/prefer-get */
 /**
  * An `IndexedPolyfaceVisitor` is an iterator-like object that "visits" facets of a mesh.
  * * The visitor extends a `PolyfaceData ` class, so it can at any time hold all the data of a single facet.
@@ -72,6 +72,7 @@ export class IndexedPolyfaceVisitor extends PolyfaceData implements PolyfaceVisi
     this._nextFacetIndex++;
     return true;
   }
+
   /** Reset the iterator to start at the first facet of the polyface. */
   public reset(): void {
     this.moveToReadIndex(0);

--- a/core/geometry/src/polyface/PolyfaceQuery.ts
+++ b/core/geometry/src/polyface/PolyfaceQuery.ts
@@ -15,16 +15,12 @@ import { LineSegment3d } from "../curve/LineSegment3d";
 import { LineString3d } from "../curve/LineString3d";
 import { Loop } from "../curve/Loop";
 import { StrokeOptions } from "../curve/StrokeOptions";
-import { Geometry } from "../Geometry";
 import { Angle } from "../geometry3d/Angle";
 import { GrowableXYZArray } from "../geometry3d/GrowableXYZArray";
 import { Plane3dByOriginAndUnitNormal } from "../geometry3d/Plane3dByOriginAndUnitNormal";
-// import { Point3d, Vector3d, Point2d } from "./PointVector";
 import { Point3d, Vector3d } from "../geometry3d/Point3dVector3d";
 import { PolygonOps } from "../geometry3d/PolygonOps";
 import { Range3d } from "../geometry3d/Range";
-import { Segment1d } from "../geometry3d/Segment1d";
-import { Transform } from "../geometry3d/Transform";
 import { Matrix4d } from "../geometry4d/Matrix4d";
 import { MomentData } from "../geometry4d/MomentData";
 import { UnionFindContext } from "../numerics/UnionFind";
@@ -33,11 +29,12 @@ import { FacetOrientationFixup } from "./FacetOrientation";
 import { IndexedEdgeMatcher, SortableEdge, SortableEdgeCluster } from "./IndexedEdgeMatcher";
 import { IndexedPolyfaceSubsetVisitor } from "./IndexedPolyfaceVisitor";
 import { BuildAverageNormalsContext } from "./multiclip/BuildAverageNormalsContext";
+import { SweepLineStringToFacetContext } from "./multiclip/SweepLineStringToFacetContext";
 import { XYPointBuckets } from "./multiclip/XYPointBuckets";
 import { IndexedPolyface, Polyface, PolyfaceVisitor } from "./Polyface";
 import { PolyfaceBuilder } from "./PolyfaceBuilder";
 import { RangeLengthData } from "./RangeLengthData";
-/* eslint-disable-NotNow no-console */
+
 /**
  * Structure to return multiple results from volume between facets and plane
  * @public
@@ -321,66 +318,65 @@ export class PolyfaceQuery {
    */
   public static announceSweepLinestringToConvexPolyfaceXY(linestringPoints: GrowableXYZArray, polyface: Polyface,
     announce: AnnounceDrapePanel): any {
-    const visitor = polyface.createVisitor(0);
-    const numLinestringPoints = linestringPoints.length;
-    const segmentPoint0 = Point3d.create();
-    const segmentPoint1 = Point3d.create();
-    const localSegmentPoint0 = Point3d.create();
-    const localSegmentPoint1 = Point3d.create();
-    const clipFractions = Segment1d.create(0, 1);
-    const localFrame = Transform.createIdentity();
-    let frame;
-    const linestringRange = linestringPoints.getRange();
-    const facetRange = Range3d.create();
-    // let numTest = 0;
-    // let numFacet = 0;
-    for (visitor.reset(); visitor.moveToNextFacet();) {
-      // numFacet++;
-      visitor.point.setRange(facetRange);
-      if (!facetRange.intersectsRangeXY(linestringRange))
-        continue;
-      // numTest++;
-      // For each triangle within the facet ...
-      for (let k1 = 1; k1 + 1 < visitor.point.length; k1++) {
-        frame = visitor.point.fillLocalXYTriangleFrame(0, k1, k1 + 1, localFrame);
-        if (frame) {
-          // For each stroke of the linestring ...
-          for (let i1 = 1; i1 < numLinestringPoints; i1++) {
-            linestringPoints.getPoint3dAtCheckedPointIndex(i1 - 1, segmentPoint0);
-            linestringPoints.getPoint3dAtCheckedPointIndex(i1, segmentPoint1);
-            frame.multiplyInversePoint3d(segmentPoint0, localSegmentPoint0);
-            frame.multiplyInversePoint3d(segmentPoint1, localSegmentPoint1);
-            clipFractions.set(0, 1);
-            /** (x,y,1-x-y) are barycentric coordinates in the triangle !!! */
-            if (clipFractions.clipBy01FunctionValuesPositive(localSegmentPoint0.x, localSegmentPoint1.x)
-              && clipFractions.clipBy01FunctionValuesPositive(localSegmentPoint0.y, localSegmentPoint1.y)
-              && clipFractions.clipBy01FunctionValuesPositive(
-                1 - localSegmentPoint0.x - localSegmentPoint0.y,
-                1 - localSegmentPoint1.x - localSegmentPoint1.y)) {
-              /* project the local segment point to the plane. */
-              const localClippedPointA = localSegmentPoint0.interpolate(clipFractions.x0, localSegmentPoint1);
-              const localClippedPointB = localSegmentPoint0.interpolate(clipFractions.x1, localSegmentPoint1);
-              const worldClippedPointA = localFrame.multiplyPoint3d(localClippedPointA)!;
-              const worldClippedPointB = localFrame.multiplyPoint3d(localClippedPointB)!;
-              const planePointA = localFrame.multiplyXYZ(localClippedPointA.x, localClippedPointA.y, 0.0)!;
-              const planePointB = localFrame.multiplyXYZ(localClippedPointB.x, localClippedPointB.y, 0.0)!;
-              const splitParameter = Geometry.inverseInterpolate01(localSegmentPoint0.z, localSegmentPoint1.z);
-              // emit 1 or 2 panels, oriented so panel normal is always to the left of the line.
-              if (splitParameter !== undefined && splitParameter > clipFractions.x0 && splitParameter < clipFractions.x1) {
-                const piercePointX = segmentPoint0.interpolate(splitParameter, segmentPoint1);
-                const piercePointY = piercePointX.clone();   // so points are distinct for the two triangle announcements.
-                announce(linestringPoints, i1 - 1, polyface, visitor.currentReadIndex(), [worldClippedPointA, piercePointX, planePointA], 2, 1);
-                announce(linestringPoints, i1 - 1, polyface, visitor.currentReadIndex(), [worldClippedPointB, piercePointY, planePointB], 1, 2);
-              } else if (localSegmentPoint0.z > 0) {  // segment is entirely above
-                announce(linestringPoints, i1 - 1, polyface, visitor.currentReadIndex(), [worldClippedPointA, worldClippedPointB, planePointB, planePointA], 3, 2);
-              } else // segment is entirely under
-                announce(linestringPoints, i1 - 1, polyface, visitor.currentReadIndex(), [worldClippedPointB, worldClippedPointA, planePointA, planePointB], 2, 3);
-            }
-          }
-        }
+    const context = SweepLineStringToFacetContext.create(linestringPoints);
+    if (context) {
+      const visitor = polyface.createVisitor(0);
+      for (visitor.reset(); visitor.moveToNextFacet();) {
+        context.projectToPolygon(visitor.point, announce, polyface, visitor.currentReadIndex());
       }
     }
-    // console.log(`numFacet ${numFacet}  numTest    ${numTest}    ratio  ${numTest / numFacet}`);
+  }
+
+
+  /** Execute context.projectToPolygon until its work estimates accumulate to workLimit  */
+  private static async continueAnnouunceSweepLinestringToConvexPolyfaceXY(
+    context: SweepLineStringToFacetContext, visitor: PolyfaceVisitor, announce: AnnounceDrapePanel): Promise<number> {
+    let workCount = 0;
+    while ((workCount < this.asyncWorkLimit) && visitor.moveToNextFacet()) {
+      workCount += context.projectToPolygon(visitor.point, announce, visitor.clientPolyface()!, visitor.currentReadIndex());
+    }
+    return workCount;
+  }
+  // amount of computation to do per step of async methods.
+  private static _asyncWorkLimit = 1.e06;
+  /** Set the limit on work during an async time blocks, and return the old value.
+   * * This should be a large number -- default is 1.0e6
+   * @internal
+   */
+  public static setAsyncWorkLimit(value: number): number { const a = this._asyncWorkLimit; this._asyncWorkLimit = value; return a; }
+  /** Query the current limit on work during an async time block.
+   * @internal
+   */
+  public static get asyncWorkLimit(): number { return this._asyncWorkLimit; }
+  /** Number of "await" steps executed in recent async calls.
+   * @internal
+   */
+  public static awaitBlockCount = 0;
+
+  /** Find segments (within the linestring) which project to facets.
+   * * Announce each pair of linestring segment and on-facet segment through a callback.
+   * * Facets are ASSUMED to be convex and planar.
+   * * REMARK: Although this is public, the usual use is via slightly higher level public methods, viz:
+   *   * asyncSweepLinestringToFacetsXYReturnChains
+   * @internal
+   */
+  public static async asyncAnnounceSweepLinestringToConvexPolyfaceXY(linestringPoints: GrowableXYZArray, polyface: Polyface,
+    announce: AnnounceDrapePanel): Promise<number> {
+    const context = SweepLineStringToFacetContext.create(linestringPoints);
+    this.awaitBlockCount = 0;
+    let workTotal = 0;;
+    if (context) {
+      const visitor = polyface.createVisitor(0);
+      let workCount;
+      while (0 < (workCount = await Promise.resolve(PolyfaceQuery.continueAnnouunceSweepLinestringToConvexPolyfaceXY(context, visitor, announce)))) {
+        workTotal += workCount;
+        this.awaitBlockCount++;
+        // console.log({ myWorkCount: workCount, myBlockCount: this.awaitBlockCount });
+      }
+    }
+    // eslint-disable-next-line no-console
+    // console.log({ myWorkTotal: workTotal, myBlockCount: this.awaitBlockCount });
+    return workTotal;
   }
 
   /** Search the facets for facet subsets that are connected with at least vertex contact.
@@ -605,6 +601,24 @@ export class PolyfaceQuery {
       });
     chainContext.clusterAndMergeVerticesXYZ();
     return chainContext.collectMaximalChains();
+  }
+  /** Find segments (within the linestring) which project to facets.
+   * * This is done as a sequence of "await" steps.
+   * * Each "await" step deals with approximately PolyfaceQuery.asyncWorkLimit pairings of (linestring edge) with (facet edge)
+   *  * PolyfaceQuery.setAsyncWorkLimit () to change work blocks from default
+   * * Return chains.
+   */
+  public static async asyncSweepLinestringToFacetsXYReturnChains(linestringPoints: GrowableXYZArray, polyface: Polyface): Promise<LineString3d[]> {
+    const chainContext = ChainMergeContext.create();
+
+    await Promise.resolve(this.asyncAnnounceSweepLinestringToConvexPolyfaceXY(linestringPoints, polyface,
+      (_linestring: GrowableXYZArray, _segmentIndex: number,
+        _polyface: Polyface, _facetIndex: number, points: Point3d[], indexA: number, indexB: number) => {
+        chainContext.addSegment(points[indexA], points[indexB]);
+      }));
+    chainContext.clusterAndMergeVerticesXYZ();
+    const chains = chainContext.collectMaximalChains();
+    return chains;
   }
 
   /**

--- a/core/geometry/src/polyface/multiclip/SweepLineStringToFacetContext.ts
+++ b/core/geometry/src/polyface/multiclip/SweepLineStringToFacetContext.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Polyface
+ */
+
+import { Transform } from "../../geometry3d/Transform";
+import { GrowableXYZArray } from "../../geometry3d/GrowableXYZArray";
+import { Point3d } from "../../geometry3d/Point3dVector3d";
+import { Segment1d } from "../../geometry3d/Segment1d";
+import { AnnounceDrapePanel } from "../PolyfaceQuery";
+import { Range3d } from "../../geometry3d/Range";
+import { Geometry } from "../../Geometry";
+import { Polyface } from "../Polyface";
+
+export class SweepLineStringToFacetContext {
+  private _spacePoints: GrowableXYZArray;
+  private _spacePointsRange: Range3d;
+  private _numSpacePoints: number;
+  private constructor(spacePoints: GrowableXYZArray) {
+    this._spacePoints = spacePoints;
+    this._spacePointsRange = new Range3d();
+    spacePoints.setRange(this._spacePointsRange);
+    this._numSpacePoints = this._spacePoints.length;
+  }
+  public static create(xyz: GrowableXYZArray): SweepLineStringToFacetContext | undefined {
+    if (xyz.length > 1) {
+      return new SweepLineStringToFacetContext(xyz.clone());
+    }
+    return undefined;
+  }
+
+  // temporaries reused over multiple calls to process a single facet . ..
+  private _segmentPoint0 = Point3d.create();
+  private _segmentPoint1 = Point3d.create();
+  private _localSegmentPoint0 = Point3d.create();
+  private _localSegmentPoint1 = Point3d.create();
+  private _clipFractions = Segment1d.create(0, 1);
+  private _localFrame = Transform.createIdentity();
+  private _polygonRange = Range3d.create();
+
+  /** process a single polygon.
+   * @returns number crudely indicating how much work was done.
+   */
+  public projectToPolygon(polygon: GrowableXYZArray, announce: AnnounceDrapePanel, polyface: Polyface, readIndex: number): number {
+    polygon.setRange(this._polygonRange);
+    let workCounter = 0;
+    if (!this._polygonRange.intersectsRangeXY(this._spacePointsRange))
+      return workCounter;
+    // numTest++;
+    // For each triangle within the facet ...
+    // remark: this loop only runs once in triangle mesh, twice in quads ...
+    for (let k1 = 1; k1 + 1 < polygon.length; k1++) {
+      workCounter++;
+      const frame = polygon.fillLocalXYTriangleFrame(0, k1, k1 + 1, this._localFrame);
+      if (frame) {
+        // For each stroke of the linestring ...
+        for (let i1 = 1; i1 < this._numSpacePoints; i1++) {
+          workCounter++;
+          this._spacePoints.getPoint3dAtCheckedPointIndex(i1 - 1, this._segmentPoint0);
+          this._spacePoints.getPoint3dAtCheckedPointIndex(i1, this._segmentPoint1);
+          frame.multiplyInversePoint3d(this._segmentPoint0, this._localSegmentPoint0);
+          frame.multiplyInversePoint3d(this._segmentPoint1, this._localSegmentPoint1);
+          this._clipFractions.set(0, 1);
+          /** (x,y,1-x-y) are barycentric coordinates in the triangle !!! */
+          if (this._clipFractions.clipBy01FunctionValuesPositive(this._localSegmentPoint0.x, this._localSegmentPoint1.x)
+            && this._clipFractions.clipBy01FunctionValuesPositive(this._localSegmentPoint0.y, this._localSegmentPoint1.y)
+            && this._clipFractions.clipBy01FunctionValuesPositive(
+              1 - this._localSegmentPoint0.x - this._localSegmentPoint0.y,
+              1 - this._localSegmentPoint1.x - this._localSegmentPoint1.y)) {
+            /* project the local segment point to the plane. */
+            workCounter++;
+            const localClippedPointA = this._localSegmentPoint0.interpolate(this._clipFractions.x0, this._localSegmentPoint1);
+            const localClippedPointB = this._localSegmentPoint0.interpolate(this._clipFractions.x1, this._localSegmentPoint1);
+            const worldClippedPointA = this._localFrame.multiplyPoint3d(localClippedPointA)!;
+            const worldClippedPointB = this._localFrame.multiplyPoint3d(localClippedPointB)!;
+            const planePointA = this._localFrame.multiplyXYZ(localClippedPointA.x, localClippedPointA.y, 0.0)!;
+            const planePointB = this._localFrame.multiplyXYZ(localClippedPointB.x, localClippedPointB.y, 0.0)!;
+            const splitParameter = Geometry.inverseInterpolate01(this._localSegmentPoint0.z, this._localSegmentPoint1.z);
+            // emit 1 or 2 panels, oriented so panel normal is always to the left of the line.
+            if (splitParameter !== undefined && splitParameter > this._clipFractions.x0 && splitParameter < this._clipFractions.x1) {
+              workCounter++;
+              const piercePointX = this._segmentPoint0.interpolate(splitParameter, this._segmentPoint1);
+              const piercePointY = piercePointX.clone();   // so points are distinct for the two triangle announcements.
+              announce(this._spacePoints, i1 - 1, polyface, readIndex, [worldClippedPointA, piercePointX, planePointA], 2, 1);
+              announce(this._spacePoints, i1 - 1, polyface, readIndex, [worldClippedPointB, piercePointY, planePointB], 1, 2);
+            } else if (this._localSegmentPoint0.z > 0) {  // segment is entirely above
+              announce(this._spacePoints, i1 - 1, polyface, readIndex, [worldClippedPointA, worldClippedPointB, planePointB, planePointA], 3, 2);
+            } else // segment is entirely under
+              announce(this._spacePoints, i1 - 1, polyface, readIndex, [worldClippedPointB, worldClippedPointA, planePointA, planePointB], 2, 3);
+          }
+        }
+      }
+    }
+    return workCounter;
+  }
+}


### PR DESCRIPTION
 New static method
```
  PolyfaceQuery.asyncSweepLinestringToFacetsXYReturnChains(
     linestringPoints: GrowableXYZArray, polyface: Polyface): Promise<LineString3d[]>
```
  to drape a linestring to a mesh, operating as an async.