### PR TITLE
Fix unresponsive UI in environment editor.

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -2041,7 +2041,7 @@ export class DisplayStyle3dState extends DisplayStyleState {
     // @internal (undocumented)
     static get className(): string;
     // @internal (undocumented)
-    clone(iModel: IModelConnection): this;
+    clone(iModel?: IModelConnection): this;
     get environment(): Environment;
     set environment(env: Environment);
     // (undocumented)
@@ -11893,6 +11893,7 @@ export abstract class ViewState3d extends ViewState {
     // @beta
     get details(): ViewDetails3d;
     get displayStyle(): DisplayStyle3dState;
+    set displayStyle(style: DisplayStyle3dState);
     // @internal (undocumented)
     protected drawGroundPlane(context: DecorateContext): void;
     // @internal (undocumented)

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -11892,6 +11892,7 @@ export abstract class ViewState3d extends ViewState {
     decorate(context: DecorateContext): void;
     // @beta
     get details(): ViewDetails3d;
+    get displayStyle(): DisplayStyle3dState;
     // @internal (undocumented)
     protected drawGroundPlane(context: DecorateContext): void;
     // @internal (undocumented)
@@ -11903,7 +11904,6 @@ export abstract class ViewState3d extends ViewState {
     getBackDistance(): number;
     // (undocumented)
     getCartographicHeight(point: XYAndZ): number | undefined;
-    // (undocumented)
     getDisplayStyle3d(): DisplayStyle3dState;
     // (undocumented)
     getExtents(): Vector3d;

--- a/common/api/ui-framework.api.md
+++ b/common/api/ui-framework.api.md
@@ -46,6 +46,7 @@ import { DialogProps as DialogProps_2 } from '@bentley/ui-abstract';
 import { DialogRow } from '@bentley/ui-abstract';
 import { Direction } from '@bentley/ui-ninezone';
 import { DisabledResizeHandles } from '@bentley/ui-ninezone';
+import { DisplayStyle3dState } from '@bentley/imodeljs-frontend';
 import { DndComponentClass } from 'react-dnd';
 import { DraggedWidgetManagerProps } from '@bentley/ui-ninezone';
 import { DragLayerProps } from '@bentley/ui-components';
@@ -5043,6 +5044,8 @@ export const SnapModeField: import("react-redux").ConnectedComponent<typeof Snap
 // @alpha
 export class SolarTimelineDataProvider extends BaseSolarDataProvider {
     constructor(viewState: ViewState, viewport?: ScreenViewport, longitude?: number, latitude?: number);
+    // (undocumented)
+    protected get _displayStyle3d(): DisplayStyle3dState | undefined;
     // (undocumented)
     onTimeChanged: (time: Date) => void;
     // (undocumented)

--- a/common/changes/@bentley/imodeljs-common/fix-view-attributes-dialog_2021-01-08-15-24.json
+++ b/common/changes/@bentley/imodeljs-common/fix-view-attributes-dialog_2021-01-08-15-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/fix-view-attributes-dialog_2021-01-08-12-55.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-view-attributes-dialog_2021-01-08-12-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "The type of ViewState3d.displayStyle is DisplayStyle3dState, to reduce need to cast.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/fix-view-attributes-dialog_2021-01-08-15-00.json
+++ b/common/changes/@bentley/ui-framework/fix-view-attributes-dialog_2021-01-08-15-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/common/src/SkyBox.ts
+++ b/core/common/src/SkyBox.ts
@@ -14,15 +14,15 @@ import { ColorDefProps } from "./ColorDef";
  */
 export enum SkyBoxImageType {
   None,
-  /** A single image mapped to the surface of a sphere. @see [[SkySphere]] */
+  /** A single image mapped to the surface of a sphere. @see [SkySphere]($frontend) */
   Spherical,
-  /** 6 images mapped to the faces of a cube. @see [[SkyCube]] */
+  /** 6 images mapped to the faces of a cube. @see [SkyCube]($frontend) */
   Cube,
   /** @internal not yet supported */
   Cylindrical,
 }
 
-/** JSON representation of a set of images used by a [[SkyCube]]. Each property specifies the element ID of a texture associated with one face of the cube.
+/** JSON representation of a set of images used by a [SkyCube]($frontend). Each property specifies the element ID of a texture associated with one face of the cube.
  * @public
  */
 export interface SkyCubeProps {
@@ -40,7 +40,7 @@ export interface SkyCubeProps {
   left?: Id64String;
 }
 
-/** JSON representation of an image or images used by a [[SkySphere]] or [[SkyCube]].
+/** JSON representation of an image or images used by a [SkySphere]($frontend) or [SkyCube]($frontend).
  * @public
  */
 export interface SkyBoxImageProps {
@@ -52,26 +52,61 @@ export interface SkyBoxImageProps {
   textures?: SkyCubeProps;
 }
 
-/** JSON representation of a [SkyBox]($frontend).
+/** JSON representation of a [SkyBox]($frontend) that can be drawn as the background of a [ViewState3d]($frontend).
+ * An object of this type can describe one of several types of sky box:
+ *  - A cube with a texture image mapped to each face; or
+ *  - A sphere with a single texture image mapped to its surface; or
+ *  - A sphere with a two- or four-color vertical [[Gradient]] mapped to its surface.
+ *
+ * Whether cuboid or spherical, the skybox is drawn as if the viewer and the contents of the view are contained within its interior.
+ *
+ * For a two-color gradient, the gradient transitions smoothly from the nadir color at the bottom of the sphere to the zenith color at the top of the sphere.
+ * The sky and ground colors are unused, as are the sky and ground exponents.
+ *
+ * For a four-color gradient, a "horizon" is produced on the equator of the sphere, where the ground color and sky color meet. The lower half of the sphere transitions
+ * smoothly from the ground color at the equator to the nadir color at the bottom, and the upper half transitions from the sky color at the equator to the zenith color at
+ * the top of the sphere.
+ *
+ * The color and exponent properties are unused if one or more texture images are supplied.
+ *
+ * @see [[DisplayStyle3dSettings.environment]] to define the skybox for a display style.
  * @public
  */
 export interface SkyBoxProps {
-  /** Whether or not the skybox should be displayed. Defaults to false. */
+  /** Whether or not the skybox should be displayed.
+   * Default: false.
+   */
   display?: boolean;
-  /** For a [[SkyGradient]], if true, a 2-color gradient skybox is used instead of a 4-color. Defaults to false. */
+  /** For a [SkyGradient]($frontend), if true, a 2-color gradient skybox is used instead of a 4-color.
+   * Default: false.
+   */
   twoColor?: boolean;
-  /** For a 4-color [[SkyGradient]], the color of the sky at the horizon. */
+  /** The color of the sky at the horizon. Unused unless this is a four-color [SkyGradient]($frontend).
+   * Default: (143, 205, 255).
+   */
   skyColor?: ColorDefProps;
-  /** For a 4-color [[SkyGradient]], the color of the ground at the horizon. */
+  /** The color of the ground at the horizon. Unused unless this is a four-color [SkyGradient]($frontend).
+   * Default: (120, 143, 125).
+   */
   groundColor?: ColorDefProps;
-  /** For a 4-color [[SkyGradient]], the color of the sky when looking straight up. For a 2-color [[SkyGradient]], the color of the sky. */
+  /** The color of the top of the sphere.
+   * Default: (54, 117, 255).
+   */
   zenithColor?: ColorDefProps;
-  /** For a 4-color [[SkyGradient]], the color of the ground when looking straight down. For a 2-color [[SkyGradient]], the color of the ground. */
+  /** The color of the bottom of the sphere.
+   * Default: (40, 15, 0).
+   */
   nadirColor?: ColorDefProps;
-  /** For a 4-color [[SkyGradient]], controls speed of change from sky color to zenith color. */
+  /** For a 4-color [SkyGradient]($frontend), controls speed of change from sky color to zenith color; otherwise unused.
+   * Default: 4.0.
+   */
   skyExponent?: number;
-  /** For a 4-color [[SkyGradient]], controls speed of change from ground color to nadir color. */
+  /** For a 4-color [SkyGradient]($frontend), controls speed of change from ground color to nadir color; otherwise unused.
+   * Default: 4.0.
+   */
   groundExponent?: number;
-  /** For a [[SkySphere]] or [[SkyCube]], the skybox image(s). */
+  /** The image(s), if any, to be mapped to the surfaces of the sphere or cube. If undefined, the skybox will be displayed as a gradient instead.
+   * Default: undefined.
+   */
   image?: SkyBoxImageProps;
 }

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -881,22 +881,23 @@ export namespace SkyBox { // eslint-disable-line no-redeclare
 
 /** A [[SkyBox]] drawn as a sphere with a gradient mapped to its interior surface.
  * @see [[SkyBox.createFromJSON]]
+ * @see [SkyBoxProps]($common) for descriptions of the color and exponent properties.
  * @public
  */
 export class SkyGradient extends SkyBox {
-  /** If true, a 2-color gradient is used (ground & sky colors only), if false a 4-color gradient is used, defaults to false. */
+  /** If true, a 2-color gradient is used (nadir and zenith colors only); if false a 4-color gradient is used. Defaults to false. */
   public readonly twoColor: boolean = false;
-  /** The color of the sky (for 4-color gradient is sky color at horizon), defaults to (143, 205, 255). */
+  /** @see [SkyBoxProp]($frontend). */
   public readonly skyColor: ColorDef;
-  /** The color of the ground (for 4-color gradient is ground color at horizon), defaults to (120, 143, 125). */
+  /** @see [SkyBoxProp]($frontend). */
   public readonly groundColor: ColorDef;
-  /** For 4-color gradient is color of sky at zenith (shown when looking straight up), defaults to (54, 117, 255). */
+  /** @see [SkyBoxProp]($frontend). */
   public readonly zenithColor: ColorDef;
-  /** For 4-color gradient is color of ground at nadir (shown when looking straight down), defaults to (40, 15, 0). */
+  /** @see [SkyBoxProp]($frontend). */
   public readonly nadirColor: ColorDef;
-  /** Controls speed of gradient change from skyColor to zenithColor (4-color SkyGradient only), defaults to 4.0. */
+  /** @see [SkyBoxProp]($frontend). */
   public readonly skyExponent: number = 4.0;
-  /** Controls speed of gradient change from groundColor to nadirColor (4-color SkyGradient only), defaults to 4.0. */
+  /** @see [SkyBoxProp]($frontend). */
   public readonly groundExponent: number = 4.0;
 
   /** Construct a SkyGradient from its JSON representation. */

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -1125,7 +1125,7 @@ export class DisplayStyle3dState extends DisplayStyleState {
   private _settings: DisplayStyle3dSettings;
 
   /** @internal */
-  public clone(iModel: IModelConnection): this {
+  public clone(iModel?: IModelConnection): this {
     const clone = super.clone(iModel);
     if (undefined === iModel || this.iModel === iModel) {
       clone._skyBoxParams = this._skyBoxParams;

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -1450,6 +1450,11 @@ export abstract class ViewState3d extends ViewState {
     return this.getDisplayStyle3d();
   }
 
+  public set displayStyle(style: DisplayStyle3dState) {
+    assert(style instanceof DisplayStyle3dState);
+    super.displayStyle = style;
+  }
+
   /** The style that controls how the contents of the view are displayed.
    * @see [[ViewState3d.displayStyle]].
    */

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -152,7 +152,7 @@ export abstract class ViewState extends ElementState {
     }
   }
 
-  /** Selects the styling parameters for this this ViewState. */
+  /** The style that controls how the contents of the view are displayed. */
   public get displayStyle(): DisplayStyleState {
     return this._displayStyle;
   }
@@ -1445,7 +1445,17 @@ export abstract class ViewState3d extends ViewState {
     return !this._cameraOn ? (this.getZVector().z > 0) : (this.getEyePoint().z > elevation);
   }
 
-  public getDisplayStyle3d() { return this.displayStyle as DisplayStyle3dState; }
+  /** The style that controls how the contents of the view are displayed. */
+  public get displayStyle(): DisplayStyle3dState {
+    return this.getDisplayStyle3d();
+  }
+
+  /** The style that controls how the contents of the view are displayed.
+   * @see [[ViewState3d.displayStyle]].
+   */
+  public getDisplayStyle3d() {
+    return super.displayStyle as DisplayStyle3dState;
+  }
 
   /** Turn the camera off for this view. After this call, the camera parameters in this view definition are ignored and views that use it will
    * display with an orthographic (infinite focal length) projection of the view volume from the view direction.

--- a/example-code/app/src/frontend/BlankConnection.ts
+++ b/example-code/app/src/frontend/BlankConnection.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { Range3d } from "@bentley/geometry-core";
 import { Cartographic, ColorDef } from "@bentley/imodeljs-common";
-import { BlankConnection, DisplayStyle3dState, IModelConnection, SpatialViewState } from "@bentley/imodeljs-frontend";
+import { BlankConnection, IModelConnection, SpatialViewState } from "@bentley/imodeljs-frontend";
 
 export class BlankConnectionExample {
 
@@ -35,7 +35,7 @@ export class BlankConnectionExample {
     const blankView = SpatialViewState.createBlank(iModel, ext.low, ext.high.minus(ext.low));
 
     // turn on the background map
-    const style = blankView.displayStyle as DisplayStyle3dState;
+    const style = blankView.displayStyle;
     const viewFlags = style.viewFlags;
     viewFlags.backgroundMap = true;
     style.viewFlags = viewFlags; // call to accessor to get the json properties to reflect the changes to ViewFlags

--- a/full-stack-tests/core/src/frontend/standalone/ViewState.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewState.test.ts
@@ -8,7 +8,7 @@ import {
   AmbientOcclusion, BackgroundMapSettings, BackgroundMapType, ColorDef, HiddenLine, RenderMode, SpatialViewDefinitionProps, ViewDefinitionProps,
 } from "@bentley/imodeljs-common";
 import {
-  AuxCoordSystemSpatialState, CategorySelectorState, DisplayStyle3dState, DrawingModelState, DrawingViewState, IModelConnection, MarginPercent,
+  AuxCoordSystemSpatialState, CategorySelectorState, DrawingModelState, DrawingViewState, IModelConnection, MarginPercent,
   MockRender, ModelSelectorState, SheetModelState, SheetViewState, SnapshotConnection, SpatialModelState, SpatialViewState, StandardView,
   StandardViewId, ViewState3d, ViewStatus,
 } from "@bentley/imodeljs-frontend";
@@ -40,8 +40,8 @@ describe("ViewState", () => {
 
   const compareView = (v1: SpatialViewState, v2: SpatialViewDefinitionProps, str: string) => {
     const compare = new DeepCompare();
-    const v2State = new SpatialViewState(v2, v1.iModel, v1.categorySelector, v1.displayStyle as DisplayStyle3dState, v1.modelSelector);
-    const v1State = new SpatialViewState(v1.toJSON(), v1.iModel, v1.categorySelector, v1.displayStyle as DisplayStyle3dState, v1.modelSelector);
+    const v2State = new SpatialViewState(v2, v1.iModel, v1.categorySelector, v1.displayStyle, v1.modelSelector);
+    const v1State = new SpatialViewState(v1.toJSON(), v1.iModel, v1.categorySelector, v1.displayStyle, v1.modelSelector);
 
     const val = compare.compare(JSON.parse(JSON.stringify(v1State)), JSON.parse(JSON.stringify(v2State)));
     if (!val)

--- a/test-apps/display-test-app/src/frontend/ViewPicker.ts
+++ b/test-apps/display-test-app/src/frontend/ViewPicker.ts
@@ -5,7 +5,7 @@
 
 import { BeEvent, compareBooleans, compareStrings, Id64, Id64String, SortedArray } from "@bentley/bentleyjs-core";
 import { ColorDef } from "@bentley/imodeljs-common";
-import { DisplayStyle3dState, IModelConnection, SpatialViewState, ViewState } from "@bentley/imodeljs-frontend";
+import { IModelConnection, SpatialViewState, ViewState } from "@bentley/imodeljs-frontend";
 
 interface ViewSpec extends IModelConnection.ViewSpec {
   isPrivate: boolean;
@@ -115,7 +115,7 @@ export class ViewList extends SortedArray<ViewSpec> {
     const blankView = SpatialViewState.createBlank(iModel, ext.low, ext.high.minus(ext.low));
 
     // turn on the background map
-    const style = blankView.displayStyle as DisplayStyle3dState;
+    const style = blankView.displayStyle;
     const viewFlags = style.viewFlags;
     viewFlags.backgroundMap = true;
     style.viewFlags = viewFlags; // call to accessor to get the json properties to reflect the changes to ViewFlags


### PR DESCRIPTION
EnvironmentEditor listens for changes to the display style. In its callback, it updates the values of UI components, which triggers callbacks that modify the display style, which trigger (on the next frame) the "display style changed" event in a ceaseless loop.
This only began happening after I made Viewport automatically detect changes to the display style, rather than relying on people to manually invoke `invalidateRenderPlan`.

Changed EnvironmentEditor to listen only for changes to the style's `environment` property, and to set a flag when it is modifying the environment itself so it knows to ignore the change events it produces.

Incidentally changed the type of `ViewState3d.displayStyle` to `DisplayStyle3dState` to eliminate yucky unnecessary casts.