### PR TITLE
Presentation: Associate updates with imodel

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1109,6 +1109,81 @@
         "[BACKEND] display-performance-test-app (chrome)"
       ]
     },
+    { /* PARTIAL */
+      "name": "[BACKEND] presentation-test-app (chrome)",
+      "presentation": {
+        "hidden": true
+      },
+      "cwd": "${workspaceFolder}/test-apps/presentation-test-app",
+      "type": "pwa-node",
+      "request": "launch",
+      "program": "${workspaceFolder}/test-apps/presentation-test-app/lib/backend/main.js",
+      "outFiles": [
+        "${workspaceFolder}/test-apps/presentation-test-app/lib/**/*.js",
+        "${workspaceFolder}/{core,clients,presentation}/*/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[FRONTEND] presentation-test-app (chrome)"
+      ]
+    },
+    { /* PARTIAL */
+      "name": "[FRONTEND] presentation-test-app (chrome)",
+      "presentation": {
+        "hidden": true
+      },
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000/",
+      "outFiles": [
+        "${workspaceFolder}/test-apps/presentation-test-app/lib/**/*.js",
+        "${workspaceFolder}/{core,clients,ui,presentation}/*/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[BACKEND] presentation-test-app (chrome)"
+      ]
+    },
+    { /* PARTIAL */
+      "name": "[BACKEND] presentation-test-app (electron)",
+      "presentation": {
+        "hidden": true
+      },
+      "cwd": "${workspaceFolder}/test-apps/presentation-test-app/",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/test-apps/presentation-test-app/node_modules/.bin/electron",
+      "runtimeArgs": [
+        "${workspaceFolder}/test-apps/presentation-test-app/lib/backend/main.js",
+        "--remote-debugging-port=9223"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "outFiles": [
+        "${workspaceFolder}/test-apps/presentation-test-app/lib/backend/**/*.js",
+        "${workspaceFolder}/{core,clients}/*/lib/**/*.js",
+        "${workspaceFolder}/ui/abstract/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[FRONTEND] presentation-test-app (electron)"
+      ]
+    },
+    { /* PARTIAL */
+      "name": "[FRONTEND] presentation-test-app (electron)",
+      "presentation": {
+        "hidden": true
+      },
+      "type": "pwa-chrome",
+      "request": "attach",
+      "port": 9223,
+      "outFiles": [
+        "${workspaceFolder}/test-apps/presentation-test-app/lib/**/*.js",
+        "${workspaceFolder}/{core,clients}/*/lib/**/*.js",
+        "${workspaceFolder}/ui/abstract/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[BACKEND] presentation-test-app (electron)"
+      ]
+    },
     // FULLSTACK TESTS
     { /* PARTIAL */
       "name": "[BACKEND] Full Stack Core Tests",
@@ -1444,6 +1519,28 @@
       "configurations": [
         "[BACKEND] ui-test-app (electron)",
         "[FRONTEND] ui-test-app (electron)"
+      ]
+    },
+    {
+      "name": "presentation-test-app (chrome)",
+      "presentation": {
+        "group": "1_TestApps",
+        "order": 1
+      },
+      "configurations": [
+        "[BACKEND] presentation-test-app (chrome)",
+        "[FRONTEND] presentation-test-app (chrome)"
+      ]
+    },
+    {
+      "name": "presentation-test-app (electron)",
+      "presentation": {
+        "group": "1_TestApps",
+        "order": 1
+      },
+      "configurations": [
+        "[BACKEND] presentation-test-app (electron)",
+        "[FRONTEND] presentation-test-app (electron)"
       ]
     },
     {

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -2372,9 +2372,11 @@ export const UPDATE_FULL = "FULL";
 // @alpha (undocumented)
 export interface UpdateInfo {
     // (undocumented)
-    [rulesetId: string]: {
-        hierarchy?: HierarchyUpdateInfo;
-        content?: ContentUpdateInfo;
+    [imodel: string]: {
+        [rulesetId: string]: {
+            hierarchy?: HierarchyUpdateInfo;
+            content?: ContentUpdateInfo;
+        };
     };
 }
 
@@ -2387,9 +2389,11 @@ export namespace UpdateInfo {
 // @alpha (undocumented)
 export interface UpdateInfoJSON {
     // (undocumented)
-    [rulesetId: string]: {
-        hierarchy?: HierarchyUpdateInfoJSON;
-        content?: ContentUpdateInfo;
+    [imodel: string]: {
+        [rulesetId: string]: {
+            hierarchy?: HierarchyUpdateInfoJSON;
+            content?: ContentUpdateInfo;
+        };
     };
 }
 

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -233,13 +233,15 @@ export class PresentationManager implements IDisposable {
     loadHierarchy(requestOptions: HierarchyRequestOptions<IModelConnection>): Promise<void>;
     // @alpha
     onIModelContentChanged: BeEvent<(args: {
-        ruleset: Ruleset;
+        rulesetId: string;
         updateInfo: "FULL";
+        imodelKey: string;
     }) => void>;
     // @alpha
     onIModelHierarchyChanged: BeEvent<(args: {
-        ruleset: Ruleset;
+        rulesetId: string;
         updateInfo: HierarchyUpdateInfo;
+        imodelKey: string;
     }) => void>;
     // @internal
     onNewiModelConnection(_: IModelConnection): Promise<void>;

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -8,6 +8,7 @@ import { BeEvent } from '@bentley/bentleyjs-core';
 import { Content } from '@bentley/presentation-common';
 import { ContentDescriptorRequestOptions } from '@bentley/presentation-common';
 import { ContentRequestOptions } from '@bentley/presentation-common';
+import { ContentUpdateInfo } from '@bentley/presentation-common';
 import { Descriptor } from '@bentley/presentation-common';
 import { DescriptorOverrides } from '@bentley/presentation-common';
 import { DisplayLabelRequestOptions } from '@bentley/presentation-common';
@@ -134,6 +135,20 @@ export interface IFavoritePropertiesStorage {
     savePropertiesOrder(orderInfos: FavoritePropertiesOrderInfo[], projectId: string | undefined, imodelId: string): Promise<void>;
 }
 
+// @alpha
+export interface IModelContentChangeEventArgs {
+    imodelKey: string;
+    rulesetId: string;
+    updateInfo: ContentUpdateInfo;
+}
+
+// @alpha
+export interface IModelHierarchyChangeEventArgs {
+    imodelKey: string;
+    rulesetId: string;
+    updateInfo: HierarchyUpdateInfo;
+}
+
 // @public
 export interface ISelectionProvider {
     getSelection(imodel: IModelConnection, level: number): Readonly<KeySet>;
@@ -232,17 +247,9 @@ export class PresentationManager implements IDisposable {
     // @alpha
     loadHierarchy(requestOptions: HierarchyRequestOptions<IModelConnection>): Promise<void>;
     // @alpha
-    onIModelContentChanged: BeEvent<(args: {
-        rulesetId: string;
-        updateInfo: "FULL";
-        imodelKey: string;
-    }) => void>;
+    onIModelContentChanged: BeEvent<(args: IModelContentChangeEventArgs) => void>;
     // @alpha
-    onIModelHierarchyChanged: BeEvent<(args: {
-        rulesetId: string;
-        updateInfo: HierarchyUpdateInfo;
-        imodelKey: string;
-    }) => void>;
+    onIModelHierarchyChanged: BeEvent<(args: IModelHierarchyChangeEventArgs) => void>;
     // @internal
     onNewiModelConnection(_: IModelConnection): Promise<void>;
     // @internal (undocumented)

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -10,6 +10,8 @@ public;HiliteSet
 public;HiliteSetProvider
 public;HiliteSetProviderProps
 beta;IFavoritePropertiesStorage
+alpha;IModelContentChangeEventArgs
+alpha;IModelHierarchyChangeEventArgs
 public;ISelectionProvider
 public;Presentation
 beta;PresentationFrontendLoggerCategory

--- a/common/changes/@bentley/presentation-backend/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
+++ b/common/changes/@bentley/presentation-backend/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Associate update records with iModel key.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
+++ b/common/changes/@bentley/presentation-common/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Add iModel key to UpdateInfo object.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
+++ b/common/changes/@bentley/presentation-components/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "Ignore update records for unrelated iModels.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-frontend/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
+++ b/common/changes/@bentley/presentation-frontend/presentation-associate_updates_with_imodel_2021-01-21-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "Add iModel key to imodel data change events.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/presentation/backend/src/presentation-backend/UpdatesTracker.ts
+++ b/presentation/backend/src/presentation-backend/UpdatesTracker.ts
@@ -6,9 +6,10 @@
  * @module Core
  */
 
-import { IDisposable } from "@bentley/bentleyjs-core";
+import { IDisposable, Logger } from "@bentley/bentleyjs-core";
 import { EventSink, IModelDb } from "@bentley/imodeljs-backend";
 import { PresentationRpcEvents, PresentationRpcInterface, UpdateInfoJSON } from "@bentley/presentation-common";
+import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { NativePlatformDefinition } from "./NativePlatform";
 
 /**
@@ -64,8 +65,10 @@ const parseUpdateInfo = (info: UpdateInfoJSON | undefined) => {
       continue;
 
     const imodelDb = IModelDb.findByFilename(fileName);
-    if (!imodelDb)
+    if (!imodelDb) {
+      Logger.logError(PresentationBackendLoggerCategory.PresentationManager, `Update records IModelDb not found with path ${fileName}`);
       continue;
+    }
 
     parsedInfo[imodelDb.getRpcProps().key] = info[fileName];
   }

--- a/presentation/backend/src/test/UpdatesTracker.test.ts
+++ b/presentation/backend/src/test/UpdatesTracker.test.ts
@@ -98,7 +98,7 @@ describe("UpdatesTracker", () => {
       eventSinkMock.verify((x) => x.emit(PresentationRpcInterface.interfaceName, PresentationRpcEvents.Update, expectedUpdateInfo), moq.Times.once());
     });
 
-    it("does not emit events if imodelDb is not fount", () => {
+    it("does not emit events if imodelDb is not found", () => {
       const updates: UpdateInfoJSON = {
         ["imodel-File-Path"]: {
           "a-ruleset": { hierarchy: "FULL" },

--- a/presentation/backend/src/test/UpdatesTracker.test.ts
+++ b/presentation/backend/src/test/UpdatesTracker.test.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import * as lolex from "lolex";
 import * as sinon from "sinon";
 import { using } from "@bentley/bentleyjs-core";
-import { EventSink } from "@bentley/imodeljs-backend";
+import { EventSink, IModelDb } from "@bentley/imodeljs-backend";
 import { PresentationRpcEvents, PresentationRpcInterface, UpdateInfoJSON } from "@bentley/presentation-common";
 import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
@@ -16,10 +16,12 @@ describe("UpdatesTracker", () => {
 
   const eventSinkMock = moq.Mock.ofType<EventSink>();
   const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
+  const imodelDbMock = moq.Mock.ofType<IModelDb>();
   let clock: lolex.Clock;
   beforeEach(() => {
     nativePlatformMock.reset();
     eventSinkMock.reset();
+    imodelDbMock.reset();
     clock = lolex.install();
   });
   afterEach(() => {
@@ -76,14 +78,39 @@ describe("UpdatesTracker", () => {
 
     it("emits events if there are updates", () => {
       const updates: UpdateInfoJSON = {
-        "a-ruleset": { hierarchy: [] },
-        "b-ruleset": { hierarchy: "FULL" },
-        "c-ruleset": { content: "FULL" },
+        ["imodel-File-Path"]: {
+          "a-ruleset": { hierarchy: [] },
+          "b-ruleset": { hierarchy: "FULL" },
+          "c-ruleset": { content: "FULL" },
+        },
       };
       nativePlatformMock.setup((x) => x.getUpdateInfo()).returns(() => ({ result: updates }));
+      const findDbStub = sinon.stub(IModelDb, "findByFilename");
+      findDbStub.returns(imodelDbMock.object);
+      imodelDbMock.setup((x) => x.getRpcProps()).returns(() => ({ key: "imodelKey" }));
+
       clock.tick(1);
       nativePlatformMock.verify((x) => x.getUpdateInfo(), moq.Times.once());
-      eventSinkMock.verify((x) => x.emit(PresentationRpcInterface.interfaceName, PresentationRpcEvents.Update, updates), moq.Times.once());
+
+      const expectedUpdateInfo: UpdateInfoJSON = {
+        ["imodelKey"]: updates["imodel-File-Path"],
+      };
+      eventSinkMock.verify((x) => x.emit(PresentationRpcInterface.interfaceName, PresentationRpcEvents.Update, expectedUpdateInfo), moq.Times.once());
+    });
+
+    it("does not emit events if imodelDb is not fount", () => {
+      const updates: UpdateInfoJSON = {
+        ["imodel-File-Path"]: {
+          "a-ruleset": { hierarchy: "FULL" },
+        },
+      };
+      nativePlatformMock.setup((x) => x.getUpdateInfo()).returns(() => ({ result: updates }));
+      const findDbStub = sinon.stub(IModelDb, "findByFilename");
+      findDbStub.returns(undefined);
+      clock.tick(1);
+      nativePlatformMock.verify((x) => x.getUpdateInfo(), moq.Times.once());
+
+      eventSinkMock.verify((x) => x.emit(PresentationRpcInterface.interfaceName, PresentationRpcEvents.Update, moq.It.isAny()), moq.Times.never());
     });
 
   });

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -13,17 +13,21 @@ export const UPDATE_FULL = "FULL";
 
 /** @alpha */
 export interface UpdateInfoJSON {
-  [rulesetId: string]: {
-    hierarchy?: HierarchyUpdateInfoJSON;
-    content?: ContentUpdateInfo;
+  [imodel: string]: {
+    [rulesetId: string]: {
+      hierarchy?: HierarchyUpdateInfoJSON;
+      content?: ContentUpdateInfo;
+    };
   };
 }
 
 /** @alpha */
 export interface UpdateInfo {
-  [rulesetId: string]: {
-    hierarchy?: HierarchyUpdateInfo;
-    content?: ContentUpdateInfo;
+  [imodel: string]: {
+    [rulesetId: string]: {
+      hierarchy?: HierarchyUpdateInfo;
+      content?: ContentUpdateInfo;
+    };
   };
 }
 
@@ -32,12 +36,21 @@ export namespace UpdateInfo {
   /** Serialize given object to JSON. */
   export function toJSON(obj: UpdateInfo): UpdateInfoJSON {
     const json: UpdateInfoJSON = {};
-    for (const key in obj) {
-      // istanbul ignore else
-      if (obj.hasOwnProperty(key)) {
-        json[key] = {
-          hierarchy: obj[key].hierarchy ? HierarchyUpdateInfo.toJSON(obj[key].hierarchy!) : undefined,
-          content: obj[key].content,
+    for (const imodel in obj) {
+      // istanbul ignore if
+      if (!obj.hasOwnProperty(imodel))
+        continue;
+
+      json[imodel] = {};
+      const rulesetObj = obj[imodel];
+      for (const rulesetId in rulesetObj) {
+        // istanbul ignore if
+        if (!rulesetObj.hasOwnProperty(rulesetId))
+          continue;
+
+        json[imodel][rulesetId] = {
+          hierarchy: rulesetObj[rulesetId].hierarchy ? HierarchyUpdateInfo.toJSON(rulesetObj[rulesetId].hierarchy!) : undefined,
+          content: rulesetObj[rulesetId].content,
         };
       }
     }
@@ -47,12 +60,21 @@ export namespace UpdateInfo {
   /** Deserialize given object from JSON */
   export function fromJSON(json: UpdateInfoJSON): UpdateInfo {
     const obj: UpdateInfo = {};
-    for (const key in json) {
-      // istanbul ignore else
-      if (json.hasOwnProperty(key)) {
-        obj[key] = {
-          hierarchy: json[key].hierarchy ? HierarchyUpdateInfo.fromJSON(json[key].hierarchy!) : undefined,
-          content: json[key].content,
+    for (const imodel in json) {
+      // istanbul ignore if
+      if (!json.hasOwnProperty(imodel))
+        continue;
+
+      obj[imodel] = {};
+      const rulesetJson = json[imodel];
+      for (const rulesetId in rulesetJson) {
+        // istanbul ignore if
+        if (!rulesetJson.hasOwnProperty(rulesetId))
+          continue;
+
+        obj[imodel][rulesetId] = {
+          hierarchy: rulesetJson[rulesetId].hierarchy ? HierarchyUpdateInfo.fromJSON(rulesetJson[rulesetId].hierarchy!) : undefined,
+          content: rulesetJson[rulesetId].content,
         };
       }
     }

--- a/presentation/common/src/test/Update.test.snap
+++ b/presentation/common/src/test/Update.test.snap
@@ -358,115 +358,123 @@ Object {
 
 exports[`UpdateInfo fromJSON deserializes \`UpdateInfo\` object from JSON 1`] = `
 Object {
-  "test_ruleset_1": Object {
-    "content": "FULL",
-    "hierarchy": undefined,
+  "test_imodel_1": Object {
+    "test_ruleset_1": Object {
+      "content": "FULL",
+      "hierarchy": undefined,
+    },
+    "test_ruleset_2": Object {
+      "content": undefined,
+      "hierarchy": "FULL",
+    },
   },
-  "test_ruleset_2": Object {
-    "content": undefined,
-    "hierarchy": "FULL",
-  },
-  "test_ruleset_3": Object {
-    "content": undefined,
-    "hierarchy": Array [
-      Object {
-        "node": Object {
-          "backColor": "rgb(
+  "test_imodel_2": Object {
+    "test_ruleset_3": Object {
+      "content": undefined,
+      "hierarchy": Array [
+        Object {
+          "node": Object {
+            "backColor": "rgb(
     193,
     243,
     39
   )",
-          "description": "Architecto pariatur magnam nam quisquam.",
-          "foreColor": "#F4E98F",
-          "hasChildren": false,
-          "isCheckboxEnabled": true,
-          "isCheckboxVisible": true,
-          "isChecked": true,
-          "isEditable": true,
-          "isExpanded": false,
-          "isSelectionDisabled": false,
-          "key": Object {
-            "instanceKeys": Array [
-              Object {
-                "className": "internet solution",
-                "id": "0xd5c10000004941",
-              },
-              Object {
-                "className": "RAM",
-                "id": "0x702300000184a5",
-              },
-            ],
-            "pathFromRoot": Array [
-              "609c256d-9938-42d0-b65c-afd19e430113",
-              "181aeb51-d8bb-4081-91eb-dc6a3ed59ec2",
-            ],
-            "type": "ECInstancesNode",
+            "description": "Architecto pariatur magnam nam quisquam.",
+            "foreColor": "#F4E98F",
+            "hasChildren": false,
+            "isCheckboxEnabled": true,
+            "isCheckboxVisible": true,
+            "isChecked": true,
+            "isEditable": true,
+            "isExpanded": false,
+            "isSelectionDisabled": false,
+            "key": Object {
+              "instanceKeys": Array [
+                Object {
+                  "className": "internet solution",
+                  "id": "0xd5c10000004941",
+                },
+                Object {
+                  "className": "RAM",
+                  "id": "0x702300000184a5",
+                },
+              ],
+              "pathFromRoot": Array [
+                "609c256d-9938-42d0-b65c-afd19e430113",
+                "181aeb51-d8bb-4081-91eb-dc6a3ed59ec2",
+              ],
+              "type": "ECInstancesNode",
+            },
+            "label": Object {
+              "displayValue": "User-centric",
+              "rawValue": "invoice",
+              "typeName": "string",
+            },
           },
-          "label": Object {
-            "displayValue": "User-centric",
-            "rawValue": "invoice",
-            "typeName": "string",
-          },
+          "type": "Delete",
         },
-        "type": "Delete",
-      },
-    ],
+      ],
+    },
   },
 }
 `;
 
 exports[`UpdateInfo toJSON serializes \`UpdateInfo\` object to JSON 1`] = `
 Object {
-  "test_ruleset_1": Object {
-    "content": "FULL",
-    "hierarchy": undefined,
+  "test_imodel_1": Object {
+    "test_ruleset_1": Object {
+      "content": "FULL",
+      "hierarchy": undefined,
+    },
+    "test_ruleset_2": Object {
+      "content": undefined,
+      "hierarchy": "FULL",
+    },
   },
-  "test_ruleset_2": Object {
-    "content": undefined,
-    "hierarchy": "FULL",
-  },
-  "test_ruleset_3": Object {
-    "content": undefined,
-    "hierarchy": Array [
-      Object {
-        "node": Object {
-          "backColor": undefined,
-          "description": "Doloribus exercitationem eius debitis quidem.",
-          "foreColor": "#CB2FF4",
-          "hasChildren": false,
-          "imageId": "Progressive",
-          "isCheckboxEnabled": true,
-          "isCheckboxVisible": false,
-          "isChecked": true,
-          "isEditable": true,
-          "isExpanded": false,
-          "isSelectionDisabled": false,
-          "key": Object {
-            "instanceKeys": Array [
-              Object {
-                "className": "transmitter",
-                "id": "0x42290000009bd8",
-              },
-              Object {
-                "className": "Bedfordshire",
-                "id": "0x11fb000000f97b",
-              },
-            ],
-            "pathFromRoot": Array [
-              "86c178ef-2a83-4ef6-a2ab-1556ecfc57e6",
-              "18dad7d8-a0cd-41ed-b11f-462952cd6500",
-            ],
-            "type": "ECInstancesNode",
+  "test_imodel_2": Object {
+    "test_ruleset_3": Object {
+      "content": undefined,
+      "hierarchy": Array [
+        Object {
+          "node": Object {
+            "backColor": undefined,
+            "description": "Doloribus exercitationem eius debitis quidem.",
+            "foreColor": "#CB2FF4",
+            "hasChildren": false,
+            "imageId": "Progressive",
+            "isCheckboxEnabled": true,
+            "isCheckboxVisible": false,
+            "isChecked": true,
+            "isEditable": true,
+            "isExpanded": false,
+            "isSelectionDisabled": false,
+            "key": Object {
+              "instanceKeys": Array [
+                Object {
+                  "className": "transmitter",
+                  "id": "0x42290000009bd8",
+                },
+                Object {
+                  "className": "Bedfordshire",
+                  "id": "0x11fb000000f97b",
+                },
+              ],
+              "pathFromRoot": Array [
+                "86c178ef-2a83-4ef6-a2ab-1556ecfc57e6",
+                "18dad7d8-a0cd-41ed-b11f-462952cd6500",
+              ],
+              "type": "ECInstancesNode",
+            },
+            "labelDefinition": Object {
+              "displayValue": "Sausages",
+              "rawValue": "Manat",
+              "typeName": "string",
+            },
           },
-          "labelDefinition": Object {
-            "displayValue": "Sausages",
-            "rawValue": "Manat",
-            "typeName": "string",
-          },
+          "type": "Delete",
         },
-        "type": "Delete",
-      },
-    ],
+      ],
+    },
   },
 }
 `;

--- a/presentation/common/src/test/Update.test.ts
+++ b/presentation/common/src/test/Update.test.ts
@@ -15,17 +15,21 @@ describe("UpdateInfo", () => {
 
     it("serializes `UpdateInfo` object to JSON", () => {
       const info: UpdateInfo = {
-        ["test_ruleset_1"]: {
-          content: "FULL",
+        ["test_imodel_1"]: {
+          ["test_ruleset_1"]: {
+            content: "FULL",
+          },
+          ["test_ruleset_2"]: {
+            hierarchy: "FULL",
+          },
         },
-        ["test_ruleset_2"]: {
-          hierarchy: "FULL",
-        },
-        ["test_ruleset_3"]: {
-          hierarchy: [{
-            type: "Delete",
-            node: createRandomECInstancesNode(),
-          }],
+        ["test_imodel_2"]: {
+          ["test_ruleset_3"]: {
+            hierarchy: [{
+              type: "Delete",
+              node: createRandomECInstancesNode(),
+            }],
+          },
         },
       };
       expect(UpdateInfo.toJSON(info)).to.matchSnapshot();
@@ -37,17 +41,21 @@ describe("UpdateInfo", () => {
 
     it("deserializes `UpdateInfo` object from JSON", () => {
       const json: UpdateInfoJSON = {
-        ["test_ruleset_1"]: {
-          content: "FULL",
+        ["test_imodel_1"]: {
+          ["test_ruleset_1"]: {
+            content: "FULL",
+          },
+          ["test_ruleset_2"]: {
+            hierarchy: "FULL",
+          },
         },
-        ["test_ruleset_2"]: {
-          hierarchy: "FULL",
-        },
-        ["test_ruleset_3"]: {
-          hierarchy: [{
-            type: "Delete",
-            node: createRandomECInstancesNodeJSON(),
-          }],
+        ["test_imodel_2"]: {
+          ["test_ruleset_3"]: {
+            hierarchy: [{
+              type: "Delete",
+              node: createRandomECInstancesNodeJSON(),
+            }],
+          },
         },
       };
       expect(UpdateInfo.fromJSON(json)).to.matchSnapshot();

--- a/presentation/components/src/presentation-components/common/ContentDataProvider.ts
+++ b/presentation/components/src/presentation-components/common/ContentDataProvider.ts
@@ -13,7 +13,7 @@ import {
   Content, ContentRequestOptions, DEFAULT_KEYS_BATCH_SIZE, Descriptor, DescriptorOverrides, Field, KeySet, PageOptions, RegisteredRuleset, Ruleset,
   SelectionInfo,
 } from "@bentley/presentation-common";
-import { Presentation } from "@bentley/presentation-frontend";
+import { IModelContentChangeEventArgs, Presentation } from "@bentley/presentation-frontend";
 import { PropertyRecord } from "@bentley/ui-abstract";
 import { PresentationComponentsLoggerCategory } from "../ComponentsLoggerCategory";
 import { IPresentationDataProvider } from "./IPresentationDataProvider";
@@ -420,7 +420,7 @@ export class ContentDataProvider implements IContentDataProvider {
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  private onIModelContentChanged = (args: { rulesetId: string, imodelKey: string }) => {
+  private onIModelContentChanged = (args: IModelContentChangeEventArgs) => {
     if (args.rulesetId === this.rulesetId && args.imodelKey === this.imodel.key)
       this.onContentUpdate();
   };

--- a/presentation/components/src/presentation-components/common/ContentDataProvider.ts
+++ b/presentation/components/src/presentation-components/common/ContentDataProvider.ts
@@ -420,8 +420,8 @@ export class ContentDataProvider implements IContentDataProvider {
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  private onIModelContentChanged = (args: { rulesetId: string }) => {
-    if (args.rulesetId === this.rulesetId)
+  private onIModelContentChanged = (args: { rulesetId: string, imodelKey: string }) => {
+    if (args.rulesetId === this.rulesetId && args.imodelKey === this.imodel.key)
       this.onContentUpdate();
   };
 

--- a/presentation/components/src/presentation-components/common/ContentDataProvider.ts
+++ b/presentation/components/src/presentation-components/common/ContentDataProvider.ts
@@ -420,8 +420,8 @@ export class ContentDataProvider implements IContentDataProvider {
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  private onIModelContentChanged = (args: { ruleset: Ruleset }) => {
-    if (args.ruleset.id === this.rulesetId)
+  private onIModelContentChanged = (args: { rulesetId: string }) => {
+    if (args.rulesetId === this.rulesetId)
       this.onContentUpdate();
   };
 

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -8,9 +8,9 @@
 
 import { useCallback, useEffect, useState } from "react";
 import {
-  HierarchyUpdateInfo, PartialHierarchyModification, RegisteredRuleset, Ruleset, UPDATE_FULL, VariableValue,
+  PartialHierarchyModification, RegisteredRuleset, Ruleset, UPDATE_FULL, VariableValue,
 } from "@bentley/presentation-common";
-import { Presentation } from "@bentley/presentation-frontend";
+import { IModelHierarchyChangeEventArgs, Presentation } from "@bentley/presentation-frontend";
 import {
   isTreeModelNode, PagedTreeNodeLoader, TreeModelSource, TreeNodeItem, usePagedTreeNodeLoader, useTreeModelSource,
 } from "@bentley/ui-components";
@@ -86,7 +86,7 @@ interface ModelSourceUpdateProps {
 
 function useModelSourceUpdateOnIModelHierarchyUpdate(props: ModelSourceUpdateProps) {
   const { modelSource, dataProvider, reset } = props;
-  const onIModelHierarchyChanged = useCallback(async (args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => {
+  const onIModelHierarchyChanged = useCallback(async (args: IModelHierarchyChangeEventArgs) => {
     if (args.rulesetId === dataProvider.rulesetId && args.imodelKey === dataProvider.imodel.key) {
       if (args.updateInfo === UPDATE_FULL)
         reset();

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -86,8 +86,8 @@ interface ModelSourceUpdateProps {
 
 function useModelSourceUpdateOnIModelHierarchyUpdate(props: ModelSourceUpdateProps) {
   const { modelSource, dataProvider, reset } = props;
-  const onIModelHierarchyChanged = useCallback(async (args: { ruleset: Ruleset, updateInfo: HierarchyUpdateInfo }) => {
-    if (args.ruleset.id === dataProvider.rulesetId) {
+  const onIModelHierarchyChanged = useCallback(async (args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => {
+    if (args.rulesetId === dataProvider.rulesetId && args.imodelKey === dataProvider.imodel.key) {
       if (args.updateInfo === UPDATE_FULL)
         reset();
       else

--- a/presentation/components/src/test/_helpers/UiComponents.ts
+++ b/presentation/components/src/test/_helpers/UiComponents.ts
@@ -6,9 +6,9 @@
 import * as faker from "faker";
 import * as moq from "typemoq";
 import { BeEvent } from "@bentley/bentleyjs-core";
-import { ContentUpdateInfo, HierarchyUpdateInfo, NodeKey, RegisteredRuleset, Ruleset, VariableValue } from "@bentley/presentation-common";
+import { NodeKey, RegisteredRuleset, Ruleset, VariableValue } from "@bentley/presentation-common";
 import { createRandomECInstancesNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
-import { PresentationManager, RulesetManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
+import { IModelContentChangeEventArgs, IModelHierarchyChangeEventArgs, PresentationManager, RulesetManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
 import { PrimitiveValue, PropertyDescription, PropertyRecord, PropertyValueFormat } from "@bentley/ui-abstract";
 import { DelayLoadedTreeNodeItem } from "@bentley/ui-components";
 import { PRESENTATION_TREE_NODE_KEY } from "../../presentation-components/tree/Utils";
@@ -48,8 +48,8 @@ export const mockPresentationManager = () => {
   const rulesetVariablesManagerMock = moq.Mock.ofType<RulesetVariablesManager>();
   rulesetVariablesManagerMock.setup((x) => x.onVariableChanged).returns(() => onRulesetVariableChanged);
 
-  const onIModelHierarchyChanged = new BeEvent<(args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => void>();
-  const onIModelContentChanged = new BeEvent<(args: { rulesetId: string, updateInfo: ContentUpdateInfo, imodelKey: string }) => void>();
+  const onIModelHierarchyChanged = new BeEvent<(args: IModelHierarchyChangeEventArgs) => void>();
+  const onIModelContentChanged = new BeEvent<(args: IModelContentChangeEventArgs) => void>();
   const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
   presentationManagerMock.setup((x) => x.onIModelHierarchyChanged).returns(() => onIModelHierarchyChanged);
   presentationManagerMock.setup((x) => x.onIModelContentChanged).returns(() => onIModelContentChanged);

--- a/presentation/components/src/test/_helpers/UiComponents.ts
+++ b/presentation/components/src/test/_helpers/UiComponents.ts
@@ -48,8 +48,8 @@ export const mockPresentationManager = () => {
   const rulesetVariablesManagerMock = moq.Mock.ofType<RulesetVariablesManager>();
   rulesetVariablesManagerMock.setup((x) => x.onVariableChanged).returns(() => onRulesetVariableChanged);
 
-  const onIModelHierarchyChanged = new BeEvent<(args: { ruleset: Ruleset, updateInfo: HierarchyUpdateInfo }) => void>();
-  const onIModelContentChanged = new BeEvent<(args: { ruleset: Ruleset, updateInfo: ContentUpdateInfo }) => void>();
+  const onIModelHierarchyChanged = new BeEvent<(args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => void>();
+  const onIModelContentChanged = new BeEvent<(args: { rulesetId: string, updateInfo: ContentUpdateInfo, imodelKey: string }) => void>();
   const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
   presentationManagerMock.setup((x) => x.onIModelHierarchyChanged).returns(() => onIModelHierarchyChanged);
   presentationManagerMock.setup((x) => x.onIModelContentChanged).returns(() => onIModelContentChanged);

--- a/presentation/components/src/test/common/ContentDataProvider.test.ts
+++ b/presentation/components/src/test/common/ContentDataProvider.test.ts
@@ -11,7 +11,7 @@ import * as sinon from "sinon";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
 import {
   Content, ContentDescriptorRequestOptions, Descriptor, DescriptorOverrides, ExtendedContentRequestOptions, Field, Item, KeySet, NestedContentField,
-  Paged, RegisteredRuleset, Ruleset, SelectionInfo,
+  Paged, RegisteredRuleset, SelectionInfo,
 } from "@bentley/presentation-common";
 import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { PromiseContainer, ResolvablePromise } from "@bentley/presentation-common/lib/test/_helpers/Promises";
@@ -639,14 +639,12 @@ describe("ContentDataProvider", () => {
   describe("reacting to updates", () => {
 
     it("doesn't react to imodel content updates to unrelated rulesets", () => {
-      const ruleset: Ruleset = { id: "unrelated", rules: [] };
-      presentationManagerMock.object.onIModelContentChanged.raiseEvent({ ruleset, updateInfo: "FULL" });
+      presentationManagerMock.object.onIModelContentChanged.raiseEvent({ rulesetId: "unrelated", updateInfo: "FULL", imodelKey: "imodelKey" });
       expect(invalidateCacheSpy).to.not.be.called;
     });
 
     it("invalidates cache when imodel content change happens to related ruleset", () => {
-      const ruleset: Ruleset = { id: rulesetId, rules: [] };
-      presentationManagerMock.object.onIModelContentChanged.raiseEvent({ ruleset, updateInfo: "FULL" });
+      presentationManagerMock.object.onIModelContentChanged.raiseEvent({ rulesetId, updateInfo: "FULL", imodelKey: "imodelKey" });
       expect(invalidateCacheSpy).to.be.calledOnceWith(CacheInvalidationProps.full());
     });
 

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -8,8 +8,8 @@ import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { BeEvent, IDisposable } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
-import { HierarchyUpdateInfo, RegisteredRuleset, Ruleset, VariableValue, VariableValueTypes } from "@bentley/presentation-common";
-import { Presentation, PresentationManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
+import { RegisteredRuleset, Ruleset, VariableValue, VariableValueTypes } from "@bentley/presentation-common";
+import { IModelHierarchyChangeEventArgs, Presentation, PresentationManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
 import { PropertyRecord } from "@bentley/ui-abstract";
 import { TreeDataChangesListener, TreeModelNodeInput, TreeNodeItem } from "@bentley/ui-components";
 import { renderHook } from "@testing-library/react-hooks";
@@ -19,7 +19,7 @@ import { createRandomTreeNodeItem, mockPresentationManager } from "../../_helper
 
 describe("usePresentationNodeLoader", () => {
 
-  let onIModelHierarchyChanged: BeEvent<(args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => void>;
+  let onIModelHierarchyChanged: BeEvent<(args: IModelHierarchyChangeEventArgs) => void>;
   let onRulesetModified: BeEvent<(curr: RegisteredRuleset, prev: Ruleset) => void>;
   let onRulesetVariableChanged: BeEvent<(variableId: string, prevValue: VariableValue, currValue: VariableValue) => void>;
   let presentationManagerMock: moq.IMock<PresentationManager>;

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -19,13 +19,14 @@ import { createRandomTreeNodeItem, mockPresentationManager } from "../../_helper
 
 describe("usePresentationNodeLoader", () => {
 
-  let onIModelHierarchyChanged: BeEvent<(args: { ruleset: Ruleset, updateInfo: HierarchyUpdateInfo }) => void>;
+  let onIModelHierarchyChanged: BeEvent<(args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => void>;
   let onRulesetModified: BeEvent<(curr: RegisteredRuleset, prev: Ruleset) => void>;
   let onRulesetVariableChanged: BeEvent<(variableId: string, prevValue: VariableValue, currValue: VariableValue) => void>;
   let presentationManagerMock: moq.IMock<PresentationManager>;
   let rulesetVariablesManagerMock: moq.IMock<RulesetVariablesManager>;
   const imodelMock = moq.Mock.ofType<IModelConnection>();
   const rulesetId = "test-ruleset-id";
+  const imodelKey = "test-imodel-key";
   const initialProps: PresentationTreeNodeLoaderProps = {
     imodel: imodelMock.object,
     ruleset: rulesetId,
@@ -33,6 +34,8 @@ describe("usePresentationNodeLoader", () => {
   };
 
   beforeEach(() => {
+    imodelMock.reset();
+    imodelMock.setup((x) => x.key).returns(() => imodelKey);
     const mocks = mockPresentationManager();
     presentationManagerMock = mocks.presentationManager;
     rulesetVariablesManagerMock = mocks.rulesetVariablesManager;
@@ -98,41 +101,50 @@ describe("usePresentationNodeLoader", () => {
       initialProps.enableHierarchyAutoUpdate = true;
     });
 
-    it("doesn't create a new nodeLoader when `PresentationManager` raises an unrelated `onIModelHierarchyChanged` event", () => {
+    it("doesn't create a new nodeLoader when `PresentationManager` raises `onIModelHierarchyChanged` event with unrelated ruleset", () => {
       const { result } = renderHook(
         (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
         { initialProps },
       );
       const oldNodeLoader = result.current;
 
-      const ruleset: Ruleset = { id: "unrelated", rules: [] };
-      onIModelHierarchyChanged.raiseEvent({ ruleset, updateInfo: "FULL" });
+      onIModelHierarchyChanged.raiseEvent({ rulesetId: "unrelated", updateInfo: "FULL", imodelKey });
+
+      expect(result.current).to.eq(oldNodeLoader);
+    });
+
+    it("doesn't create a new nodeLoader when `PresentationManager` raises `onIModelHierarchyChanged` event with unrelated imodel", () => {
+      const { result } = renderHook(
+        (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
+        { initialProps },
+      );
+      const oldNodeLoader = result.current;
+
+      onIModelHierarchyChanged.raiseEvent({ rulesetId, updateInfo: "FULL", imodelKey: "unrelated" });
 
       expect(result.current).to.eq(oldNodeLoader);
     });
 
     it("creates a new nodeLoader when `PresentationManager` raises a related `onIModelHierarchyChanged` event with FULL hierarchy update", () => {
-      const ruleset: Ruleset = { id: rulesetId, rules: [] };
       const { result } = renderHook(
         (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
-        { initialProps: { ...initialProps, ruleset: ruleset.id } },
+        { initialProps: { ...initialProps, ruleset: rulesetId } },
       );
       const oldNodeLoader = result.current;
 
-      onIModelHierarchyChanged.raiseEvent({ ruleset, updateInfo: "FULL" });
+      onIModelHierarchyChanged.raiseEvent({ rulesetId, updateInfo: "FULL", imodelKey });
 
       expect(result.current).to.not.eq(oldNodeLoader);
     });
 
     it("creates a new nodeLoader when `PresentationManager` raises a related `onIModelHierarchyChanged` event with partial hierarchy updates", () => {
-      const ruleset: Ruleset = { id: rulesetId, rules: [] };
       const { result } = renderHook(
         (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
-        { initialProps: { ...initialProps, ruleset: ruleset.id } },
+        { initialProps: { ...initialProps, ruleset: rulesetId } },
       );
       const oldNodeLoader = result.current;
 
-      onIModelHierarchyChanged.raiseEvent({ ruleset, updateInfo: [] });
+      onIModelHierarchyChanged.raiseEvent({ rulesetId, updateInfo: [], imodelKey });
 
       expect(result.current).to.not.eq(oldNodeLoader);
     });

--- a/presentation/frontend/src/presentation-frontend.ts
+++ b/presentation/frontend/src/presentation-frontend.ts
@@ -9,7 +9,9 @@
  * Common types used for retrieving presentation data from iModels.
  */
 export { Presentation } from "./presentation-frontend/Presentation";
-export { PresentationManager, PresentationManagerProps } from "./presentation-frontend/PresentationManager";
+export {
+  IModelContentChangeEventArgs, IModelHierarchyChangeEventArgs, PresentationManager, PresentationManagerProps,
+} from "./presentation-frontend/PresentationManager";
 export { RulesetManager } from "./presentation-frontend/RulesetManager";
 export { RulesetVariablesManager } from "./presentation-frontend/RulesetVariablesManager";
 export {

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -24,6 +24,32 @@ import { RulesetVariablesManager, RulesetVariablesManagerImpl } from "./RulesetV
 import { TRANSIENT_ELEMENT_CLASSNAME } from "./selection/SelectionManager";
 
 /**
+ * Data structure that describes IModel hierarchy change event arguments.
+ * @alpha
+ */
+export interface IModelHierarchyChangeEventArgs {
+  /** Id of ruleset that was used to create hierarchy. */
+  rulesetId: string;
+  /** Hierarchy changes info. */
+  updateInfo: HierarchyUpdateInfo;
+  /** Key of iModel that was used to create hierarchy. It matches [[IModelConnection.key]] property. */
+  imodelKey: string;
+};
+
+/**
+ * Data structure that describes iModel content change event arguments.
+ * @alpha
+ */
+export interface IModelContentChangeEventArgs {
+  /** Id of ruleset that was used to create content. */
+  rulesetId: string;
+  /** Content changes info. */
+  updateInfo: ContentUpdateInfo;
+  /** Key of iModel that was used to create content. It matches [[IModelConnection.key]] property. */
+  imodelKey: string;
+}
+
+/**
  * Properties used to configure [[PresentationManager]]
  * @public
  */
@@ -77,13 +103,13 @@ export class PresentationManager implements IDisposable {
    * An event raised when hierarchies created using specific ruleset change
    * @alpha
    */
-  public onIModelHierarchyChanged = new BeEvent<(args: { rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }) => void>();
+  public onIModelHierarchyChanged = new BeEvent<(args: IModelHierarchyChangeEventArgs) => void>();
 
   /**
    * An event raised when content created using specific ruleset changes
    * @alpha
    */
-  public onIModelContentChanged = new BeEvent<(args: { rulesetId: string, updateInfo: ContentUpdateInfo, imodelKey: string }) => void>();
+  public onIModelContentChanged = new BeEvent<(args: IModelContentChangeEventArgs) => void>();
 
   /** Get / set active locale used for localizing presentation data */
   public activeLocale: string | undefined;

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -1347,8 +1347,8 @@ describe("PresentationManager", () => {
   describe("listening to updates", () => {
 
     let eventSourceListener: (report: UpdateInfo) => void;
-    let hierarchyUpdatesSpy: sinon.SinonSpy<[{ ruleset: Ruleset, updateInfo: HierarchyUpdateInfo }], void>;
-    let contentUpdatesSpy: sinon.SinonSpy<[{ ruleset: Ruleset, updateInfo: ContentUpdateInfo }], void>;
+    let hierarchyUpdatesSpy: sinon.SinonSpy<[{ rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }], void>;
+    let contentUpdatesSpy: sinon.SinonSpy<[{ rulesetId: string, updateInfo: ContentUpdateInfo, imodelKey: string }], void>;
 
     beforeEach(() => {
       sinon.stub(IModelApp, "isNativeApp").get(() => true);
@@ -1367,6 +1367,7 @@ describe("PresentationManager", () => {
     });
 
     it("triggers appropriate hierarchy and content events on update event", async () => {
+      const imodelKey = "test-imodel-key";
       const ruleset1: Ruleset = { id: "1", rules: [] };
       const ruleset2: Ruleset = { id: "2", rules: [] };
       const ruleset3: Ruleset = { id: "3", rules: [] };
@@ -1377,17 +1378,19 @@ describe("PresentationManager", () => {
       rulesetsManagerMock.setup((x) => x.get(ruleset4.id)).returns(async () => undefined);
 
       const report: UpdateInfo = {
-        [ruleset1.id]: {
-          hierarchy: "FULL",
-          content: "FULL",
+        [imodelKey]: {
+          [ruleset1.id]: {
+            hierarchy: "FULL",
+            content: "FULL",
+          },
+          [ruleset2.id]: {
+            hierarchy: [],
+          },
+          [ruleset3.id]: {
+            content: "FULL",
+          },
+          [ruleset4.id]: {},
         },
-        [ruleset2.id]: {
-          hierarchy: [],
-        },
-        [ruleset3.id]: {
-          content: "FULL",
-        },
-        [ruleset4.id]: {},
       };
       eventSourceListener(report);
 
@@ -1396,22 +1399,26 @@ describe("PresentationManager", () => {
 
       expect(hierarchyUpdatesSpy).to.be.calledTwice;
       expect(hierarchyUpdatesSpy.firstCall).to.be.calledWith({
-        ruleset: sinon.match((r) => r.id === ruleset1.id),
+        rulesetId: ruleset1.id,
         updateInfo: "FULL",
+        imodelKey,
       });
       expect(hierarchyUpdatesSpy.secondCall).to.be.calledWith({
-        ruleset: sinon.match((r) => r.id === ruleset2.id),
+        rulesetId: ruleset2.id,
         updateInfo: [],
+        imodelKey,
       });
 
       expect(contentUpdatesSpy).to.be.calledTwice;
       expect(contentUpdatesSpy.firstCall).to.be.calledWith({
-        ruleset: sinon.match((r) => r.id === ruleset1.id),
+        rulesetId: ruleset1.id,
         updateInfo: "FULL",
+        imodelKey,
       });
       expect(contentUpdatesSpy.secondCall).to.be.calledWith({
-        ruleset: sinon.match((r) => r.id === ruleset3.id),
+        rulesetId: ruleset3.id,
         updateInfo: "FULL",
+        imodelKey,
       });
     });
 

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -11,9 +11,9 @@ import { IModelRpcProps } from "@bentley/imodeljs-common";
 import { EventSource, IModelApp, IModelConnection } from "@bentley/imodeljs-frontend";
 import { I18N, I18NNamespace } from "@bentley/imodeljs-i18n";
 import {
-  Content, ContentDescriptorRequestOptions, ContentRequestOptions, ContentUpdateInfo, Descriptor, DisplayLabelRequestOptions,
+  Content, ContentDescriptorRequestOptions, ContentRequestOptions, Descriptor, DisplayLabelRequestOptions,
   DisplayLabelsRequestOptions, DisplayValueGroup, DistinctValuesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions,
-  FieldDescriptor, FieldDescriptorType, HierarchyRequestOptions, HierarchyUpdateInfo, InstanceKey, Item, KeySet, LabelDefinition, LabelRequestOptions,
+  FieldDescriptor, FieldDescriptorType, HierarchyRequestOptions, InstanceKey, Item, KeySet, LabelDefinition, LabelRequestOptions,
   Node, NodeKey, NodePathElement, Paged, PresentationDataCompareOptions, PresentationError, PresentationRpcEvents, PresentationRpcInterface,
   PresentationStatus, PresentationUnitSystem, RegisteredRuleset, RequestPriority, RpcRequestsHandler, Ruleset, RulesetVariable, UpdateInfo,
   VariableValueTypes,
@@ -24,7 +24,7 @@ import {
   createRandomLabelDefinition, createRandomNodePathElement, createRandomRuleset, createRandomTransientId,
 } from "@bentley/presentation-common/lib/test/_helpers/random";
 import { Presentation } from "../presentation-frontend/Presentation";
-import { buildPagedResponse, PresentationManager } from "../presentation-frontend/PresentationManager";
+import { buildPagedResponse, IModelContentChangeEventArgs, IModelHierarchyChangeEventArgs, PresentationManager } from "../presentation-frontend/PresentationManager";
 import { RulesetManagerImpl } from "../presentation-frontend/RulesetManager";
 import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager";
 import { TRANSIENT_ELEMENT_CLASSNAME } from "../presentation-frontend/selection/SelectionManager";
@@ -1347,8 +1347,8 @@ describe("PresentationManager", () => {
   describe("listening to updates", () => {
 
     let eventSourceListener: (report: UpdateInfo) => void;
-    let hierarchyUpdatesSpy: sinon.SinonSpy<[{ rulesetId: string, updateInfo: HierarchyUpdateInfo, imodelKey: string }], void>;
-    let contentUpdatesSpy: sinon.SinonSpy<[{ rulesetId: string, updateInfo: ContentUpdateInfo, imodelKey: string }], void>;
+    let hierarchyUpdatesSpy: sinon.SinonSpy<[IModelHierarchyChangeEventArgs], void>;
+    let contentUpdatesSpy: sinon.SinonSpy<[IModelContentChangeEventArgs], void>;
 
     beforeEach(() => {
       sinon.stub(IModelApp, "isNativeApp").get(() => true);

--- a/test-apps/presentation-test-app/package.json
+++ b/test-apps/presentation-test-app/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint -f visualstudio --config package.json --no-eslintrc ./src/**/*.{ts,tsx} 1>&2",
     "electron": "run-p start:webserver start:electron",
     "start:electron": "electron ./lib/backend/main.js",
-    "start:webserver": "cross-env BROWSER=none EXTEND_ESLINT=true react-scripts start",
+    "start:webserver": "cross-env BROWSER=none USE_FULL_SOURCEMAP=true EXTEND_ESLINT=true react-scripts start",
     "start:backend": "node --inspect --max-http-header-size=16000 lib/backend/main.js",
     "start:servers": "run-p start:webserver start:backend",
     "test": "",

--- a/test-apps/presentation-test-app/src/backend/main.ts
+++ b/test-apps/presentation-test-app/src/backend/main.ts
@@ -16,10 +16,6 @@ import rpcs from "../common/Rpcs";
 // __PUBLISH_EXTRACT_END__
 import { PresentationBackendLoggerCategory, PresentationBackendNativeLoggerCategory } from "@bentley/presentation-backend"; // eslint-disable-line no-duplicate-imports
 
-if (electron) {
-  require("@bentley/electron-manager"); // static electron manager initialization
-}
-
 (async () => { // eslint-disable-line @typescript-eslint/no-floating-promises
   IModelJsConfig.init(true /* suppress error */, true /* suppress message */, Config.App);
 

--- a/test-apps/presentation-test-app/src/backend/main.ts
+++ b/test-apps/presentation-test-app/src/backend/main.ts
@@ -16,6 +16,10 @@ import rpcs from "../common/Rpcs";
 // __PUBLISH_EXTRACT_END__
 import { PresentationBackendLoggerCategory, PresentationBackendNativeLoggerCategory } from "@bentley/presentation-backend"; // eslint-disable-line no-duplicate-imports
 
+if (electron) {
+  require("@bentley/electron-manager"); // static electron manager initialization
+}
+
 (async () => { // eslint-disable-line @typescript-eslint/no-floating-promises
   IModelJsConfig.init(true /* suppress error */, true /* suppress message */, Config.App);
 


### PR DESCRIPTION
* Made changes to associate update records with imodel using imodel key. This enabled ui controls to ignore updates from different imodels.
* Added vs code debug configuration for presentation-test-app. This allows to debug presentation-test-app frontend and backend in vs code. With current configuration `npm run start:webserver` should be run before starting debugger.

