### PR TITLE
Fix accidentally committed --to flag in build

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -67,7 +67,7 @@ steps:
     workingDirectory: ${{ parameters.workingDir }}
 
   # By default linux agents do not have a real display so use the virtual framebuffer
-  - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' node common/scripts/install-run-rush.js cover --to core-full-stack-tests --verbose
+  - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' node common/scripts/install-run-rush.js cover --verbose
     displayName: rush cover
     workingDirectory: ${{ parameters.workingDir }}
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))


### PR DESCRIPTION
While looking at trying to speed up our builds overall I noticed I accidentally merged this last week.  I'm going to override @wgoehrig and @ColinKerr review once this is approved and builds.