### PR TITLE
Set accept header for iTwin services

### DIFF
--- a/clients/context-registry/src/ContextRegistryClient.ts
+++ b/clients/context-registry/src/ContextRegistryClient.ts
@@ -154,10 +154,11 @@ export class ContextRegistryClient extends WsgClient {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
+    const iTwinJsAccept = Config.App.get("imjs_itwinjs_api_accept", "application/vnd.bentley.itwinjs+json");
     deepAssign(options, {
       headers: {
         "content-type": "application/json",
-        "accept": "application/vnd.bentley.itwinjs+json",
+        "accept": iTwinJsAccept,
       },
     });
   }

--- a/clients/context-registry/src/ContextRegistryClient.ts
+++ b/clients/context-registry/src/ContextRegistryClient.ts
@@ -154,7 +154,12 @@ export class ContextRegistryClient extends WsgClient {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
-    deepAssign(options, { headers: { "content-type": "application/json" } });
+    deepAssign(options, {
+      headers: {
+        "content-type": "application/json",
+        "accept": "application/vnd.bentley.itwinjs+json",
+      },
+    });
   }
 
   /** Gets theRelyingPartyUrl for the service.

--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@bentley/bentleyjs-core": "2.12.0-dev.6",
     "@bentley/imodeljs-common": "2.12.0-dev.6",
-    "@bentley/itwin-client": "2.12.0-dev.6"
+    "@bentley/itwin-client": "2.12.0-dev.6",
+    "deep-assign": "^2.0.0"
   },
   "devDependencies": {
     "@bentley/build-tools": "2.12.0-dev.6",
@@ -47,6 +48,7 @@
     "@bentley/eslint-plugin": "2.12.0-dev.6",
     "@bentley/oidc-signin-tool": "2.12.0-dev.6",
     "@types/chai": "^4.1.4",
+    "@types/deep-assign": "^0.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "10.14.1",
     "chai": "^4.1.2",

--- a/clients/extension/src/ExtensionClient.ts
+++ b/clients/extension/src/ExtensionClient.ts
@@ -7,7 +7,7 @@
  * @module ExtensionService
  */
 
-import { ClientRequestContext, ExtensionStatus } from "@bentley/bentleyjs-core";
+import { ClientRequestContext, Config, ExtensionStatus } from "@bentley/bentleyjs-core";
 import { IModelError } from "@bentley/imodeljs-common";
 import { AuthorizedClientRequestContext, Client, getArrayBuffer, request, RequestOptions, ResponseError } from "@bentley/itwin-client";
 import { ExtensionFile } from "./ExtensionFile";
@@ -33,9 +33,10 @@ export class ExtensionClient extends Client {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
+    const iTwinJsAccept = Config.App.get("imjs_itwinjs_api_accept", "application/vnd.bentley.itwinjs+json");
     deepAssign(options, {
       headers: {
-        accept: "application/vnd.bentley.itwinjs+json",
+        accept: iTwinJsAccept,
       },
     });
   }

--- a/clients/imodelhub/src/IModelClient.ts
+++ b/clients/imodelhub/src/IModelClient.ts
@@ -21,6 +21,7 @@ import { UserInfoHandler } from "./imodelhub/Users";
 import { VersionHandler } from "./imodelhub/Versions";
 import { PermissionHandler } from "./imodelhub/Permissions";
 import { CheckpointV2Handler } from "./imodelhub/CheckpointsV2";
+import { Config } from "@bentley/bentleyjs-core";
 
 /**
  * Base class that allows access to different iModel related Class handlers. Handlers should be accessed through an instance of this class, rather than constructed directly.
@@ -35,7 +36,8 @@ export abstract class IModelClient {
    */
   public constructor(baseHandler: IModelBaseHandler, fileHandler?: FileHandler, applicationVersion?: string) {
     this._handler = baseHandler;
-    this.use(addHeader("accept", () => "application/vnd.bentley.itwinjs+json"));
+    const iTwinJsAccept = Config.App.get("imjs_itwinjs_api_accept", "application/vnd.bentley.itwinjs+json");
+    this.use(addHeader("accept", () => iTwinJsAccept));
     if (applicationVersion)
       this.use(addApplicationVersion(applicationVersion));
     this._fileHandler = fileHandler || this._handler.getFileHandler();

--- a/clients/imodelhub/src/IModelClient.ts
+++ b/clients/imodelhub/src/IModelClient.ts
@@ -6,7 +6,7 @@
  * @module iModelHubClient
  */
 import { FileHandler } from "@bentley/itwin-client";
-import { addApplicationVersion, HttpRequestOptionsTransformer, IModelBaseHandler } from "./imodelhub/BaseHandler";
+import { addApplicationVersion, addHeader, HttpRequestOptionsTransformer, IModelBaseHandler } from "./imodelhub/BaseHandler";
 import { BriefcaseHandler } from "./imodelhub/Briefcases";
 import { ChangeSetHandler } from "./imodelhub/ChangeSets";
 import { CheckpointHandler } from "./imodelhub/Checkpoints";
@@ -35,6 +35,7 @@ export abstract class IModelClient {
    */
   public constructor(baseHandler: IModelBaseHandler, fileHandler?: FileHandler, applicationVersion?: string) {
     this._handler = baseHandler;
+    this.use(addHeader("accept", () => "application/vnd.bentley.itwinjs+json"));
     if (applicationVersion)
       this.use(addApplicationVersion(applicationVersion));
     this._fileHandler = fileHandler || this._handler.getFileHandler();

--- a/clients/product-settings/package.json
+++ b/clients/product-settings/package.json
@@ -48,6 +48,7 @@
     "@bentley/oidc-signin-tool": "2.12.0-dev.6",
     "@bentley/rbac-client": "2.12.0-dev.6",
     "@types/chai": "^4.1.4",
+    "@types/deep-assign": "^0.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "10.14.1",
     "chai": "^4.1.2",
@@ -58,6 +59,9 @@
     "source-map-loader": "^1.0.0",
     "typescript": "~3.7.4",
     "webpack": "4.42.0"
+  },
+  "dependencies": {
+    "deep-assign": "^2.0.0"
   },
   "nyc": {
     "nycrc-path": "./node_modules/@bentley/build-tools/.nycrc"

--- a/clients/product-settings/src/SettingsClient.ts
+++ b/clients/product-settings/src/SettingsClient.ts
@@ -6,7 +6,7 @@
 /** @packageDocumentation
  * @module Settings
  */
-import { BentleyError, BentleyStatus, ClientRequestContext } from "@bentley/bentleyjs-core";
+import { BentleyError, BentleyStatus, ClientRequestContext, Config } from "@bentley/bentleyjs-core";
 import { AuthorizedClientRequestContext, Client, request, RequestOptions, Response } from "@bentley/itwin-client";
 import { SettingsAdmin, SettingsMapResult, SettingsResult, SettingsStatus } from "./SettingsAdmin";
 import * as deepAssign from "deep-assign";
@@ -39,9 +39,10 @@ export class ConnectSettingsClient extends Client implements SettingsAdmin {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
+    const iTwinJsAccept = Config.App.get("imjs_itwinjs_api_accept", "application/vnd.bentley.itwinjs+json");
     deepAssign(options, {
       headers: {
-        accept: "application/vnd.bentley.itwinjs+json",
+        accept: iTwinJsAccept,
       },
     });
   }

--- a/clients/product-settings/src/SettingsClient.ts
+++ b/clients/product-settings/src/SettingsClient.ts
@@ -9,6 +9,7 @@
 import { BentleyError, BentleyStatus, ClientRequestContext } from "@bentley/bentleyjs-core";
 import { AuthorizedClientRequestContext, Client, request, RequestOptions, Response } from "@bentley/itwin-client";
 import { SettingsAdmin, SettingsMapResult, SettingsResult, SettingsStatus } from "./SettingsAdmin";
+import * as deepAssign from "deep-assign";
 
 /** Client API for the iTwin Product Settings Service
  *
@@ -38,6 +39,11 @@ export class ConnectSettingsClient extends Client implements SettingsAdmin {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
+    deepAssign(options, {
+      headers: {
+        accept: "application/vnd.bentley.itwinjs+json",
+      },
+    });
   }
 
   /** Gets the URL of the service.

--- a/clients/projectshare/package.json
+++ b/clients/projectshare/package.json
@@ -48,6 +48,7 @@
     "@bentley/itwin-client": "2.12.0-dev.6",
     "@bentley/oidc-signin-tool": "2.12.0-dev.6",
     "@types/chai": "^4.1.4",
+    "@types/deep-assign": "^0.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "10.14.1",
     "chai": "^4.1.2",
@@ -58,6 +59,9 @@
     "source-map-loader": "^1.0.0",
     "typescript": "~3.7.4",
     "webpack": "4.42.0"
+  },
+  "dependencies": {
+    "deep-assign": "^2.0.0"
   },
   "nyc": {
     "nycrc-path": "./node_modules/@bentley/build-tools/.nycrc"

--- a/clients/projectshare/src/ProjectShareClient.ts
+++ b/clients/projectshare/src/ProjectShareClient.ts
@@ -9,6 +9,7 @@ import { BentleyError, BentleyStatus, Config, GuidString, Logger } from "@bentle
 import {
   AuthorizedClientRequestContext, ECJsonTypeMap, ITwinClientLoggerCategory, request, RequestOptions, WsgClient, WsgInstance, WsgQuery,
 } from "@bentley/itwin-client";
+import * as deepAssign from "deep-assign";
 
 const loggerCategory = ITwinClientLoggerCategory.Clients;
 
@@ -258,6 +259,15 @@ export class ProjectShareClient extends WsgClient {
    */
   public constructor() {
     super("v2.4");
+  }
+
+  protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
+    await super.setupOptionDefaults(options);
+    deepAssign(options, {
+      headers: {
+        accept: "application/vnd.bentley.itwinjs+json",
+      },
+    });
   }
 
   protected getRelyingPartyUrl(): string {

--- a/clients/projectshare/src/ProjectShareClient.ts
+++ b/clients/projectshare/src/ProjectShareClient.ts
@@ -263,9 +263,10 @@ export class ProjectShareClient extends WsgClient {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
+    const iTwinJsAccept = Config.App.get("imjs_itwinjs_api_accept", "application/vnd.bentley.itwinjs+json");
     deepAssign(options, {
       headers: {
-        accept: "application/vnd.bentley.itwinjs+json",
+        accept: iTwinJsAccept,
       },
     });
   }

--- a/clients/rbac/package.json
+++ b/clients/rbac/package.json
@@ -35,7 +35,8 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@bentley/bentleyjs-core": "2.12.0-dev.6"
+    "@bentley/bentleyjs-core": "2.12.0-dev.6",
+    "deep-assign": "^2.0.0"
   },
   "peerDependencies": {
     "@bentley/itwin-client": "^2.12.0-dev.6"
@@ -49,6 +50,7 @@
     "@bentley/itwin-client": "2.12.0-dev.6",
     "@bentley/oidc-signin-tool": "2.12.0-dev.6",
     "@types/chai": "^4.1.4",
+    "@types/deep-assign": "^0.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "10.14.1",
     "chai": "^4.1.2",

--- a/clients/rbac/src/RbacClient.ts
+++ b/clients/rbac/src/RbacClient.ts
@@ -7,7 +7,8 @@
  */
 
 import { Config, GuidString } from "@bentley/bentleyjs-core";
-import { AuthorizedClientRequestContext, ECJsonTypeMap, request, Response, WsgClient, WsgInstance } from "@bentley/itwin-client";
+import { AuthorizedClientRequestContext, ECJsonTypeMap, request, RequestOptions, Response, WsgClient, WsgInstance } from "@bentley/itwin-client";
+import * as deepAssign from "deep-assign";
 
 /** RBAC permission
  * @internal
@@ -52,6 +53,15 @@ export class RbacClient extends WsgClient {
 
   public constructor() {
     super("v2.4");
+  }
+
+  protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
+    await super.setupOptionDefaults(options);
+    deepAssign(options, {
+      headers: {
+        accept: "application/vnd.bentley.itwinjs+json",
+      },
+    });
   }
 
   /**

--- a/clients/rbac/src/RbacClient.ts
+++ b/clients/rbac/src/RbacClient.ts
@@ -57,9 +57,10 @@ export class RbacClient extends WsgClient {
 
   protected async setupOptionDefaults(options: RequestOptions): Promise<void> {
     await super.setupOptionDefaults(options);
+    const iTwinJsAccept = Config.App.get("imjs_itwinjs_api_accept", "application/vnd.bentley.itwinjs+json");
     deepAssign(options, {
       headers: {
-        accept: "application/vnd.bentley.itwinjs+json",
+        accept: iTwinJsAccept,
       },
     });
   }


### PR DESCRIPTION
Set "Accept" header to one required by iTwin API services
Allow the header to be set in configuration variable `imjs_itwinjs_api_accept`
Depends on #577 