### PR TITLE
Fix mis-matched Guids between the iModel and the iModelHub

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/fix-guid-mismatch_2021-01-21-14-24.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-guid-mismatch_2021-01-21-14-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -282,7 +282,7 @@ export class V1CheckpointManager {
         const dbContextGuid = Guid.normalize(nativeDb.queryProjectGuid());
         if (dbContextGuid !== Guid.normalize(requestedCkp.contextId)) {
           Logger.logWarning(loggerCategory, "ContextId was not properly setup in the briefcase. Updated briefcase to the correct ContextId.", () => ({ ...traceInfo, ...checkpoint, dbContextGuid }));
-          nativeDb.saveProjectGuid(dbContextGuid);
+          nativeDb.saveProjectGuid(Guid.normalize(requestedCkp.contextId));
         }
 
         // Apply change sets if necessary

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -275,11 +275,15 @@ export class V1CheckpointManager {
         if (dbGuid !== Guid.normalize(requestedCkp.iModelId)) {
           Logger.logWarning(loggerCategory, "iModelId is not properly setup in the briefcase. Updated briefcase to the correct iModelId.", () => ({ ...traceInfo, ...checkpoint, dbGuid }));
           nativeDb.setDbGuid(Guid.normalize(requestedCkp.iModelId));
+          // Required to reset the ChangeSetId because the `setDbGuid` method resets the value.
+          nativeDb.saveLocalValue("ParentChangeSetId", dbChangeSetId);
         }
 
         const dbContextGuid = Guid.normalize(nativeDb.queryProjectGuid());
-        if (dbContextGuid !== Guid.normalize(requestedCkp.contextId))
-          throw new IModelError(IModelStatus.ValidationFailed, "ContextId was not properly setup in the briefcase", Logger.logError, loggerCategory, () => ({ ...traceInfo, dbContextGuid }));
+        if (dbContextGuid !== Guid.normalize(requestedCkp.contextId)) {
+          Logger.logWarning(loggerCategory, "ContextId was not properly setup in the briefcase. Updated briefcase to the correct ContextId.", () => ({ ...traceInfo, ...checkpoint, dbContextGuid }));
+          nativeDb.saveProjectGuid(dbContextGuid);
+        }
 
         // Apply change sets if necessary
         if (dbChangeSetId !== requestedCkp.changeSetId) {

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -275,7 +275,7 @@ export class V1CheckpointManager {
         if (dbGuid !== Guid.normalize(requestedCkp.iModelId)) {
           Logger.logWarning(loggerCategory, "iModelId is not properly setup in the briefcase. Updated briefcase to the correct iModelId.", () => ({ ...traceInfo, ...checkpoint, dbGuid }));
           nativeDb.setDbGuid(Guid.normalize(requestedCkp.iModelId));
-          // Required to reset the ChangeSetId because the `setDbGuid` method resets the value.
+          // Required to reset the ChangeSetId because setDbGuid clears the value.
           nativeDb.saveLocalValue("ParentChangeSetId", dbChangeSetId);
         }
 


### PR DESCRIPTION
Two issues were found after the previous fix to set the DbGuid in the iModel (#590);

1. When calling `native.setDbGuid()`, it clears the changeset Id so resetting that value directly after setting DbGuid.
2. The ProjectGuid is not correctly set in all cases so also setting that value if there is a mis-match

I'll follow with tests later today but want to get this out in a release candidate.