### PR TITLE
Volume classification in dpta

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/volume-classification-in-dpta_2021-02-05-15-05.json
+++ b/common/changes/@bentley/imodeljs-frontend/volume-classification-in-dpta_2021-02-05-15-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "fix for running display-performance-test-app with a saved view which has volume classification using overrides",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "36053767+MarcNeely@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/SceneCompositor.ts
+++ b/core/frontend/src/render/webgl/SceneCompositor.ts
@@ -1674,7 +1674,7 @@ abstract class Compositor extends SceneCompositor {
 
     // Process the volume classifiers.
     const vcHiliteCmds = commands.getCommands(RenderPass.HiliteClassification);
-    if (0 !== vcHiliteCmds.length) {
+    if (0 !== vcHiliteCmds.length && undefined !== this._vcBranchState) {
       // Set the stencil for the given classifier stencil volume.
       system.frameBufferStack.execute(this._frameBuffers.stencilSet!, false, false, () => {
         this.target.pushState(this._vcBranchState!);


### PR DESCRIPTION
Fixed a problem which was hanging display-performance-test-app when a saved view was tested which had a volume classifier and one of the classifiers was selected or emphasized.