### PR TITLE
Fix eslint glob patterns for MacOS

### DIFF
--- a/clients/backend-application-insights/package.json
+++ b/clients/backend-application-insights/package.json
@@ -17,7 +17,7 @@
     "test": "",
     "extract-api": "betools extract-api --entry=backend-application-insights-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/backend-application-insights-client/file.json --tsIndexFile=backend-application-insights-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2"
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2"
   },
   "keywords": [
     "Bentley",

--- a/clients/context-registry/package.json
+++ b/clients/context-registry/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=context-registry-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/context-registry-client/file.json --tsIndexFile=context-registry-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "webpackTests": "webpack --config ./src/test/utils/webpack.config.js 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",

--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -16,7 +16,7 @@
     "cover": "",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/extension-client/file.json --tsIndexFile=./extension-client.ts --onlyJson",
     "extract-api": "betools extract-api --entry=extension-client",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",
     "test:integration:chrome": "certa -r chrome",

--- a/clients/forms-data-management/package.json
+++ b/clients/forms-data-management/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=forms-data-management-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/forms-data-management-client/file.json --tsIndexFile=forms-data-management-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "webpackTests": "webpack --config ./src/test/utils/webpack.config.js 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",

--- a/clients/frontend-application-insights/package.json
+++ b/clients/frontend-application-insights/package.json
@@ -18,7 +18,7 @@
     "test": "",
     "extract-api": "betools extract-api --entry=frontend-application-insights-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/frontend-application-insights-client/file.json --tsIndexFile=frontend-application-insights-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2"
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2"
   },
   "keywords": [
     "Bentley",

--- a/clients/frontend-authorization/package.json
+++ b/clients/frontend-authorization/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=frontend-authorization-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/frontend-authorization-client/file.json --tsIndexFile=frontend-authorization-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "cover": ""
   },

--- a/clients/imodelhub/package.json
+++ b/clients/imodelhub/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=imodelhub-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/imodelhub-client/file.json --tsIndexFile=imodelhub-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "cover": ""
   },

--- a/clients/itwin/package.json
+++ b/clients/itwin/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=itwin-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/itwin-client/file.json --tsIndexFile=itwin-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test --offline=\"mock\"",
     "cover": "nyc npm test"
   },

--- a/clients/product-settings/package.json
+++ b/clients/product-settings/package.json
@@ -17,7 +17,7 @@
     "cover": "",
     "extract-api": "betools extract-api --entry=product-settings-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/product-settings-client/file.json --tsIndexFile=product-settings-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",
     "test:integration:chrome": "certa -r chrome --grep \"#integration\"",

--- a/clients/projectshare/package.json
+++ b/clients/projectshare/package.json
@@ -17,7 +17,7 @@
     "cover": "",
     "extract-api": "betools extract-api --entry=projectshare-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/projectshare-client/file.json --tsIndexFile=projectshare-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",
     "test:integration:chrome": "certa -r chrome --grep \"#integration\"",

--- a/clients/rbac/package.json
+++ b/clients/rbac/package.json
@@ -17,7 +17,7 @@
     "cover": "",
     "extract-api": "betools extract-api --entry=rbac-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/rbac-client/file.json --tsIndexFile=rbac-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",
     "test:integration:chrome": "certa -r chrome --grep \"#integration\"",

--- a/clients/reality-data/package.json
+++ b/clients/reality-data/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=reality-data-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/reality-data-client/file.json --tsIndexFile=reality-data-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "webpackTests": "webpack --config ./src/test/utils/webpack.config.js 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",

--- a/clients/telemetry/package.json
+++ b/clients/telemetry/package.json
@@ -18,7 +18,7 @@
     "test": "",
     "extract-api": "betools extract-api --entry=telemetry-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/telemetry-client/file.json --tsIndexFile=telemetry-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2"
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2"
   },
   "keywords": [
     "Bentley",

--- a/clients/usage-logging/package.json
+++ b/clients/usage-logging/package.json
@@ -17,7 +17,7 @@
     "cover": "",
     "extract-api": "betools extract-api --entry=usage-logging-client",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/usage-logging-client/file.json --tsIndexFile=usage-logging-client.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "test:integration": "npm run webpackTests && npm run test:integration:chrome",
     "test:integration:chrome": "certa -r chrome --grep \"#integration\"",

--- a/common/changes/@bentley/analytical-backend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/analytical-backend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/analytical-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/backend-application-insights-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/backend-application-insights-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-application-insights-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-application-insights-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/backend-itwin-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/backend-itwin-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-itwin-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-itwin-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/bentleyjs-core/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/bentleyjs-core/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/bentleyjs-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/bentleyjs-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/certa/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/certa/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/certa",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/certa",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/config-loader/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/config-loader/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/config-loader",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/config-loader",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/context-registry-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/context-registry-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/context-registry-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/context-registry-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema-locaters/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ecschema-locaters/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema-locaters",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema-locaters",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema-metadata/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ecschema-metadata/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema-metadata",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema-metadata",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ecschema2ts/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ecschema2ts/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema2ts",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema2ts",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/electron-manager/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/electron-manager/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/express-server/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/express-server/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/express-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/express-server",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-cli/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/extension-cli/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-cli",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/extension-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/forms-data-management-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/forms-data-management-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/forms-data-management-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/forms-data-management-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/frontend-application-insights-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/frontend-application-insights-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-application-insights-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-application-insights-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/frontend-authorization-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/frontend-authorization-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-authorization-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-authorization-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/frontend-devtools/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/frontend-devtools/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-devtools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-devtools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/geometry-core/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/geometry-core/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/geonames-extension/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/geonames-extension/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geonames-extension",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geonames-extension",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/hypermodeling-frontend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/hypermodeling-frontend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/hypermodeling-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/hypermodeling-frontend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodel-bridge/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodel-bridge/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-bridge",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodel-bridge",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client-tests/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodelhub-client-tests/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client-tests",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodelhub-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodelhub-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodeljs-common/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-i18n/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodeljs-i18n/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-i18n",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-i18n",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-markup/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodeljs-markup/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-markup",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-quantity/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/imodeljs-quantity/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-quantity",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-quantity",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/itwin-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/itwin-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/itwin-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/linear-referencing-backend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/linear-referencing-backend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/linear-referencing-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/linear-referencing-common/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/linear-referencing-common/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/linear-referencing-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/linear-referencing-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/logger-config/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/logger-config/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/logger-config",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/logger-config",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/map-layers/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/map-layers/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/map-layers",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/map-layers",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/oidc-signin-tool/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/oidc-signin-tool/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/oidc-signin-tool",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/oidc-signin-tool",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/physical-material-backend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/physical-material-backend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/physical-material-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/physical-material-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-backend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/presentation-backend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/presentation-common/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/presentation-components/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-frontend/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/presentation-frontend/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-testing/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/presentation-testing/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-testing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-testing",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/product-settings-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/product-settings-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/product-settings-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/product-settings-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/projectshare-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/projectshare-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/projectshare-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/projectshare-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/rbac-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/rbac-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/rbac-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/rbac-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/reality-data-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/reality-data-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/reality-data-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/reality-data-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/rpcinterface-full-stack-tests/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/rpcinterface-full-stack-tests/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/rpcinterface-full-stack-tests",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/telemetry-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/telemetry-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/telemetry-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/telemetry-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-abstract/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ui-abstract/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-abstract",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-abstract",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-components/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ui-components/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ui-framework/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-ninezone/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/ui-ninezone/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-ninezone",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-ninezone",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/usage-logging-client/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/usage-logging-client/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/usage-logging-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/usage-logging-client",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/webgl-compatibility/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/webgl-compatibility/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webgl-compatibility",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/common/changes/@bentley/webpack-tools-core/fix-mac-linting_2020-12-22-00-46.json
+++ b/common/changes/@bentley/webpack-tools-core/fix-mac-linting_2020-12-22-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webpack-tools-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webpack-tools-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/core/backend-itwin-client/package.json
+++ b/core/backend-itwin-client/package.json
@@ -20,7 +20,7 @@
     "cover:integration": "nyc --report-dir ./lib/test/coverage/integration npm run test:integration",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/backend-itwin-client/file.json --tsIndexFile=backend-itwin-client.ts --onlyJson",
     "extract-api": "betools extract-api --entry=backend-itwin-client",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pretest": "npm run copy:test-assets",
     "test": "",
     "test:integration": "npm run pretest && betools test --grep=\"#integration\""

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -18,7 +18,7 @@
     "cover": "nyc npm test",
     "cover:integration": "nyc npm run test:integration",
     "extract-api": "betools extract-api --entry=imodeljs-backend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pretest": "cpx ./src/test/logging.config.json ./lib/test",
     "test": "betools test --offline=\"mock\" --grep=\"#integration|#WebGLPerformance\" --invert",
     "test:integration": "npm run pretest && betools test --testDir=\"./lib/test/integration\"",

--- a/core/bentley/package.json
+++ b/core/bentley/package.json
@@ -19,7 +19,7 @@
     "docs": "betools docs --json=../../generated-docs/core/bentleyjs-core/file.json --tsIndexFile=bentleyjs-core.ts --onlyJson",
     "cover": "nyc npm test",
     "cover:docs": "node ./node_modules/@bentley/build-tools/scripts/docscoverage.js",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2"
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2"
   },
   "keywords": [
     "Bentley",

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/imodeljs-common/file.json --tsIndexFile=./imodeljs-common.ts --onlyJson",
     "extract-api": "betools extract-api --entry=imodeljs-common",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test",
     "cover": "nyc npm test"
   },

--- a/core/ecschema-locaters/package.json
+++ b/core/ecschema-locaters/package.json
@@ -14,7 +14,7 @@
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=ecschema-locaters",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test-tsnode --testDir=./test/",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/ecschema-locaters/file.json --tsIndexFile=./ecschema-locaters.ts --onlyJson",
     "cover": "nyc npm test",

--- a/core/ecschema-metadata/package.json
+++ b/core/ecschema-metadata/package.json
@@ -15,7 +15,7 @@
     "build": "tsc 1>&2  && npm run createLocalization",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=ecschema-metadata",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test-tsnode --testDir=./test/",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/ecschema-metadata/file.json --tsIndexFile=./ecschema-metadata.ts --onlyJson",
     "cover": "nyc npm test",

--- a/core/electron-manager/package.json
+++ b/core/electron-manager/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/electron-manager/file.json --tsIndexFile=./ElectronManager.ts --onlyJson",
     "extract-api": "betools extract-api --entry=ElectronManager",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "cover": ""
   },

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/express-server/file.json --tsIndexFile=./ExpressServer.ts --onlyJson",
     "extract-api": "betools extract-api --entry=ExpressServer",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test",
     "cover": "nyc npm test"
   },

--- a/core/frontend-devtools/package.json
+++ b/core/frontend-devtools/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/frontend-devtools/file.json --tsIndexFile=./frontend-devtools.ts --onlyJson",
     "extract-api": "betools extract-api --entry=frontend-devtools",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "cover": ""
   },

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -13,7 +13,7 @@
     "copy:assets": "cpx ./src/loader/checkbrowser.js ./lib/loader && cpx \"./src/public/**/*\" ./lib/public",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/imodeljs-frontend/file.json --tsIndexFile=./imodeljs-frontend.ts --onlyJson --excludes=webgl/**/*,**/primitives --excludeGlob=**/*-css.ts",
     "extract-api": "betools extract-api --entry=imodeljs-frontend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./src/public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "npm run webpackTests && certa -r chrome",
     "cover": "npm test -- --cover",

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -17,7 +17,7 @@
     "docs": "betools docs --tsIndexFile=./geometry-core.ts --json=../../generated-docs/core/geometry-core/file.json --onlyJson",
     "cover": "nyc npm test",
     "cover:docs": "node ./node_modules/@bentley/build-tools/scripts/docscoverage.js",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2"
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2"
   },
   "repository": {
     "type": "git",

--- a/core/hypermodeling/package.json
+++ b/core/hypermodeling/package.json
@@ -13,7 +13,7 @@
     "cover": "npm test -- --cover",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/hypermodeling-frontend/file.json --tsIndexFile=./hypermodeling-frontend.ts --onlyJson",
     "extract-api": "betools extract-api --entry=hypermodeling-frontend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./src/public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "npm run webpackTests && certa -r chrome",
     "test:debug": "certa -r chrome --debug",

--- a/core/i18n/package.json
+++ b/core/i18n/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/imodeljs-i18n/file.json --tsIndexFile=./imodeljs-i18n.ts --onlyJson",
     "extract-api": "betools extract-api --entry=imodeljs-i18n",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "cover": ""
   },

--- a/core/imodel-bridge/package.json
+++ b/core/imodel-bridge/package.json
@@ -22,7 +22,7 @@
     "cover": "nyc npm test",
     "cover:integration": "nyc npm run test:integration",
     "extract-api": "betools extract-api --entry=imodel-bridge",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pretest": "cpx ./src/test/logging.config.json ./lib/test",
     "test": "betools test --offline=\"mock\" --grep=\"#integration|#WebGLPerformance\" --invert",
     "test:all": "npm run pretest && betools test --grep=\"IModelBridgeFwk\"",

--- a/core/logger-config/package.json
+++ b/core/logger-config/package.json
@@ -13,7 +13,7 @@
     "cover": "",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/logger-config/file.json --tsIndexFile=./logger-config.ts --onlyJson",
     "extract-api": "betools extract-api --entry=logger-config",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": ""
   },
   "author": {

--- a/core/markup/package.json
+++ b/core/markup/package.json
@@ -13,7 +13,7 @@
     "cover": "npm test -- --cover",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/imodeljs-markup/file.json --tsIndexFile=./imodeljs-markup.ts --onlyJson",
     "extract-api": "betools extract-api --entry=imodeljs-markup",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./src/public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "npm run webpackTests && certa -r chrome",
     "test:debug": "certa -r chrome --debug",

--- a/core/quantity/package.json
+++ b/core/quantity/package.json
@@ -15,7 +15,7 @@
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json .nyc_output",
     "extract-api": "betools extract-api --entry=imodeljs-quantity",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test-tsnode --testDir=./test/",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/imodeljs-quantity/file.json --tsIndexFile=./imodeljs-quantity.ts --onlyJson",
     "cover": "nyc npm test",

--- a/core/webgl-compatibility/package.json
+++ b/core/webgl-compatibility/package.json
@@ -12,7 +12,7 @@
     "cover": "npm test -- --cover",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/webgl-compatibility/file.json --tsIndexFile=./webgl-compatibility.ts --onlyJson",
     "extract-api": "betools extract-api --entry=webgl-compatibility",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run webpackTests && certa -r chrome",
     "webpackTests": "webpack --config ./src/test/utils/webpack.config.js 1>&2"
   },

--- a/domains/analytical/backend/package.json
+++ b/domains/analytical/backend/package.json
@@ -15,7 +15,7 @@
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../../generated-docs/extract --json=../../../generated-docs/domains/analytical-backend/file.json --tsIndexFile=./analytical-backend.ts --onlyJson",
     "extract-api": "betools extract-api --entry=analytical-backend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test"
   },
   "repository": {

--- a/domains/linear-referencing/backend/package.json
+++ b/domains/linear-referencing/backend/package.json
@@ -15,7 +15,7 @@
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../../generated-docs/extract --json=../../../generated-docs/domains/linear-referencing-backend/file.json --tsIndexFile=./linear-referencing-backend.ts --onlyJson",
     "extract-api": "betools extract-api --entry=linear-referencing-backend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test"
   },
   "repository": {

--- a/domains/linear-referencing/common/package.json
+++ b/domains/linear-referencing/common/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../../generated-docs/extract --json=../../../generated-docs/domains/linear-referencing-common/file.json --tsIndexFile=./linear-referencing-common.ts --onlyJson",
     "extract-api": "betools extract-api --entry=linear-referencing-common",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": ""
   },
   "repository": {

--- a/domains/physical-material/backend/package.json
+++ b/domains/physical-material/backend/package.json
@@ -14,7 +14,7 @@
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../../generated-docs/extract --json=../../../generated-docs/domains/physical-material-backend/file.json --tsIndexFile=./physical-material-backend.ts --onlyJson",
     "extract-api": "betools extract-api --entry=physical-material-backend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "betools test"
   },
   "repository": {

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -12,7 +12,7 @@
     "copy:test-backend-assets": "cpx \"./src/backend/test/assets/**/*\" ./lib/backend/test/assets",
     "extract": "betools extract --fileExt=ts --extractFrom=./src --recursive --out=../../generated-docs/extract",
     "docs": "npm run extract && npm run extract-assets",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run copy:test-backend-assets && npm run copy:backend-assets && betools test --defineWindow --testDir=\"./lib/backend/test\"",
     "cover": "npm test"
   },

--- a/example-code/snippets/package.json
+++ b/example-code/snippets/package.json
@@ -10,7 +10,7 @@
     "copy:assets": "cpx \"./src/backend/assets/**/*\" ./lib/backend/assets",
     "extract": "betools extract --fileExt=ts --extractFrom=./src --recursive --out=../../generated-docs/extract",
     "docs": "npm run copy:assets && npm run extract",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run test:backend",
     "test:backend": "npm run copy:assets && betools test --testDir=\"./lib\"",
     "cover": "npm test"

--- a/extensions/geonames/package.json
+++ b/extensions/geonames/package.json
@@ -11,7 +11,7 @@
     "copy:assets": "cpx \"./src/public/**/*\" ./lib/extension/",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": ""
   },
   "keywords": [

--- a/extensions/iot-demo/package.json
+++ b/extensions/iot-demo/package.json
@@ -12,7 +12,7 @@
     "copy:assets": "cpx \"./src/public/**/*\" ./lib/extension/",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir=./src/public/locales/en --out=./lib/extension/locales/en-PSEUDO",
     "test": ""
   },

--- a/extensions/map-layers/package.json
+++ b/extensions/map-layers/package.json
@@ -14,7 +14,7 @@
     "copy:assets": "cpx \"./src/**/*.{*css,json,svg}\" \"./lib\" && cpx \"./src/public/locales/**/*\" ./lib/extension/locales/",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir=./src/public/locales/en --out=./lib/extension/locales/en-PSEUDO",
     "test": ""
   },

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -11,7 +11,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json coverage",
     "cover": "npm run test:chrome -- --cover && npm run test:electron -- --cover",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run test:chrome && npm run test:electron",
     "test:chrome": "certa -r chrome --grep \"#integration\" --invert",
     "test:electron": "certa -r electron --grep \"#integration\" --invert",

--- a/full-stack-tests/imodelhub-client/package.json
+++ b/full-stack-tests/imodelhub-client/package.json
@@ -18,7 +18,7 @@
     "cover:backend-itwin-client": "nyc --nycrc-path=backend-itwin-client.nycrc npm test",
     "cover:itwin-client": "nyc --nycrc-path=itwin-client.nycrc npm test",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pretest": "npm run copy:test-assets",
     "test": "npm run pretest && betools test --offline=\"mock\" --grep=\"#integration\" --invert --testDir ./lib",
     "test:integration": "npm run pretest && betools test --grep=\"#unit\" --invert --testDir ./lib",

--- a/full-stack-tests/native-app/package.json
+++ b/full-stack-tests/native-app/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json coverage",
     "cover": "npm run test:chrome -- --cover && npm run test:electron -- --cover",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run test:chrome && npm run test:electron",
     "test:chrome": "certa -r chrome --grep \"#integration\" --invert",
     "test:electron": "certa -r electron --grep \"#integration\" --invert",

--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "npm run extract",
     "extract": "betools extract --fileExt=ts --extractFrom=./src --recursive --out=../../generated-docs/extract",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "cross-env NODE_ENV=development mocha --opts ./mocha.opts \"./lib/**/*.js\" --grep \"#with-services\" --invert",
     "test:integration": "mocha --opts ./mocha.opts \"./lib/**/*.js\" --grep \"#with-services\"",
     "cover": "npm run test"

--- a/full-stack-tests/rpc-interface/package.json
+++ b/full-stack-tests/rpc-interface/package.json
@@ -10,7 +10,7 @@
     "copy:files": "cpx \"./rulesets/**/*\" ./lib/rulesets/",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "optest": "certa -r chrome --fgrep \"Operational: \"",
     "start:backend": "node ./lib/test/backend.js",
     "test": "",

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json coverage",
     "cover": "npm test",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run test:chrome && npm run test:electron",
     "test:chrome": "certa -r chrome -b ./lib/backend/http.js",
     "test:electron": "certa -r electron -b ./lib/backend/electron.js",

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -32,7 +32,7 @@
     "docs:reference": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/presentation/presentation-backend/file.json --tsIndexFile=presentation-backend.ts --onlyJson",
     "extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=../../generated-docs/extract",
     "extract-api": "betools extract-api --entry=presentation-backend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "mocha --opts ../mocha.opts --file ./lib/test/index.test.js \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts --watch"
   },

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -36,7 +36,7 @@
     "ruleset-json-schema": "npm run ruleset-json-schema:generate && npm run ruleset-json-schema:post-process",
     "ruleset-json-schema:generate": "typescript-json-schema ./tsconfig.json Ruleset --noExtraProps --required --strictNullChecks --include ./src/presentation-common/rules/**/*.ts --include ./src/presentation-common/rules/*.ts > ./Ruleset.schema.json",
     "ruleset-json-schema:post-process": "node ./scripts/post-process-json-schema.js --path ./Ruleset.schema.json",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize:assets": "betools pseudolocalize --englishDir ./assets/locales/en --out ./lib/assets/locales/en-PSEUDO",
     "pseudolocalize:public": "betools pseudolocalize --englishDir ./assets/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "mocha --opts ../mocha.opts \"./lib/test/**/*.test.js\"",

--- a/presentation/components/package.json
+++ b/presentation/components/package.json
@@ -36,7 +36,7 @@
     "docs:reference": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/presentation/presentation-components/file.json --tsIndexFile=presentation-components.ts --onlyJson --excludeGlob=**/presentation-components.ts",
     "extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=../../generated-docs/extract",
     "extract-api": "betools extract-api --entry=presentation-components",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./lib/public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "mocha --opts ../mocha.opts -r ignore-styles -r jsdom-global/register --file ./lib/test/index.test.js \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts,tsx --watch"

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -34,7 +34,7 @@
     "docs:reference": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/presentation/presentation-frontend/file.json --tsIndexFile=presentation-frontend.ts --onlyJson",
     "extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=../../generated-docs/extract",
     "extract-api": "betools extract-api --entry=presentation-frontend",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./lib/public/locales/en --out ./lib/public/locales/en-PSEUDO",
     "test": "mocha -r jsdom-global/register --opts ../mocha.opts \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts --watch"

--- a/presentation/testing/package.json
+++ b/presentation/testing/package.json
@@ -30,7 +30,7 @@
     "docs:reference": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/presentation/presentation-testing/json/file.json --tsIndexFile=presentation-testing.ts --onlyJson",
     "extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=../../generated-docs/extract",
     "extract-api": "betools extract-api --entry=presentation-testing",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "mocha -r ignore-styles -r jsdom-global/register --opts ../mocha.opts \"./lib/test/**/*.test.js\""
   },
   "devDependencies": {

--- a/test-apps/analysis-importer/package.json
+++ b/test-apps/analysis-importer/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "npm run build",
     "build": "tsc 1>&2 && npm run extract-assets",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json ../../generated-docs",
     "extract-assets": "cpx assets/**/*  lib/assets/",
     "test": "",

--- a/test-apps/export-gltf/package.json
+++ b/test-apps/export-gltf/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "npm run build",
     "build": "tsc 1>&2",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "test": "",
     "docs": "",

--- a/test-apps/export-obj/package.json
+++ b/test-apps/export-obj/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "npm run build",
     "build": "tsc 1>&2",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "test": "",
     "docs": "",

--- a/test-apps/imjs-importer/package.json
+++ b/test-apps/imjs-importer/package.json
@@ -12,7 +12,7 @@
     "docs": "",
     "test": "",
     "cover": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "blint": "npm run build && npm run lint",
     "main1": "node lib/main.js",
     "byDirectory": "node lib/byDirectory.js --input=CurveFactory --output=abc",

--- a/test-apps/imodel-from-geojson/package.json
+++ b/test-apps/imodel-from-geojson/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": ""
   },
   "repository": {},

--- a/test-apps/imodel-from-orbitgt/package.json
+++ b/test-apps/imodel-from-orbitgt/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": ""
   },
   "repository": {},

--- a/test-apps/imodel-from-reality-model/package.json
+++ b/test-apps/imodel-from-reality-model/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": ""
   },
   "repository": {},

--- a/test-apps/synchro-schedule-importer/package.json
+++ b/test-apps/synchro-schedule-importer/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "npm run build",
     "build": "npm run build-code && npm run extract-assets",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "build-code": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json ../../generated-docs",
     "extract-assets": "cpx assets/**/*  lib/assets/",

--- a/test-apps/ui-test-extension/package.json
+++ b/test-apps/ui-test-extension/package.json
@@ -12,7 +12,7 @@
     "copy:assets": "cpx \"./src/**/*.{*css,json,svg}\" \"./lib\" && cpx \"./src/public/locales/**/*\" ./lib/extension/locales/",
     "cover": "",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir=./src/public/locales/en --out=./lib/extension/locales/en-PSEUDO",
     "test": ""
   },

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -15,7 +15,7 @@
     "compile": "npm run build",
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "docs": "",
     "cover": ""

--- a/tools/config-loader/package.json
+++ b/tools/config-loader/package.json
@@ -13,7 +13,7 @@
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "extract-api": "betools extract-api --entry=index",
     "test": "",
     "cover": ""

--- a/tools/ecschema2ts/package.json
+++ b/tools/ecschema2ts/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "copy:test-assets": "cpx \"./src/test/assets/**/*\" ./lib/test/assets",
     "extract-api": "betools extract-api --entry=ecschema2ts",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "docs": "",
     "test": "betools test",
     "test:watch": "betools test-tsnode --watch",

--- a/tools/extension-cli/package.json
+++ b/tools/extension-cli/package.json
@@ -15,7 +15,7 @@
     "compile": "npm run build",
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "wip-test:integration": "betools test --defineWindow --testDir=\"./lib/test\"",
     "docs": "",

--- a/tools/oidc-signin-tool/package.json
+++ b/tools/oidc-signin-tool/package.json
@@ -13,7 +13,7 @@
     "compile": "npm run build",
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "test:integration": "betools test",
     "docs": "",

--- a/tools/webpack-core/package.json
+++ b/tools/webpack-core/package.json
@@ -17,7 +17,7 @@
     "build": "tsc 1>&2",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "docs": "",
-    "lint": "eslint -f visualstudio ./src/**/*.ts 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
     "cover": ""
   },

--- a/ui/abstract/package.json
+++ b/ui/abstract/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/ui-abstract/file.json --tsIndexFile=./ui-abstract.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "extract-api": "betools extract-api --entry=ui-abstract",
     "test": "mocha --opts ../mocha.opts \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts,tsx --watch"

--- a/ui/components/package.json
+++ b/ui/components/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/ui-components/file.json --tsIndexFile=./ui-components.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "extract-api": "betools extract-api --entry=ui-components",
     "test": "mocha --opts ../mocha.opts \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts,tsx --watch"

--- a/ui/framework/package.json
+++ b/ui/framework/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "nyc npm test",
     "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/ui-framework/file.json --tsIndexFile=./ui-framework.ts --onlyJson",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "extract-api": "betools extract-api --entry=ui-framework",
     "test": "mocha --opts ../mocha.opts \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts,tsx --watch"

--- a/ui/ninezone/package.json
+++ b/ui/ninezone/package.json
@@ -19,7 +19,7 @@
     "docs": "npm run docs:typedoc",
     "docs:typedoc": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/ui-ninezone/file.json --tsIndexFile=./ui-ninezone.ts --onlyJson",
     "extract-api": "betools extract-api --entry=ui-ninezone",
-    "lint": "eslint -f visualstudio ./src/**/*.{ts,tsx} 1>&2",
+    "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "test": "mocha --opts ../mocha.opts \"./lib/test/**/*.test.js\"",
     "test:watch": "npm test -- --reporter min --watch-extensions ts,tsx --watch"
   },


### PR DESCRIPTION
ESLint glob patterns have the same issue as cpx where it needs to be surrounded by quotes and since `'` doesn't work on Windows, adding `\"` around each pattern.