### PR TITLE
Presentation: Make navigation property values be instance keys

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -187,11 +187,7 @@ export interface ClassInfoJSON {
 }
 
 // @public
-export type ComputeDisplayValueCallback = (type: string, value: string | number | boolean | {
-    x: number;
-    y: number;
-    z?: number;
-} | undefined, displayValue: string) => Promise<string>;
+export type ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise<string>;
 
 // @public
 export interface ConditionContainer {
@@ -1654,6 +1650,9 @@ export enum PresentationUnitSystem {
     // (undocumented)
     UsSurvey = "us-survey"
 }
+
+// @public
+export type PrimitivePropertyValue = string | number | boolean | Point | InstanceKey | undefined;
 
 // @public
 export interface PrimitiveTypeDescription extends BaseTypeDescription {

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -18,7 +18,7 @@ public;ClassId = Id64String
 public;ClassInfo
 public;ClassInfo
 public;ClassInfoJSON
-public;ComputeDisplayValueCallback = (type: string, value: string | number | boolean |
+public;ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise
 public;ConditionContainer
 public;Content
 beta;ContentDescriptorRequestOptions
@@ -206,6 +206,7 @@ public;PresentationRpcInterface
 public;PresentationRpcRequestOptions
 public;PresentationStatus
 alpha;PresentationUnitSystem
+public;PrimitivePropertyValue = string | number | boolean | Point | InstanceKey | undefined
 public;PrimitiveTypeDescription 
 public;PropertiesField 
 beta;PropertiesFieldDescriptor 

--- a/common/api/ui-abstract.api.md
+++ b/common/api/ui-abstract.api.md
@@ -1307,7 +1307,7 @@ export namespace Primitives {
         // (undocumented)
         className: string;
         // (undocumented)
-        id: Hexadecimal;
+        id: Id64String;
     }
     export type Int = number | string;
     export type Numeric = Float | Int;

--- a/common/api/ui-abstract.api.md
+++ b/common/api/ui-abstract.api.md
@@ -1303,6 +1303,12 @@ export namespace Primitives {
     export type Enum = number | string;
     export type Float = number | string;
     export type Hexadecimal = Id64String;
+    export interface InstanceKey {
+        // (undocumented)
+        className: string;
+        // (undocumented)
+        id: Hexadecimal;
+    }
     export type Int = number | string;
     export type Numeric = Float | Int;
     export type Point = Point2d | Point3d;
@@ -1319,7 +1325,7 @@ export namespace Primitives {
     export type String = string;
     export type Text = string;
     // (undocumented)
-    export type Value = Text | String | ShortDate | Boolean | Numeric | Enum | Point | Composite;
+    export type Value = Text | String | ShortDate | Boolean | Numeric | Enum | Point | Composite | InstanceKey;
 }
 
 // @beta

--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -2834,9 +2834,9 @@ export interface NavCubeFaceProps extends React.AllHTMLAttributes<HTMLDivElement
 // @public
 export class NavigationPropertyTypeConverter extends TypeConverter {
     // (undocumented)
-    convertPropertyToString(propertyDescription: PropertyDescription, value?: Primitives.Hexadecimal): string;
+    convertPropertyToString(propertyDescription: PropertyDescription, value?: Primitives.Value): string;
     // (undocumented)
-    sortCompare(a: Primitives.Hexadecimal, b: Primitives.Hexadecimal, ignoreCase?: boolean): number;
+    sortCompare(a: Primitives.Value, b: Primitives.Value, ignoreCase?: boolean): number;
 }
 
 // @public

--- a/common/changes/@bentley/presentation-common/presentation-navigation-instancekey_2020-12-22-08-51.json
+++ b/common/changes/@bentley/presentation-common/presentation-navigation-instancekey_2020-12-22-08-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Add class information to navigation properties",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/presentation-navigation-instancekey_2020-12-22-08-51.json
+++ b/common/changes/@bentley/presentation-components/presentation-navigation-instancekey_2020-12-22-08-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "Add class information to navigation properties",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-abstract/presentation-navigation-instancekey_2020-12-22-08-51.json
+++ b/common/changes/@bentley/ui-abstract/presentation-navigation-instancekey_2020-12-22-08-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-abstract",
+      "comment": "Add InstanceKey type description",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-abstract",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-components/presentation-navigation-instancekey_2020-12-22-08-51.json
+++ b/common/changes/@bentley/ui-components/presentation-navigation-instancekey_2020-12-22-08-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Update `NavigationPropertyTypeConverter` to handle navigation properties represented by `InstanceKey`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/src/frontend/providers/PropertyPaneDataProvider.test.snap
+++ b/full-stack-tests/presentation/src/frontend/providers/PropertyPaneDataProvider.test.snap
@@ -310,7 +310,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalModel",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -336,7 +339,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Uncategorized",
-          "value": "0x17",
+          "value": Object {
+            "className": "BisCore:SpatialCategory",
+            "id": "0x17",
+          },
           "valueFormat": 0,
         },
       },
@@ -1595,7 +1601,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -1644,7 +1653,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -1660,7 +1672,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -2123,7 +2138,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalModel",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -2149,7 +2167,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Uncategorized",
-          "value": "0x17",
+          "value": Object {
+            "className": "BisCore:SpatialCategory",
+            "id": "0x17",
+          },
           "valueFormat": 0,
         },
       },
@@ -3410,7 +3431,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -3471,7 +3495,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -3487,7 +3514,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },

--- a/full-stack-tests/presentation/src/frontend/providers/TableDataProvider.test.snap
+++ b/full-stack-tests/presentation/src/frontend/providers/TableDataProvider.test.snap
@@ -39,7 +39,10 @@ Object {
         },
         "value": Object {
           "displayValue": "Properties_60InstancesWithUrl2",
-          "value": "0x1c",
+          "value": Object {
+            "className": "BisCore:PhysicalPartition",
+            "id": "0x1c",
+          },
           "valueFormat": 0,
         },
       },
@@ -86,7 +89,10 @@ Array [
           },
           "value": Object {
             "displayValue": "BisCore.DictionaryModel",
-            "value": "0x10",
+            "value": Object {
+              "className": "BisCore:DefinitionPartition",
+              "id": "0x10",
+            },
             "valueFormat": 0,
           },
         },
@@ -108,7 +114,10 @@ Array [
           },
           "value": Object {
             "displayValue": "Properties_60InstancesWithUrl2",
-            "value": "0x1c",
+            "value": Object {
+              "className": "BisCore:PhysicalPartition",
+              "id": "0x1c",
+            },
             "valueFormat": 0,
           },
         },
@@ -135,7 +144,10 @@ Array [
           },
           "value": Object {
             "displayValue": "Properties_60InstancesWithUrl2",
-            "value": "0x1c",
+            "value": Object {
+              "className": "BisCore:PhysicalPartition",
+              "id": "0x1c",
+            },
             "valueFormat": 0,
           },
         },
@@ -157,7 +169,10 @@ Array [
           },
           "value": Object {
             "displayValue": "BisCore.DictionaryModel",
-            "value": "0x10",
+            "value": Object {
+              "className": "BisCore:DefinitionPartition",
+              "id": "0x10",
+            },
             "valueFormat": 0,
           },
         },

--- a/presentation/common/src/test/RulesetsFactory.test.ts
+++ b/presentation/common/src/test/RulesetsFactory.test.ts
@@ -441,7 +441,7 @@ describe("RulesetsFactory", () => {
       const field = new PropertiesField(createRandomCategory(), "MyProperty",
         "My Property", createNavigationPropertyTypeDescription(), true, 1, [property]);
       const record = new Item([], faker.random.word(), "", recordClass,
-        { ["MyProperty"]: "0x16" }, { ["MyProperty"]: "test display value" }, []);
+        { ["MyProperty"]: { className: "MySchema:MyClass", id: "0x16"} }, { ["MyProperty"]: "test display value" }, []);
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [{
         ruleType: RuleTypes.Content,
@@ -1135,27 +1135,28 @@ describe("RulesetsFactory", () => {
     });
 
     describe("invalid conditions", () => {
-
-      it("throws when record contains invalid value", async () => {
-        const recordClass: ClassInfo = {
-          id: createRandomId(),
-          name: "MySchema:MyClass",
-          label: "My Class",
-        };
-        const property: Property = {
-          property: {
-            classInfo: recordClass,
-            type: "boolean",
-            name: "MyProperty",
-          },
-          relatedClassPath: [],
-        };
-        const field = new PropertiesField(createRandomCategory(), "MyProperty",
-          faker.random.word(), createBooleanTypeDescription(), true, 1, [property]);
-        const record = new Item([], faker.random.word(), "", recordClass,
-          { ["MyProperty"]: [] }, { ["MyProperty"]: "" }, []);
-        await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith("Can only create 'similar instances' ruleset for primitive values");
-      });
+      for (const invalidValue of [[], {}]) {
+        it(`throws when record value is '${invalidValue}'`, async () => {
+          const recordClass: ClassInfo = {
+            id: createRandomId(),
+            name: "MySchema:MyClass",
+            label: "My Class",
+          };
+          const property: Property = {
+            property: {
+              classInfo: recordClass,
+              type: "boolean",
+              name: "MyProperty",
+            },
+            relatedClassPath: [],
+          };
+          const field = new PropertiesField(createRandomCategory(), "MyProperty",
+            faker.random.word(), createBooleanTypeDescription(), true, 1, [property]);
+          const record = new Item([], faker.random.word(), "", recordClass,
+            { ["MyProperty"]: invalidValue }, { ["MyProperty"]: "" }, []);
+          await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith("Can only create 'similar instances' ruleset for primitive values");
+        });
+      }
 
       it("throws when properties field contains no properties", async () => {
         const recordClass: ClassInfo = {

--- a/presentation/components/src/presentation-components/DataProvidersFactory.ts
+++ b/presentation/components/src/presentation-components/DataProvidersFactory.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { Omit, RulesetsFactory } from "@bentley/presentation-common";
+import { Omit, PrimitivePropertyValue, RulesetsFactory } from "@bentley/presentation-common";
 import { PropertyRecord } from "@bentley/ui-abstract";
 import { TypeConverterManager } from "@bentley/ui-components";
 import { findField } from "./common/Utils";
@@ -36,9 +36,9 @@ export class DataProvidersFactory {
     this._rulesetsFactory = props && props.rulesetsFactory ? props.rulesetsFactory : new RulesetsFactory();
   }
 
-  private async computeDisplayValue(typename: string, value: string | number | boolean | { x: number, y: number, z?: number } | undefined, displayValue: string): Promise<string> {
+  private async computeDisplayValue(typename: string, value: PrimitivePropertyValue, displayValue: string): Promise<string> {
     if (typename === "navigation") {
-      // note: type converters can't convert raw navigation value (ECInstanceId) to
+      // note: type converters can't convert raw navigation value (InstanceKey) to
       // display value - we have to use what's stored in the property record (supplied
       // display value)
       return displayValue;

--- a/ui/abstract/src/ui-abstract/properties/PrimitiveTypes.ts
+++ b/ui/abstract/src/ui-abstract/properties/PrimitiveTypes.ts
@@ -56,7 +56,7 @@ export namespace Primitives {
   /** Instance key type. */
   export interface InstanceKey {
     className: string;
-    id: Hexadecimal;
+    id: Id64String;
   }
 
   export type Value = Text | String | ShortDate | Boolean | Numeric | Enum | Point | Composite | InstanceKey;

--- a/ui/abstract/src/ui-abstract/properties/PrimitiveTypes.ts
+++ b/ui/abstract/src/ui-abstract/properties/PrimitiveTypes.ts
@@ -32,13 +32,13 @@ export namespace Primitives {
   export type Enum = number | string;
   /** Numeric type (can be float or int) */
   export type Numeric = Float | Int;
-  /** Point2d type (contains an x and a y coordinate) */
 
+  /** Point2d type (contains an x and a y coordinate) */
   export type Point2d = string[] | number[] | { x: number, y: number };
   /** Point3d type (contains x,y,and z coordinates) */
   export type Point3d = string[] | number[] | { x: number, y: number, z: number };
-  /** Point type (can be a 2d or 3d point) */
 
+  /** Point type (can be a 2d or 3d point) */
   export type Point = Point2d | Point3d;
 
   /** CompositePart (ties a raw value of a specific type to a display string) */
@@ -53,6 +53,11 @@ export namespace Primitives {
     parts: CompositePart[];
   }
 
-  // eslint-disable-next-line
-  export type Value = Text | String | ShortDate | Boolean | Numeric | Enum | Point | Composite;
+  /** Instance key type. */
+  export interface InstanceKey {
+    className: string;
+    id: Hexadecimal;
+  }
+
+  export type Value = Text | String | ShortDate | Boolean | Numeric | Enum | Point | Composite | InstanceKey;
 }

--- a/ui/components/src/test/TestUtils.ts
+++ b/ui/components/src/test/TestUtils.ts
@@ -6,7 +6,8 @@ import { ColorByName } from "@bentley/imodeljs-common";
 import { I18N } from "@bentley/imodeljs-i18n";
 import {
   ArrayValue, BasePropertyEditorParams, ButtonGroupEditorParams, ColorEditorParams, CustomFormattedNumberParams, ImageCheckBoxParams, ParseResults,
-  PrimitiveValue, PropertyDescription, PropertyEditorInfo, PropertyEditorParamTypes, PropertyRecord, PropertyValueFormat, StandardEditorNames, StandardTypeNames, StructValue,
+  Primitives, PrimitiveValue, PropertyDescription, PropertyEditorInfo, PropertyEditorParamTypes, PropertyRecord, PropertyValueFormat,
+  StandardEditorNames, StandardTypeNames, StructValue,
 } from "@bentley/ui-abstract";
 import { ColumnDescription, CompositeFilterDescriptorCollection, FilterableTable, UiComponents } from "../ui-components";
 import { TableFilterDescriptorCollection } from "../ui-components/table/columnfiltering/TableFilterDescriptorCollection";
@@ -386,6 +387,17 @@ export class TestUtils {
     const propertyRecord = new PropertyRecord(value, description);
     propertyRecord.isReadonly = false;
     return propertyRecord;
+  }
+
+  public static createNavigationProperty(
+    name: string,
+    value: Primitives.InstanceKey,
+    displayValue?: string,
+  ): PropertyRecord {
+    const property = TestUtils.createPrimitiveStringProperty(name, "", displayValue);
+    property.property.typename = "navigation";
+    (property.value as PrimitiveValue).value = value;
+    return property;
   }
 }
 

--- a/ui/components/src/test/converters/NavigationPropertyTypeConverter.test.ts
+++ b/ui/components/src/test/converters/NavigationPropertyTypeConverter.test.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { PrimitiveValue } from "@bentley/ui-abstract";
+import { expect } from "chai";
+import { NavigationPropertyTypeConverter } from "../../ui-components/converters/NavigationPropertyTypeConverter";
+import { TestUtils } from "../TestUtils";
+
+describe("NavigationPropertyTypeConverter", () => {
+  const converter = new NavigationPropertyTypeConverter();
+  describe("convertPropertyToString", () => {
+    it("returns property description display label when value is not undefined", () => {
+      const record = TestUtils.createNavigationProperty("test_property", { className: "", id: "0x1" }, "test_value");
+      const { property, value } = record;
+      const convertedString = converter.convertPropertyToString(property, (value as PrimitiveValue).value);
+      expect(convertedString).to.be.equal("test_property");
+    });
+
+    it("returns empty string when value is undefined", () => {
+      const record = TestUtils.createNavigationProperty("test_property", { className: "", id: "0x1" }, "test_value");
+      const convertedString = converter.convertPropertyToString(record.property, undefined);
+      expect(convertedString).to.be.equal("");
+    });
+  });
+
+  describe("sortCompare", () => {
+    it("compares two navigation property values", () => {
+      const { value: a } = TestUtils.createNavigationProperty("test_property", { className: "", id: "0x1" });
+      const { value: b } = TestUtils.createNavigationProperty("test_property", { className: "", id: "0x2" });
+      const result = converter.sortCompare((a as PrimitiveValue).value!, (b as PrimitiveValue).value!);
+      expect(result).to.be.equal(-1);
+    });
+
+    it("does not throw when handling non-navigation property values", () => {
+      const result = converter.sortCompare(1, 2);
+      expect(result).to.be.equal(0);
+    });
+  });
+});

--- a/ui/components/src/test/properties/renderers/value/NavigationPropertyValueRenderer.test.tsx
+++ b/ui/components/src/test/properties/renderers/value/NavigationPropertyValueRenderer.test.tsx
@@ -6,24 +6,18 @@ import { expect } from "chai";
 import * as React from "react";
 import * as sinon from "sinon";
 import { Id64 } from "@bentley/bentleyjs-core";
-import { Primitives, PrimitiveValue } from "@bentley/ui-abstract";
 import { render } from "@testing-library/react";
 import { NavigationPropertyValueRenderer } from "../../../../ui-components/properties/renderers/value/NavigationPropertyValueRenderer";
 import { PropertyValueRendererContext } from "../../../../ui-components/properties/ValueRendererManager";
 import TestUtils from "../../../TestUtils";
 
-function createNavigationProperty(value: Primitives.Hexadecimal, displayValue?: string) {
-  const property = TestUtils.createPrimitiveStringProperty("Category", "", displayValue);
-  property.property.typename = "navigation";
-  (property.value as PrimitiveValue).value = value;
-  return property;
-}
-
 describe("NavigationPropertyValueRenderer", () => {
+  const instanceKey = { className: "", id: Id64.fromUint32Pair(1, 0) };
+
   describe("render", () => {
     it("renders navigation property from display value", () => {
       const renderer = new NavigationPropertyValueRenderer();
-      const property = createNavigationProperty(Id64.fromUint32Pair(1, 0), "Rod");
+      const property = TestUtils.createNavigationProperty("Category", instanceKey, "Rod");
 
       const element = renderer.render(property);
       const elementRender = render(<>{element}</>);
@@ -33,7 +27,7 @@ describe("NavigationPropertyValueRenderer", () => {
 
     it("renders navigation property from raw value", () => {
       const renderer = new NavigationPropertyValueRenderer();
-      const property = createNavigationProperty(Id64.fromUint32Pair(1, 0), "");
+      const property = TestUtils.createNavigationProperty("Category", instanceKey, "");
 
       const element = renderer.render(property);
       const elementRender = render(<>{element}</>);
@@ -79,7 +73,7 @@ describe("NavigationPropertyValueRenderer", () => {
   describe("canRender", () => {
     it("returns true for a navigation property", () => {
       const renderer = new NavigationPropertyValueRenderer();
-      const property = createNavigationProperty(Id64.fromUint32Pair(1, 0));
+      const property = TestUtils.createNavigationProperty("Category", instanceKey);
       expect(renderer.canRender(property)).to.be.true;
     });
 

--- a/ui/components/src/ui-components/converters/NavigationPropertyTypeConverter.ts
+++ b/ui/components/src/ui-components/converters/NavigationPropertyTypeConverter.ts
@@ -2,7 +2,8 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-/** @packageDocumentation
+/**
+ * @packageDocumentation
  * @module TypeConverters
  */
 
@@ -11,19 +12,18 @@ import { TypeConverter } from "./TypeConverter";
 import { TypeConverterManager } from "./TypeConverterManager";
 
 /**
- * Navigation property type converter
+ * Navigation property type converter.
  * @public
  */
-// istanbul ignore next
 export class NavigationPropertyTypeConverter extends TypeConverter {
-  public convertPropertyToString(propertyDescription: PropertyDescription, value?: Primitives.Hexadecimal) {
-    if (value === undefined)
-      return "";
-    return propertyDescription.displayLabel;
+  public convertPropertyToString(propertyDescription: PropertyDescription, value?: Primitives.Value) {
+    return value === undefined ? "" : propertyDescription.displayLabel;
   }
 
-  public sortCompare(a: Primitives.Hexadecimal, b: Primitives.Hexadecimal, ignoreCase?: boolean): number {
-    return TypeConverterManager.getConverter(StandardTypeNames.Hexadecimal).sortCompare(a, b, ignoreCase);
+  public sortCompare(a: Primitives.Value, b: Primitives.Value, ignoreCase?: boolean): number {
+    return TypeConverterManager
+      .getConverter(StandardTypeNames.Hexadecimal)
+      .sortCompare((a as Primitives.InstanceKey).id, (b as Primitives.InstanceKey).id, ignoreCase);
   }
 }
 


### PR DESCRIPTION
In addition to instance id, navigation properties now also have information of related instance's class id. This greatly increases navigation property value usefulness as it can now be treated as an instance key.

This is a **breaking change**, however only uncommon Presentation use cases are affected.