### PR TITLE
add ResponseHandler to FrontendIpc

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -121,6 +121,7 @@ import { MobileAuthorizationClientConfiguration } from '@bentley/imodeljs-common
 import { ModelLoadProps } from '@bentley/imodeljs-common';
 import { ModelProps } from '@bentley/imodeljs-common';
 import { ModelSelectorProps } from '@bentley/imodeljs-common';
+import { NativeAppResponse } from '@bentley/imodeljs-common';
 import { NativeLoggerCategory } from '@bentley/imodeljs-native';
 import { NavigationBindingValue } from '@bentley/imodeljs-common';
 import { NavigationValue } from '@bentley/imodeljs-common';
@@ -3306,6 +3307,8 @@ export class ModelSelector extends DefinitionElement implements ModelSelectorPro
 export class NativeAppBackend {
     static get appSettingsCacheDir(): string;
     static checkInternetConnectivity(): InternetConnectivityStatus;
+    // (undocumented)
+    static notifyFrontend<T extends keyof NativeAppResponse>(methodName: T, ...args: Parameters<NativeAppResponse[T]>): void;
     // (undocumented)
     static onInternetConnectivityChanged: BeEvent<(status: InternetConnectivityStatus) => void>;
     static overrideInternetConnectivity(_overridenBy: OverriddenBy, status: InternetConnectivityStatus): void;

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4773,7 +4773,7 @@ export interface NativeAppIpc {
     toggleInteractiveEditingSession: (_tokenProps: IModelRpcProps, _startSession: boolean) => Promise<boolean>;
 }
 
-// @public (undocumented)
+// @internal
 export interface NativeAppResponse {
     // (undocumented)
     notifyInternetConnectivityChanged: (status: InternetConnectivityStatus) => void;
@@ -4786,7 +4786,7 @@ export interface NativeAppResponse {
     }) => void;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const nativeAppResponse = "nativeApp-notify";
 
 // @public
@@ -5909,7 +5909,7 @@ export interface RequestNewBriefcaseProps {
     iModelId: GuidString;
 }
 
-// @public (undocumented)
+// @beta
 export abstract class ResponseHandler {
     static register(): RemoveFunction;
     abstract get responseChannel(): string;

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -2388,14 +2388,6 @@ export namespace Events {
     export namespace NativeApp {
         const // (undocumented)
         namespace = "NativeApp";
-        const // (undocumented)
-        onMemoryWarning = "onMemoryWarning";
-        const // (undocumented)
-        onBriefcaseDownloadProgress = "download-progress";
-        const // (undocumented)
-        onInternetConnectivityChanged = "onInternetConnectivityChanged";
-        const // (undocumented)
-        onUserStateChanged = "onUserStateChanged";
         const modelGeometryChanges = "modelGeometryChanges";
     }
 }
@@ -4777,6 +4769,22 @@ export interface NativeAppIpc {
     toggleInteractiveEditingSession: (_tokenProps: IModelRpcProps, _startSession: boolean) => Promise<boolean>;
 }
 
+// @public (undocumented)
+export interface NativeAppResponse {
+    // (undocumented)
+    notifyInternetConnectivityChanged: (status: InternetConnectivityStatus) => void;
+    // (undocumented)
+    notifyMemoryWarning: () => void;
+    // (undocumented)
+    notifyUserStateChanged: (arg: {
+        accessToken: any;
+        err?: string;
+    }) => void;
+}
+
+// @public (undocumented)
+export const nativeAppResponse = "nativeApp-notify";
+
 // @public
 export interface NavigationBindingValue {
     id: Id64String;
@@ -5895,6 +5903,12 @@ export interface RequestNewBriefcaseProps {
     contextId: GuidString;
     fileName?: string;
     iModelId: GuidString;
+}
+
+// @public (undocumented)
+export abstract class ResponseHandler {
+    static register(): RemoveFunction;
+    abstract get responseChannel(): string;
 }
 
 // @public (undocumented)

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -171,6 +171,7 @@ import { ModelQueryParams } from '@bentley/imodeljs-common';
 import { ModelSelectorProps } from '@bentley/imodeljs-common';
 import { MonochromeMode } from '@bentley/imodeljs-common';
 import { NativeAppIpc } from '@bentley/imodeljs-common';
+import { NativeAppResponse } from '@bentley/imodeljs-common';
 import { ObservableSet } from '@bentley/bentleyjs-core';
 import { OctEncodedNormal } from '@bentley/imodeljs-common';
 import { OpenBriefcaseProps } from '@bentley/imodeljs-common';
@@ -222,6 +223,7 @@ import { RenderSchedule } from '@bentley/imodeljs-common';
 import { RenderTexture } from '@bentley/imodeljs-common';
 import { RequestBasicCredentials } from '@bentley/itwin-client';
 import { RequestOptions } from '@bentley/itwin-client';
+import { ResponseHandler } from '@bentley/imodeljs-common';
 import { RgbColor } from '@bentley/imodeljs-common';
 import { RpcRoutingToken } from '@bentley/imodeljs-common';
 import { SectionDrawingViewProps } from '@bentley/imodeljs-common';
@@ -5900,7 +5902,7 @@ export enum ModifyElementSource {
 }
 
 // @alpha
-export class NativeApp {
+export class NativeApp extends ResponseHandler implements NativeAppResponse {
     // (undocumented)
     static callBackend<T extends AsyncMethodsOf<NativeAppIpc>>(methodName: T, ...args: Parameters<NativeAppIpc[T]>): Promise<PromiseReturnType<NativeAppIpc[T]>>;
     // (undocumented)
@@ -5916,9 +5918,23 @@ export class NativeApp {
     // (undocumented)
     static get isValid(): boolean;
     // (undocumented)
+    notifyInternetConnectivityChanged(status: InternetConnectivityStatus): void;
+    // (undocumented)
+    notifyMemoryWarning(): void;
+    // (undocumented)
+    notifyUserStateChanged(arg: {
+        accessToken: any;
+        err?: string;
+    }): void;
+    // (undocumented)
     static onInternetConnectivityChanged: BeEvent<(status: InternetConnectivityStatus) => void>;
     // (undocumented)
     static onMemoryWarning: BeEvent<() => void>;
+    // (undocumented)
+    static onUserStateChanged: BeEvent<(_arg: {
+        accessToken: any;
+        err?: string | undefined;
+    }) => void>;
     // (undocumented)
     static openBriefcase(briefcaseProps: OpenBriefcaseProps): Promise<LocalBriefcaseConnection>;
     static openStorage(name: string): Promise<Storage>;
@@ -5926,6 +5942,8 @@ export class NativeApp {
     static overrideInternetConnectivity(status: InternetConnectivityStatus): Promise<void>;
     // (undocumented)
     static requestDownloadBriefcase(contextId: string, iModelId: string, downloadOptions: DownloadBriefcaseOptions, asOf?: IModelVersion, progress?: ProgressCallback): Promise<BriefcaseDownloader>;
+    // (undocumented)
+    get responseChannel(): string;
     // (undocumented)
     static shutdown(): Promise<void>;
     static startup(opts?: IModelAppOptions): Promise<void>;

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -341,6 +341,8 @@ public;ModelSelectorProps
 public;MonochromeMode
 internal;nativeAppChannel = "nativeApp"
 internal;NativeAppIpc
+public;NativeAppResponse
+public;nativeAppResponse = "nativeApp-notify"
 public;NavigationBindingValue
 public;NavigationValue
 public;nextHighestPowerOfTwo(num: number): number
@@ -427,6 +429,7 @@ beta;class RenderTexture
 beta;RenderTexture
 public;RepositoryLinkProps 
 beta;RequestNewBriefcaseProps
+public;class ResponseHandler
 public;ResponseLike 
 public;RgbColor
 public;RgbColorProps

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -341,8 +341,8 @@ public;ModelSelectorProps
 public;MonochromeMode
 internal;nativeAppChannel = "nativeApp"
 internal;NativeAppIpc
-public;NativeAppResponse
-public;nativeAppResponse = "nativeApp-notify"
+internal;NativeAppResponse
+internal;nativeAppResponse = "nativeApp-notify"
 public;NavigationBindingValue
 public;NavigationValue
 public;nextHighestPowerOfTwo(num: number): number
@@ -429,7 +429,7 @@ beta;class RenderTexture
 beta;RenderTexture
 public;RepositoryLinkProps 
 beta;RequestNewBriefcaseProps
-public;class ResponseHandler
+beta;class ResponseHandler
 public;ResponseLike 
 public;RgbColor
 public;RgbColorProps

--- a/common/api/summary/imodeljs-frontend.exports.csv
+++ b/common/api/summary/imodeljs-frontend.exports.csv
@@ -313,7 +313,7 @@ alpha;ModelDisplayTransformProvider
 public;ModelSelectorState 
 public;ModelState 
 internal;ModifyElementSource
-alpha;NativeApp
+alpha;NativeApp 
 internal;NativeAppLogger
 internal;NoRenderApp
 public;NotificationManager

--- a/common/changes/@bentley/imodeljs-backend/ipc-response-handler_2021-01-22-16-35.json
+++ b/common/changes/@bentley/imodeljs-backend/ipc-response-handler_2021-01-22-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/ipc-response-handler_2021-01-22-16-35.json
+++ b/common/changes/@bentley/imodeljs-common/ipc-response-handler_2021-01-22-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "add ResponseHandler for notifications from backend to frontend",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/ipc-response-handler_2021-01-22-16-35.json
+++ b/common/changes/@bentley/imodeljs-frontend/ipc-response-handler_2021-01-22-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/core/common/src/ipc/FrontendIpc.ts
+++ b/core/common/src/ipc/FrontendIpc.ts
@@ -99,7 +99,7 @@ export class FrontendIpc {
    * @note Ipc is only supported if [[isValid]] is true.
    */
   public static async callBackend(channelName: string, methodName: string, ...args: any[]): Promise<any> {
-    const retVal = (await this._ipc!.invoke(iTwinChannel(channelName), methodName, ...args)) as IpcInvokeReturn;
+    const retVal = (await this.invoke(channelName, methodName, ...args)) as IpcInvokeReturn;
     if (undefined !== retVal.error)
       throw new BackendError(retVal.error.errorNumber, retVal.error.name, retVal.error.message);
     return retVal.result;
@@ -107,13 +107,26 @@ export class FrontendIpc {
 
 }
 
+/**
+ * Base class for all implementations of an Ipc notification response interface. This class is implemented on your frontend to supply
+ * methods to receive notifications from your backend.
+ *
+ * Create a subclass to implement your Ipc response interface. Your class should be declared like this:
+ * ```ts
+ * class MyResponseHandler extends ResponseHandler implements MyResponseInterface
+ * ```
+ * to ensure all method names and signatures are correct. Your methods cannot have a return value.
+ *
+ * Then, call `MyResponseHandler.register` at startup to connect your class to your channel.
+ * @beta
+ */
 export abstract class ResponseHandler {
-  /** All subclasses must implement this method to specify their channel name. */
+  /** All subclasses must implement this method to specify their response channel name. */
   public abstract get responseChannel(): string;
 
   /**
    * Register this class as the handler for methods on its channel. This static method creates a new instance
-   * that becomes the handler and is `this` when its methods are called.
+   * that becomes the response handler and is `this` when its methods are called.
    * @returns A function that can be called to remove the handler.
    * @note this method should only be called once per channel. If it is called multiple times, subsequent calls replace the previous ones.
    */

--- a/core/common/src/ipc/NativeAppIpc.ts
+++ b/core/common/src/ipc/NativeAppIpc.ts
@@ -12,6 +12,7 @@ import { IModelConnectionProps, IModelRpcProps } from "../IModel";
 
 /** @internal */
 export const nativeAppChannel = "nativeApp";
+export const nativeAppResponse = "nativeApp-notify";
 
 /**
  * Type of value for storage values
@@ -32,20 +33,6 @@ export interface QueuedEvent {
   eventName: string;
   /** Event payload. The specific type depends on the event name. */
   data: any;
-}
-/** Event names and namespace exposed by iModel.js.
- * @internal
- */
-export namespace Events {
-  export namespace NativeApp {
-    export const namespace = "NativeApp";
-    export const onMemoryWarning = "onMemoryWarning";
-    export const onBriefcaseDownloadProgress = "download-progress";
-    export const onInternetConnectivityChanged = "onInternetConnectivityChanged";
-    export const onUserStateChanged = "onUserStateChanged";
-    /** [[QueuedEvent.data]] is an array of [[ModelGeometryChangesProps]]. */
-    export const modelGeometryChanges = "modelGeometryChanges";
-  }
 }
 
 /** Identifies a list of tile content Ids belonging to a single tile tree.
@@ -72,11 +59,17 @@ export enum OverriddenBy {
   User,
 }
 
+export interface NativeAppResponse {
+  onInternetConnectivityChanged: (status: InternetConnectivityStatus) => void;
+  onUserStateChanged: (arg: { accessToken: any, err?: string }) => void;
+}
+
 /**
  * The methods that may be invoked via Ipc from the frontend of a Native App and are implemented on its backend.
  * @internal
  */
 export interface NativeAppIpc {
+
   /** Send frontend log to backend.
    * @param _level Specify log level.
    * @param _category Specify log category.

--- a/core/common/src/ipc/NativeAppIpc.ts
+++ b/core/common/src/ipc/NativeAppIpc.ts
@@ -12,6 +12,7 @@ import { IModelConnectionProps, IModelRpcProps } from "../IModel";
 
 /** @internal */
 export const nativeAppChannel = "nativeApp";
+/** @internal */
 export const nativeAppResponse = "nativeApp-notify";
 
 /**
@@ -33,6 +34,16 @@ export interface QueuedEvent {
   eventName: string;
   /** Event payload. The specific type depends on the event name. */
   data: any;
+}
+/** Event names and namespace exposed by iModel.js.
+ * @internal
+ */
+export namespace Events {
+  export namespace NativeApp {
+    export const namespace = "NativeApp";
+    /** [[QueuedEvent.data]] is an array of [[ModelGeometryChangesProps]]. */
+    export const modelGeometryChanges = "modelGeometryChanges";
+  }
 }
 
 /** Identifies a list of tile content Ids belonging to a single tile tree.
@@ -59,9 +70,14 @@ export enum OverriddenBy {
   User,
 }
 
+/**
+ * Interface registered by the frontend [NotificationHandler]($common) to be notified of events from NativeApp backend.
+ * @internal
+ */
 export interface NativeAppResponse {
-  onInternetConnectivityChanged: (status: InternetConnectivityStatus) => void;
-  onUserStateChanged: (arg: { accessToken: any, err?: string }) => void;
+  notifyInternetConnectivityChanged: (status: InternetConnectivityStatus) => void;
+  notifyUserStateChanged: (arg: { accessToken: any, err?: string }) => void;
+  notifyMemoryWarning: () => void;
 }
 
 /**

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -849,12 +849,11 @@ export abstract class Viewport implements IDisposable {
    * @note this method clones the current ViewState2d and sets its baseModelId to the supplied value. The DisplayStyle and CategorySelector remain unchanged.
    */
   public async changeViewedModel2d(baseModelId: Id64String, options?: ChangeViewedModel2dOptions & ViewChangeOptions): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    if (!this.view.is2d)
+    if (!this.view.is2d())
       return;
 
     // Clone the current ViewState, change its baseModelId, and ensure the new model is loaded.
-    const newView = this.view.clone() as ViewState2d; // start by cloning the current ViewState
+    const newView = this.view.clone(); // start by cloning the current ViewState
     await newView.changeViewedModel(baseModelId);
 
     this.changeView(newView, options); // switch this viewport to use new ViewState2d

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -7,8 +7,8 @@
  */
 
 import {
-  asInstanceOf, assert, BeDuration, BeEvent, BeTimePoint, Constructor, dispose, Id64, Id64Arg, Id64Set,
-  Id64String, IDisposable, isInstanceOf, StopWatch,
+  asInstanceOf, assert, BeDuration, BeEvent, BeTimePoint, Constructor, dispose, Id64, Id64Arg, Id64Set, Id64String, IDisposable, isInstanceOf,
+  StopWatch,
 } from "@bentley/bentleyjs-core";
 import {
   Angle, AngleSweep, Arc3d, Geometry, LowAndHighXY, LowAndHighXYZ, Map4d, Matrix3d, Plane3dByOriginAndUnitNormal, Point2d, Point3d, Point4d, Range1d,
@@ -21,12 +21,19 @@ import {
 } from "@bentley/imodeljs-common";
 import { AuxCoordSystemState } from "./AuxCoordSys";
 import { BackgroundMapGeometry } from "./BackgroundMapGeometry";
+import { ChangeFlag, ChangeFlags } from "./ChangeFlags";
+import { CoordSystem } from "./CoordSystem";
 import { DisplayStyleState } from "./DisplayStyleState";
 import { ElementPicker, LocateOptions } from "./ElementLocateManager";
+import { FeatureOverrideProvider } from "./FeatureOverrideProvider";
+import { FrustumAnimator } from "./FrustumAnimator";
+import { GlobeAnimator } from "./GlobeAnimator";
 import { HitDetail, SnapDetail } from "./HitDetail";
 import { IModelApp } from "./IModelApp";
 import { IModelConnection } from "./IModelConnection";
+import { linePlaneIntersect } from "./LinePlaneIntersect";
 import { ToolTipOptions } from "./NotificationManager";
+import { PerModelCategoryVisibility } from "./PerModelCategoryVisibility";
 import { CanvasDecoration } from "./render/CanvasDecoration";
 import { Decorations } from "./render/Decorations";
 import { FeatureSymbology } from "./render/FeatureSymbology";
@@ -42,21 +49,14 @@ import { SubCategoriesCache } from "./SubCategoriesCache";
 import { TileBoundingBoxes, TiledGraphicsProvider, TileTreeReference, TileTreeSet } from "./tile/internal";
 import { EventController } from "./tools/EventController";
 import { ToolSettings } from "./tools/ToolSettings";
+import { Animator, ViewAnimationOptions, ViewChangeOptions } from "./ViewAnimation";
 import { DecorateContext, SceneContext } from "./ViewContext";
 import { GlobalLocation } from "./ViewGlobalLocation";
 import { ViewingSpace } from "./ViewingSpace";
-import { ViewRect } from "./ViewRect";
-import { ViewStatus } from "./ViewStatus";
 import { ViewPose } from "./ViewPose";
-import { ModelDisplayTransformProvider, ViewState, ViewState2d } from "./ViewState";
-import { FeatureOverrideProvider } from "./FeatureOverrideProvider";
-import { ChangeFlag, ChangeFlags } from "./ChangeFlags";
-import { CoordSystem } from "./CoordSystem";
-import { Animator, ViewAnimationOptions, ViewChangeOptions } from "./ViewAnimation";
-import { GlobeAnimator } from "./GlobeAnimator";
-import { FrustumAnimator } from "./FrustumAnimator";
-import { PerModelCategoryVisibility } from "./PerModelCategoryVisibility";
-import { linePlaneIntersect } from "./LinePlaneIntersect";
+import { ViewRect } from "./ViewRect";
+import { ModelDisplayTransformProvider, ViewState } from "./ViewState";
+import { ViewStatus } from "./ViewStatus";
 
 // cSpell:Ignore rect's ovrs subcat subcats unmounting UI's
 

--- a/core/frontend/src/oidc/MobileAuthorizationClient.ts
+++ b/core/frontend/src/oidc/MobileAuthorizationClient.ts
@@ -10,8 +10,7 @@ import { assert, BeEvent, ClientRequestContext, Logger } from "@bentley/bentleyj
 import { FrontendAuthorizationClient } from "@bentley/frontend-authorization-client";
 import { AccessToken, ImsAuthorizationClient } from "@bentley/itwin-client";
 import { FrontendLoggerCategory } from "../FrontendLoggerCategory";
-import { defaultMobileAuthorizationClientExpiryBuffer, Events, MobileAuthorizationClientConfiguration } from "@bentley/imodeljs-common";
-import { EventSource } from "../EventSource";
+import { defaultMobileAuthorizationClientExpiryBuffer, MobileAuthorizationClientConfiguration } from "@bentley/imodeljs-common";
 import { FrontendRequestContext } from "../FrontendRequestContext";
 import { NativeApp } from "../NativeApp";
 
@@ -26,7 +25,7 @@ export class MobileAuthorizationClient extends ImsAuthorizationClient implements
   public constructor(clientConfiguration: MobileAuthorizationClientConfiguration) {
     super();
     this._clientConfiguration = clientConfiguration;
-    EventSource.global.on(Events.NativeApp.namespace, Events.NativeApp.onUserStateChanged, (args: any) => {
+    NativeApp.onUserStateChanged.addListener((args: any) => {
       if (args.accessToken) {
         this._accessToken = AccessToken.fromJson(args.accessToken);
       } else {


### PR DESCRIPTION
This is helpful to group sets of notifications sent from backend -> frontend, making them type safe.