### PR TITLE
Fix analytical domain test

### DIFF
--- a/common/changes/@bentley/analytical-backend/fix-analytical-domain-test_2021-01-25-13-13.json
+++ b/common/changes/@bentley/analytical-backend/fix-analytical-domain-test_2021-01-25-13-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/analytical-backend",
+  "email": "36768600+scsewall@users.noreply.github.com"
+}

--- a/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
+++ b/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
@@ -136,7 +136,7 @@ describe("AnalyticalSchema", () => {
     assert.isTrue(Id64.isValidId64(iModelDb.elements.getElement<GeometricElement3d>(elementId).typeDefinition!.id), "Expect valid typeDefinition.id");
     elementProps.typeDefinition = undefined;
     iModelDb.elements.updateElement(elementProps);
-    assert.isTrue(Id64.isValidId64(iModelDb.elements.getElement<GeometricElement3d>(elementId).typeDefinition!.id), "Still expect valid typeDefinition.id because undefined causes update to skip it");
+    assert.isUndefined(iModelDb.elements.getElement<GeometricElement3d>(elementId).typeDefinition, "Expect typeDefinition to be undefined");
     elementProps.typeDefinition = RelatedElement.none;
     iModelDb.elements.updateElement(elementProps);
     assert.isUndefined(iModelDb.elements.getElement<GeometricElement3d>(elementId).typeDefinition, "Expect typeDefinition to be undefined");


### PR DESCRIPTION
Adjust analytical domain unit test for new updateElement behavior when a property is present but undefined.