### PR TITLE
Correctly handle capitalized SyncEventIds

### DIFF
--- a/common/changes/@bentley/ui-abstract/ui-fix-capitalized-syncuieventid_2021-02-01-14-46.json
+++ b/common/changes/@bentley/ui-abstract/ui-fix-capitalized-syncuieventid_2021-02-01-14-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-abstract",
+      "comment": "Correctly handle capitalized SyncEventIds.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-abstract",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/ui/abstract/src/test/backstage/BackstageItemsManager.test.tsx
+++ b/ui/abstract/src/test/backstage/BackstageItemsManager.test.tsx
@@ -146,69 +146,80 @@ describe("BackstageItemsManager", () => {
   });
 
   describe("uisync", () => {
-    let isVisible = true;
-    let isEnabled = true;
-    const setVisibility = (value: boolean) => { isVisible = value; };
-    const setEnabled = (value: boolean) => { isEnabled = value; };
-    const syncId = "test-on-display-changed";
-    const hiddenCondition = new ConditionalBooleanValue(() => !isVisible, [syncId]);
-    const disabledCondition = new ConditionalBooleanValue(() => !isEnabled, [syncId]);
-    const conditionalLabel = new ConditionalStringValue(() => isVisible ? "Hello" : "Goodbye", [syncId]);
-    const conditionalIcon = new ConditionalStringValue(() => isVisible ? "icon-hand-2" : "icon-hand", [syncId]);
-    const subTitleConditional = new ConditionalStringValue(() => isVisible ? "default subtitle" : "new subtitle", [syncId]);
+    it("uisync", () => {
+      let isVisible = true;
+      let isEnabled = true;
+      const setVisibility = (value: boolean) => { isVisible = value; };
+      const setEnabled = (value: boolean) => { isEnabled = value; };
+      const syncId = "test-on-display-changed";
+      const hiddenCondition = new ConditionalBooleanValue(() => !isVisible, [syncId]);
+      const disabledCondition = new ConditionalBooleanValue(() => !isEnabled, [syncId]);
+      const conditionalLabel = new ConditionalStringValue(() => isVisible ? "Hello" : "Goodbye", [syncId]);
+      const conditionalIcon = new ConditionalStringValue(() => isVisible ? "icon-hand-2" : "icon-hand", [syncId]);
+      const subTitleConditional = new ConditionalStringValue(() => isVisible ? "default subtitle" : "new subtitle", [syncId]);
 
-    const getActionItemWithNoConditions = () => BackstageItemUtilities.createActionItem("Action-NC", 100, 50, () => { }, "Custom Label", "subtitle", "icon-placeholder");  // try to init isVisible to false but this should be reset when loaded due to condition function
-    const getActionItemWithConditions = () => BackstageItemUtilities.createActionItem("Action-C", 100, 50, () => { }, conditionalLabel, subTitleConditional, conditionalIcon,
-      { isHidden: hiddenCondition });  // try to init isVisible to false but this should be reset when loaded due to condition function
-    const getStageLauncherItemWithNoConditions = () => BackstageItemUtilities.createStageLauncher("stageId-NC", 100, 50, "Custom Label", "subtitle", "icon-placeholder");
-    const getStageLauncherItemWithConditions = () => BackstageItemUtilities.createStageLauncher("stageId-C", 100, 50, conditionalLabel, subTitleConditional, conditionalIcon,
-      { isDisabled: disabledCondition });
+      const getActionItemWithNoConditions = () => BackstageItemUtilities.createActionItem("Action-NC", 100, 50, () => { }, "Custom Label", "subtitle", "icon-placeholder");  // try to init isVisible to false but this should be reset when loaded due to condition function
+      const getActionItemWithConditions = () => BackstageItemUtilities.createActionItem("Action-C", 100, 50, () => { }, conditionalLabel, subTitleConditional, conditionalIcon,
+        { isHidden: hiddenCondition });  // try to init isVisible to false but this should be reset when loaded due to condition function
+      const getStageLauncherItemWithNoConditions = () => BackstageItemUtilities.createStageLauncher("stageId-NC", 100, 50, "Custom Label", "subtitle", "icon-placeholder");
+      const getStageLauncherItemWithConditions = () => BackstageItemUtilities.createStageLauncher("stageId-C", 100, 50, conditionalLabel, subTitleConditional, conditionalIcon,
+        { isDisabled: disabledCondition });
 
-    const sut = new BackstageItemsManager();
+      const sut = new BackstageItemsManager();
 
-    sut.add([getActionItemWithNoConditions(), getActionItemWithConditions(), getStageLauncherItemWithNoConditions(), getStageLauncherItemWithConditions()]);
+      sut.add([getActionItemWithNoConditions(), getActionItemWithConditions(), getStageLauncherItemWithNoConditions(), getStageLauncherItemWithConditions()]);
 
-    const syncIds = BackstageItemsManager.getSyncIdsOfInterest(sut.items);
-    expect(syncIds.length).to.be.eq(1);
-    expect(syncIds[0]).to.be.eq(syncId);
+      const syncIds = BackstageItemsManager.getSyncIdsOfInterest(sut.items);
+      expect(syncIds.length).to.be.eq(1);
+      expect(syncIds[0]).to.be.eq(syncId);
 
-    let actionItem = sut.items.find((i) => i.id === "Action-C");
-    expect(ConditionalBooleanValue.getValue(actionItem!.isHidden)).to.be.false;
-    expect(ConditionalStringValue.getValue(actionItem!.label)).to.be.equal("Hello");
-    expect(ConditionalStringValue.getValue(actionItem!.icon)).to.be.equal("icon-hand-2");
-    expect(ConditionalStringValue.getValue(actionItem!.subtitle)).to.be.equal("default subtitle");
+      let actionItem = sut.items.find((i) => i.id === "Action-C");
+      expect(ConditionalBooleanValue.getValue(actionItem!.isHidden)).to.be.false;
+      expect(ConditionalStringValue.getValue(actionItem!.label)).to.be.equal("Hello");
+      expect(ConditionalStringValue.getValue(actionItem!.icon)).to.be.equal("icon-hand-2");
+      expect(ConditionalStringValue.getValue(actionItem!.subtitle)).to.be.equal("default subtitle");
 
-    let stageItem = sut.items.find((i) => i.id === "stageId-C");
-    expect(ConditionalBooleanValue.getValue(actionItem!.isDisabled)).to.be.false;
-    expect(ConditionalBooleanValue.getValue(actionItem!.isHidden)).to.be.false;
-    expect(ConditionalStringValue.getValue(stageItem!.label)).to.be.equal("Hello");
-    expect(ConditionalStringValue.getValue(stageItem!.icon)).to.be.equal("icon-hand-2");
-    expect(ConditionalStringValue.getValue(stageItem!.subtitle)).to.be.equal("default subtitle");
+      let stageItem = sut.items.find((i) => i.id === "stageId-C");
+      expect(ConditionalBooleanValue.getValue(actionItem!.isDisabled)).to.be.false;
+      expect(ConditionalBooleanValue.getValue(actionItem!.isHidden)).to.be.false;
+      expect(ConditionalStringValue.getValue(stageItem!.label)).to.be.equal("Hello");
+      expect(ConditionalStringValue.getValue(stageItem!.icon)).to.be.equal("icon-hand-2");
+      expect(ConditionalStringValue.getValue(stageItem!.subtitle)).to.be.equal("default subtitle");
 
-    let ncActionItem = sut.items.find((i) => i.id === "Action-NC");
-    expect(ConditionalBooleanValue.getValue(ncActionItem!.isHidden)).to.be.false;
-    let ncStageItem = sut.items.find((i) => i.id === "stageId-NC");
-    expect(ConditionalBooleanValue.getValue(ncStageItem!.isDisabled)).to.be.false;
+      let ncActionItem = sut.items.find((i) => i.id === "Action-NC");
+      expect(ConditionalBooleanValue.getValue(ncActionItem!.isHidden)).to.be.false;
+      let ncStageItem = sut.items.find((i) => i.id === "stageId-NC");
+      expect(ConditionalBooleanValue.getValue(ncStageItem!.isDisabled)).to.be.false;
 
-    setVisibility(false);
-    setEnabled(false);
-    const syncIdSet = new Set<string>([syncId]);
-    sut.refreshAffectedItems(syncIdSet);
+      setVisibility(false);
+      setEnabled(false);
+      const syncIdSet = new Set<string>([syncId]);
+      sut.refreshAffectedItems(syncIdSet);
 
-    actionItem = sut.items.find((i) => i.id === "Action-C");
-    expect(ConditionalBooleanValue.getValue(actionItem!.isHidden)).to.be.true;
-    stageItem = sut.items.find((i) => i.id === "stageId-C");
-    expect(ConditionalBooleanValue.getValue(stageItem!.isDisabled)).to.be.true;
-    ncActionItem = sut.items.find((i) => i.id === "Action-NC");
-    expect(ConditionalBooleanValue.getValue(ncActionItem!.isHidden)).to.be.false;
-    ncStageItem = sut.items.find((i) => i.id === "stageId-NC");
-    expect(ConditionalBooleanValue.getValue(ncStageItem!.isDisabled)).to.be.false;
+      actionItem = sut.items.find((i) => i.id === "Action-C");
+      expect(ConditionalBooleanValue.getValue(actionItem!.isHidden)).to.be.true;
+      stageItem = sut.items.find((i) => i.id === "stageId-C");
+      expect(ConditionalBooleanValue.getValue(stageItem!.isDisabled)).to.be.true;
+      ncActionItem = sut.items.find((i) => i.id === "Action-NC");
+      expect(ConditionalBooleanValue.getValue(ncActionItem!.isHidden)).to.be.false;
+      ncStageItem = sut.items.find((i) => i.id === "stageId-NC");
+      expect(ConditionalBooleanValue.getValue(ncStageItem!.isDisabled)).to.be.false;
 
-    expect(ConditionalStringValue.getValue(actionItem!.label)).to.be.equal("Goodbye");
-    expect(ConditionalStringValue.getValue(actionItem!.icon)).to.be.equal("icon-hand");
-    expect(ConditionalStringValue.getValue(actionItem!.subtitle)).to.be.equal("new subtitle");
-    expect(ConditionalStringValue.getValue(stageItem!.label)).to.be.equal("Goodbye");
-    expect(ConditionalStringValue.getValue(stageItem!.icon)).to.be.equal("icon-hand");
-    expect(ConditionalStringValue.getValue(stageItem!.subtitle)).to.be.equal("new subtitle");
+      expect(ConditionalStringValue.getValue(actionItem!.label)).to.be.equal("Goodbye");
+      expect(ConditionalStringValue.getValue(actionItem!.icon)).to.be.equal("icon-hand");
+      expect(ConditionalStringValue.getValue(actionItem!.subtitle)).to.be.equal("new subtitle");
+      expect(ConditionalStringValue.getValue(stageItem!.label)).to.be.equal("Goodbye");
+      expect(ConditionalStringValue.getValue(stageItem!.icon)).to.be.equal("icon-hand");
+      expect(ConditionalStringValue.getValue(stageItem!.subtitle)).to.be.equal("new subtitle");
+    });
+
+    it("should convert SyncEventIds to lowercase", () => {
+      const isHidden = new ConditionalBooleanValue(() => true, ["Test:CustomId"]);
+      const action = BackstageItemUtilities.createActionItem("TestAction", 100, 50, () => { }, "", undefined, undefined, { isHidden });
+      const sut = new BackstageItemsManager();
+      sut.add(action);
+      const syncIds = BackstageItemsManager.getSyncIdsOfInterest(sut.items);
+      syncIds.should.eql(["test:customid"]);
+    });
   });
 });

--- a/ui/abstract/src/test/items/ConditionalBooleanValue.test.ts
+++ b/ui/abstract/src/test/items/ConditionalBooleanValue.test.ts
@@ -8,7 +8,7 @@ import { ConditionalBooleanValue } from "../../ui-abstract";
 
 const trueFunc = () => true;
 const falseFunc = () => false;
-const syncEventIds = ["sync-id-one", "sync-id-two"];
+const syncEventIds = ["sync-id-one", "sync-id-two", "sync-id-THREE"];
 
 describe("ConditionalBooleanValue", () => {
   it("should construct without initial boolean value", () => {
@@ -39,6 +39,16 @@ describe("ConditionalBooleanValue", () => {
     expect(ConditionalBooleanValue.refreshValue(sut, new Set<string>(["cat"]))).to.be.false;
     expect(sut.value).to.be.false;
     expect(ConditionalBooleanValue.refreshValue(sut, new Set<string>(["sync-id-two"]))).to.be.true;
+    expect(sut.value).to.be.true;
+    expect(ConditionalBooleanValue.refreshValue(undefined, new Set<string>(["cat"]))).to.be.false;
+  });
+
+  it("test static refreshValue method with capitalized ids", () => {
+    const sut = new ConditionalBooleanValue(trueFunc, syncEventIds, false);
+    expect(sut.value).to.be.false;
+    expect(ConditionalBooleanValue.refreshValue(sut, new Set<string>(["cat"]))).to.be.false;
+    expect(sut.value).to.be.false;
+    expect(ConditionalBooleanValue.refreshValue(sut, new Set<string>(["sync-id-three"]))).to.be.true;
     expect(sut.value).to.be.true;
     expect(ConditionalBooleanValue.refreshValue(undefined, new Set<string>(["cat"]))).to.be.false;
   });

--- a/ui/abstract/src/test/items/ConditionalStringValue.test.ts
+++ b/ui/abstract/src/test/items/ConditionalStringValue.test.ts
@@ -11,7 +11,7 @@ const goodByeValue = "goodBye";
 const defaultValue = "default";
 const helloFunc = () => helloValue;
 const goodbyeFunc = () => goodByeValue;
-const syncEventIds = ["sync-id-one", "sync-id-two"];
+const syncEventIds = ["sync-id-one", "sync-id-two", "sync-id-THREE"];
 
 describe("ConditionalStringValue", () => {
   it("should construct without initial string value", () => {
@@ -51,6 +51,15 @@ describe("ConditionalStringValue", () => {
     expect(ConditionalStringValue.refreshValue(sut, new Set<string>(["sync-id-two"]))).to.be.true;
     expect(sut.value).to.be.equal(helloValue);
     expect(ConditionalStringValue.refreshValue(undefined, new Set<string>(["cat"]))).to.be.false;
+  });
 
+  it("test static refreshValue method with capitalized ids", () => {
+    const sut = new ConditionalStringValue(helloFunc, syncEventIds, defaultValue);
+    expect(sut.value).to.be.equal(defaultValue);
+    expect(ConditionalStringValue.refreshValue(sut, new Set<string>(["cat"]))).to.be.false;
+    expect(sut.value).to.be.equal(defaultValue);
+    expect(ConditionalStringValue.refreshValue(sut, new Set<string>(["sync-id-three"]))).to.be.true;
+    expect(sut.value).to.be.equal(helloValue);
+    expect(ConditionalStringValue.refreshValue(undefined, new Set<string>(["cat"]))).to.be.false;
   });
 });

--- a/ui/abstract/src/ui-abstract/backstage/BackstageItemsManager.ts
+++ b/ui/abstract/src/ui-abstract/backstage/BackstageItemsManager.ts
@@ -108,9 +108,9 @@ export class BackstageItemsManager {
     items.forEach((item) => {
       for (const [, entry] of Object.entries(item)) {
         if (entry instanceof ConditionalBooleanValue) {
-          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId));
+          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId.toLowerCase()));
         } else /* istanbul ignore else */ if (entry instanceof ConditionalStringValue) {
-          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId));
+          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId.toLowerCase()));
         }
       }
     });

--- a/ui/abstract/src/ui-abstract/items/ConditionalBooleanValue.ts
+++ b/ui/abstract/src/ui-abstract/items/ConditionalBooleanValue.ts
@@ -47,7 +47,7 @@ export class ConditionalBooleanValue {
     if (undefined === conditionalValue || !(conditionalValue instanceof ConditionalBooleanValue))
       return false;
 
-    if (conditionalValue.syncEventIds.some((value: string): boolean => eventIds.has(value)))
+    if (conditionalValue.syncEventIds.some((value: string): boolean => eventIds.has(value.toLowerCase())))
       return conditionalValue.refresh();
 
     return false;

--- a/ui/abstract/src/ui-abstract/items/ConditionalStringValue.ts
+++ b/ui/abstract/src/ui-abstract/items/ConditionalStringValue.ts
@@ -49,7 +49,7 @@ export class ConditionalStringValue {
     if (undefined === conditionalValue || !(conditionalValue instanceof ConditionalStringValue))
       return false;
 
-    if (conditionalValue.syncEventIds.some((value: string): boolean => eventIds.has(value)))
+    if (conditionalValue.syncEventIds.some((value: string): boolean => eventIds.has(value.toLowerCase())))
       return conditionalValue.refresh();
 
     return false;

--- a/ui/abstract/src/ui-abstract/statusbar/StatusBarItemsManager.ts
+++ b/ui/abstract/src/ui-abstract/statusbar/StatusBarItemsManager.ts
@@ -112,9 +112,9 @@ export class StatusBarItemsManager {
     items.forEach((item) => {
       for (const [, entry] of Object.entries(item)) {
         if (entry instanceof ConditionalBooleanValue) {
-          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId));
+          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId.toLowerCase()));
         } else /* istanbul ignore else */ if (entry instanceof ConditionalStringValue) {
-          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId));
+          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId.toLowerCase()));
         }
       }
     });

--- a/ui/abstract/src/ui-abstract/toolbars/ToolbarItemsManager.ts
+++ b/ui/abstract/src/ui-abstract/toolbars/ToolbarItemsManager.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* Licensed under the MIT License. See LICENSE.md in the project root for license terms.
+* See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 /** @packageDocumentation
  * @module Toolbar
@@ -111,9 +111,9 @@ export class ToolbarItemsManager {
     for (const item of items) {
       for (const [, entry] of Object.entries(item)) {
         if (entry instanceof ConditionalBooleanValue) {
-          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId));
+          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId.toLowerCase()));
         } else /* istanbul ignore else */ if (entry instanceof ConditionalStringValue) {
-          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId));
+          entry.syncEventIds.forEach((eventId: string) => eventIds.add(eventId.toLowerCase()));
         }
       }
 


### PR DESCRIPTION
This PR fixes an issue where conditional value would not update when capitalized sync event id is provided (since it is lowercased in the dispatcher).