### PR TITLE
Prevent unnecessary re-renders of 1.0 Toolbar in ToolbarComposer

### DIFF
--- a/common/changes/@bentley/ui-framework/ui-fix-toolbar-auto-blur_2021-01-19-15-25.json
+++ b/common/changes/@bentley/ui-framework/ui-fix-toolbar-auto-blur_2021-01-19-15-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Prevent unnecessary 1.0 Toolbar rerenders in ToolbarComposer.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/ui/framework/src/ui-framework/toolbar/GroupButtonItem.tsx
+++ b/ui/framework/src/ui-framework/toolbar/GroupButtonItem.tsx
@@ -158,6 +158,7 @@ export class ToolbarGroupItem extends React.Component<ToolbarGroupItemComponentP
 
   public componentDidUpdate(prevProps: ToolbarGroupItemComponentProps, _prevState: ToolbarGroupItemState) {
     if (!PropsHelper.isShallowEqual(this.props, prevProps)) {
+      // istanbul ignore else
       if (this.props.groupItem !== prevProps.groupItem)
         Logger.logTrace(UiFramework.loggerCategory(this), `Different ToolbarGroupItem for same groupId of ${this.state.groupItem.id}`);
       this.setState((_, props) => this.getGroupItemState(props));

--- a/ui/framework/src/ui-framework/toolbar/ToolbarComposer.tsx
+++ b/ui/framework/src/ui-framework/toolbar/ToolbarComposer.tsx
@@ -271,26 +271,13 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
   const useProximityOpacity = useProximityOpacitySetting();
 
   if ("1" === version) {
-    const createReactNodes = (): React.ReactNode => {
-      const availableItems = toolbarItems;
-      if (0 === availableItems.length)
-        return null;
-
-      const createdNodes = availableItems.map((item: CommonToolbarItem) => {
-        return ToolbarHelper.createNodeForToolbarItem(item);
-      });
-      return createdNodes;
-    };
-
-    return <Toolbar
-      expandsTo={expandsTo}
-      panelAlignment={panelAlignment}
-      items={
-        <>
-          {createReactNodes()}
-        </>
-      }
-    />;
+    return (
+      <ToolbarUi1
+        items={toolbarItems}
+        expandsTo={expandsTo}
+        panelAlignment={panelAlignment}
+      />
+    );
   }
 
   return <ToolbarWithOverflow
@@ -300,5 +287,39 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
     useDragInteraction={isDragEnabled}
     toolbarOpacitySetting={useProximityOpacity && !UiFramework.isMobile() ? ToolbarOpacitySetting.Proximity : /* istanbul ignore next */ ToolbarOpacitySetting.Defaults}
   />;
-
 }
+
+interface ToolbarUi1Props {
+  items: CommonToolbarItem[];
+  expandsTo: Direction;
+  panelAlignment: ToolbarPanelAlignment;
+}
+
+/** Toolbar rendered in 1.0 mode.
+ * @internal
+ */
+const ToolbarUi1 = React.memo<ToolbarUi1Props>(function ToolbarUi1({
+  items,
+  expandsTo,
+  panelAlignment,
+}) {
+  const createReactNodes = (): React.ReactNode => {
+    if (0 === items.length)
+      return null;
+
+    const createdNodes = items.map((item: CommonToolbarItem) => {
+      return ToolbarHelper.createNodeForToolbarItem(item);
+    });
+    return createdNodes;
+  };
+
+  return <Toolbar
+    expandsTo={expandsTo}
+    panelAlignment={panelAlignment}
+    items={
+      <>
+        {createReactNodes()}
+      </>
+    }
+  />;
+});


### PR DESCRIPTION
Reported issue:
Focused input element of expandable Toolbar item panel is blurred (looses focus) when mouse is moved.

To fix reported issue this PR reduces unnecessary re-renders of 1.0 Toolbar to prevent PanelsProvider from re-appending panel to panel container.
