### PR TITLE
Fix mobile backend for RPC tests using wrong port.

### DIFF
--- a/full-stack-tests/rpc/src/backend/http.ts
+++ b/full-stack-tests/rpc/src/backend/http.ts
@@ -13,7 +13,8 @@ import { TestServer } from "./TestServer";
 
 async function init() {
   const port = Number(process.env.CERTA_PORT || 3021) + 2000;
-  await setupMockMobileTest(port + 1);
+  const mobilePort = port + 2000;
+  await setupMockMobileTest(mobilePort);
 
   await commonSetup();
   registerBackendCallback(BackendTestCallbacks.getEnvironment, () => "http");
@@ -23,12 +24,14 @@ async function init() {
   // create a basic express web server
   const server = new TestServer(rpcConfig.protocol);
   await server.initialize(port);
+  // eslint-disable-next-line no-console
+  console.log(`Web backend for rpc full-stack-tests listening on port ${port}`);
 
   initializeAttachedInterfacesTest(rpcConfig);
   await initializeMockMobileTest();
 
   // eslint-disable-next-line no-console
-  console.log(`Web backend for full-stack-tests listening on port ${port}`);
+  console.log(`Mobile backend for rpc full-stack-tests listening on port ${mobilePort}`);
 }
 
 function initializeAttachedInterfacesTest(config: BentleyCloudRpcConfiguration) {

--- a/full-stack-tests/rpc/src/frontend/_Setup.test.ts
+++ b/full-stack-tests/rpc/src/frontend/_Setup.test.ts
@@ -12,13 +12,14 @@ RpcConfiguration.disableRoutingValidation = true;
 
 function initializeCloud(protocol: string) {
   const port = Number(window.location.port) + 2000;
+  const mobilePort = port + 2000;
 
   const config = BentleyCloudRpcManager.initializeClient({ info: { title: "rpc-full-stack-test", version: "v1.0" } }, rpcInterfaces);
   config.protocol.pathPrefix = `${protocol}://${window.location.hostname}:${port}`;
 
   initializeMultipleClientsTest(config.protocol.pathPrefix);
   initializeAttachedInterfacesTest(config);
-  setupMockMobileFrontend(port + 1);
+  setupMockMobileFrontend(mobilePort);
 }
 
 function setupMockMobileFrontend(port: number) {


### PR DESCRIPTION
This could cause port conflicts when running multiple builds on the same machine.  Having a larger offset obviously doesn't _guarantee_ the port will be free, but fits our normal convention for avoiding conflicts.

Also, we should really log any ports we use, as it is extremely helpful when tracking down these sorts of things.