### PR TITLE
Do semantic version comparison in the iModelJsLibraryImportsPlugin fo…

### DIFF
--- a/common/changes/@bentley/webpack-tools-core/check-version-semantically-imports-plugin-webpack_2021-01-05-15-39.json
+++ b/common/changes/@bentley/webpack-tools-core/check-version-semantically-imports-plugin-webpack_2021-01-05-15-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webpack-tools-core",
+      "comment": "Add function to check versions semantically ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webpack-tools-core",
+  "email": "22119573+nick4598@users.noreply.github.com"
+}

--- a/tools/webpack-core/src/plugins/IModeljsLibraryImportsPlugin.ts
+++ b/tools/webpack-core/src/plugins/IModeljsLibraryImportsPlugin.ts
@@ -6,12 +6,32 @@
 import { Compiler } from "webpack";
 import { ConcatSource } from "webpack-sources";
 import * as utils from "./IModeljsLibraryUtils";
-
 function getLoaderString(pkgName: string, pkgVersion: string) {
-  return `  module.exports = (() => {
+  return `  const semverGte = (appVersion, extensionVersion) => {
+    const dashIndexApp = appVersion.indexOf("-");
+    const dashIndexExtension = extensionVersion.indexOf("-");
+    if (dashIndexExtension >= 0 ) {
+      console.warn("This extension depends on a nightly version of iModel.js Shared Libraries. Use in production with caution as stability is not guaranteed.");
+      extensionVersion = extensionVersion.substring(0, dashIndexExtension);
+    }
+    if (dashIndexApp >= 0) appVersion = appVersion.substring(0, dashIndexApp);
+    const appVersionSplit = appVersion.split(".").map((value) => parseInt(value));
+    const extensionVersionSplit = extensionVersion.split(".").map((value) => parseInt(value));
+    if (appVersionSplit.length !== 3)
+      throw new Error("An iModel.js Shared Library is not versioned correctly. Expected 3 numbers separated by '.' for the version");
+    if (extensionVersionSplit.length !== 3) throw new Error("Extension is not versioned correctly.Expected 3 numbers separated by '.' for the version.");
+    for (const [index, value] of appVersionSplit.entries()) {
+      if (value > extensionVersionSplit[index])
+        return true;
+      else if (value < extensionVersionSplit[index])
+        return false;
+    }
+    return true; // If we don't return while in the loop, then we're in the case where the versions are equal.
+  };
+  module.exports = (() => {
     if (!window.${utils.IMJS_GLOBAL_OBJECT} || !window.${utils.IMJS_GLOBAL_LIBS_VERS} || !window.${utils.IMJS_GLOBAL_LIBS})
       throw new Error("Expected globals are missing!");
-    if (window.${utils.IMJS_GLOBAL_LIBS_VERS}[${pkgName}] >= ${pkgVersion})
+    if (semverGte(window.${utils.IMJS_GLOBAL_LIBS_VERS}[${pkgName}], ${pkgVersion}))
       return window.${utils.IMJS_GLOBAL_LIBS}[${pkgName}];
     if (window.${utils.IMJS_GLOBAL_LIBS}[${pkgName}])
       throw new Error("iModel.js Shared Library " + ${pkgName} + " is loaded, but is an incompatible version." )
@@ -39,7 +59,6 @@ export class IModeljsLibraryImportsPlugin {
       compilation.moduleTemplates.javascript.hooks.content.tap("IModeljsLibraryImportsPlugin", (source, module) => {
         if (!module.___IS_BENTLEY)
           return source;
-
         const pkgName = JSON.stringify(module.___IMJS_NAME);
         const pkgVersion = JSON.stringify(module.___IMJS_VER);
         return new ConcatSource(getLoaderString(pkgName, pkgVersion));


### PR DESCRIPTION
…r webpack (#525)

* Add semver function for use instead of just string comparison with >=

* Rush change

* Change warning message if extension depends on dev release

Co-authored-by: Caleb Shafer <31107829+calebmshafer@users.noreply.github.com>
Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>