### PR TITLE
Fix particle effect locate

### DIFF
--- a/common/changes/@bentley/frontend-devtools/particle-effect-locate_2021-01-25-16-48.json
+++ b/common/changes/@bentley/frontend-devtools/particle-effect-locate_2021-01-25-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-devtools",
+      "comment": "Fix locate for particle effects.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-devtools",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/particle-effect-locate_2021-01-25-16-48.json
+++ b/common/changes/@bentley/imodeljs-frontend/particle-effect-locate_2021-01-25-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix locate for particle effects.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend-devtools/src/effects/Explosion.ts
+++ b/core/frontend-devtools/src/effects/Explosion.ts
@@ -184,10 +184,6 @@ class ParticleSystem {
     return "Explosion effect";
   }
 
-  public async onDecorationButtonEvent(_hit: HitDetail, _ev: BeButtonEvent): Promise<EventHandled> {
-    return EventHandled.Yes;
-  }
-
   public static async addDecorator(iModel: IModelConnection): Promise<void> {
     // Note: The decorator takes ownership of the texture, and disposes of it when the decorator is disposed.
     const isOwned = true;

--- a/core/frontend-devtools/src/effects/Explosion.ts
+++ b/core/frontend-devtools/src/effects/Explosion.ts
@@ -10,7 +10,7 @@ import { Id64String } from "@bentley/bentleyjs-core";
 import { Point3d, Range1d, Vector3d } from "@bentley/geometry-core";
 import { RenderTexture } from "@bentley/imodeljs-common";
 import {
-  BeButtonEvent, DecorateContext, EventHandled, GraphicType, HitDetail, imageElementFromUrl, IModelApp, IModelConnection, ParticleCollectionBuilder, ParticleProps, Tool,
+  DecorateContext, GraphicType, HitDetail, imageElementFromUrl, IModelApp, IModelConnection, ParticleCollectionBuilder, ParticleProps, Tool,
 } from "@bentley/imodeljs-frontend";
 import { randomFloat, randomFloatInRange, randomIntegerInRange, randomPositionInRange } from "./Random";
 

--- a/core/frontend/src/render/ParticleCollectionBuilder.ts
+++ b/core/frontend/src/render/ParticleCollectionBuilder.ts
@@ -224,7 +224,9 @@ class Builder implements ParticleCollectionBuilder {
     let graphic = this._viewport.target.renderSystem.createGraphicBranch(branch, toWorld);
 
     // If we have a pickable Id, produce a batch.
-    const featureTable = this._pickableId ? new FeatureTable(1) : undefined;
+    // NB: We pass this._pickableId as the FeatureTable's modelId so that it will be treated like a reality model or a map -
+    // specifically, it can be located and display a tooltip, but can't be selected.
+    const featureTable = this._pickableId ? new FeatureTable(1, this._pickableId) : undefined;
     if (featureTable) {
       this._localToWorldTransform.multiplyRange(range, range);
       featureTable.insert(new Feature(this._pickableId));


### PR DESCRIPTION
They behave like reality models and maps: select tool will display a tooltip, and they can provide the depth point for zoom/pan/rotate, but they are not selectable.