### PR TITLE
Match global reality model height to match background map bias (bp #367)

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -6796,6 +6796,8 @@ export class RealityTreeReference extends RealityModelTileTree.Reference {
     // (undocumented)
     collectStatistics(stats: RenderMemory.Statistics): void;
     // (undocumented)
+    createDrawArgs(context: SceneContext): TileDrawArgs | undefined;
+    // (undocumented)
     discloseTileTrees(trees: TileTreeSet): void;
     // (undocumented)
     getToolTip(hit: HitDetail): Promise<HTMLElement | string | undefined>;

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -2070,6 +2070,8 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     // @internal (undocumented)
     get backgroundMapBase(): BaseLayerSettings | undefined;
     // @internal (undocumented)
+    get backgroundMapElevationBias(): number;
+    // @internal (undocumented)
     get backgroundMapLayers(): MapLayerSettings[];
     get backgroundMapSettings(): BackgroundMapSettings;
     set backgroundMapSettings(settings: BackgroundMapSettings);

--- a/common/changes/@bentley/imodeljs-frontend/match-global-building-height-to-non-geodetic-terrain_2020-12-04-19-50.json
+++ b/common/changes/@bentley/imodeljs-frontend/match-global-building-height-to-non-geodetic-terrain_2020-12-04-19-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Bias global reality models to match terrain corrections.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "rbbentley@users.noreply.github.com"
+}

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -653,15 +653,23 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
   }
 
   /** @internal */
-  public getBackgroundMapGeometry(): BackgroundMapGeometry | undefined {
-    if (undefined === this.iModel.ecefLocation)
-      return undefined;
-
+  public get backgroundMapElevationBias(): number {
     let bimElevationBias = this.backgroundMapSettings.groundBias;
     const mapTree = this.backgroundMap.treeOwner.load() as MapTileTree;
 
     if (mapTree !== undefined)
       bimElevationBias = mapTree.bimElevationBias;    // Terrain trees calculate their bias when loaded (sea level or ground offset).
+
+    return bimElevationBias;
+  }
+
+  /** @internal */
+  public getBackgroundMapGeometry(): BackgroundMapGeometry | undefined {
+    if (undefined === this.iModel.ecefLocation)
+      return undefined;
+
+    const bimElevationBias = this.backgroundMapElevationBias;
+
 
     const globeMode = this.globeMode;
     if (undefined === this._backgroundMapGeometry || this._backgroundMapGeometry.globeMode !== globeMode || this._backgroundMapGeometry.bimElevationBias !== bimElevationBias) {

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -22,7 +22,7 @@ import { SceneContext } from "../ViewContext";
 import { ViewState } from "../ViewState";
 import {
   BatchedTileIdMap, createClassifierTileTreeReference, getCesiumAccessTokenAndEndpointUrl, RealityTile, RealityTileLoader, RealityTileParams,
-  RealityTileTree, RealityTileTreeParams, SpatialClassifierTileTreeReference, Tile, TileLoadPriority, TileRequest, TileTree, TileTreeOwner,
+  RealityTileTree, RealityTileTreeParams, SpatialClassifierTileTreeReference, Tile, TileDrawArgs, TileLoadPriority, TileRequest, TileTree, TileTreeOwner,
   TileTreeReference, TileTreeSet, TileTreeSupplier,
 } from "./internal";
 import { createDefaultViewFlagOverrides } from "./ViewFlagOverrides";
@@ -380,18 +380,17 @@ export type RealityModelSource = ViewState | DisplayStyleState;
 
 /** @internal */
 export class RealityModelTileTree extends RealityTileTree {
+  private readonly _isContentUnbounded: boolean;
   public constructor(params: RealityTileTreeParams) {
     super(params);
 
+    this._isContentUnbounded = this.rootTile.contentRange.diagonal().magnitude() > 2 * Constant.earthRadiusWGS84.equator;
     if (!this.isContentUnbounded && !this.rootTile.contentRange.isNull) {
       const worldContentRange = this.iModelTransform.multiplyRange(this.rootTile.contentRange);
       this.iModel.expandDisplayedExtents(worldContentRange);
     }
   }
-  public get isContentUnbounded() {
-    return this.rootTile.contentRange.diagonal().magnitude() > 2 * Constant.earthRadiusWGS84.equator;
-  }
-
+  public get isContentUnbounded() { return this._isContentUnbounded; }
 }
 
 /** @internal */
@@ -502,6 +501,20 @@ export class RealityTreeReference extends RealityModelTileTree.Reference {
   }
 
   public get classifiers(): SpatialClassifiers | undefined { return undefined !== this._classifier ? this._classifier.classifiers : undefined; }
+  public createDrawArgs(context: SceneContext): TileDrawArgs | undefined {
+    // For global reality models (OSM Building layer only) - offset the reality model by the BIM elevation bias.  This would not be necessary
+    // if iModels had their elevation set correctly but unfortunately many GCS erroneously report Sea (Geoid) elevation rather than
+    // Geodetic.
+    const tree = this.treeOwner.load();
+    if (undefined === tree)
+      return undefined;
+
+    const drawArgs = super.createDrawArgs(context);
+    if (drawArgs !== undefined && this._iModel.isGeoLocated && tree.isContentUnbounded)
+      drawArgs.location.origin.z += context.viewport.displayStyle.backgroundMapElevationBias;
+
+    return drawArgs;
+  }
 
   public addToScene(context: SceneContext): void {
     // NB: The classifier must be added first, so we can find it when adding our own tiles.


### PR DESCRIPTION
* Bias global reality models to match background map.

* extract-api and changes

* Calculate isContentUnbounded once for reality model tile trees

* Simplify createDrawArgs

* Fix private/public mismatch on _isContentUnbounded

* Fix lint errors

Co-authored-by: Ray.Bentley <rbbentley@users.noreply.github.com>
Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>