### PR TITLE
correctly register electron protocol.

### DIFF
--- a/common/changes/@bentley/electron-manager/register-electron-protocol_2021-01-21-20-11.json
+++ b/common/changes/@bentley/electron-manager/register-electron-protocol_2021-01-21-20-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/core/electron-manager/src/ElectronBackend.ts
+++ b/core/electron-manager/src/ElectronBackend.ts
@@ -207,8 +207,7 @@ export class ElectronBackend implements IpcSocketBackend {
 
     const app = this.instance.app;
     app.allowRendererProcessReuse = true; // see https://www.electronjs.org/docs/api/app#appallowrendererprocessreuse
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    if (!app.isReady)
+    if (!app.isReady())
       this.instance.electron.protocol.registerSchemesAsPrivileged([{ scheme: "electron", privileges: { standard: true, secure: true } }]);
 
     return this._instance;


### PR DESCRIPTION
Weren't calling `registerSchemesAsPrivileged` due to a typo.