### PR TITLE
Adjustments to latest ECDb changes for moving properties

### DIFF
--- a/common/api/bentleyjs-core.api.md
+++ b/common/api/bentleyjs-core.api.md
@@ -201,7 +201,7 @@ export enum ChangeSetStatus {
     NoTransactions = 90127,
     ParentMismatch = 90128,
     ProcessSchemaChangesOnOpen = 90134,
-    ReverseOrReinstateSchemaChangesOnOpen = 90133,
+    ReverseOrReinstateSchemaChanges = 90133,
     SQLiteError = 90129,
     // (undocumented)
     Success = 0,

--- a/common/changes/@bentley/bentleyjs-core/move-property_2021-02-09-11-48.json
+++ b/common/changes/@bentley/bentleyjs-core/move-property_2021-02-09-11-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/bentleyjs-core",
+      "comment": "Adjusted error messages and error when reversing or reinstating schema changesets",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/bentleyjs-core",
+  "email": "rschili@users.noreply.github.com"
+}

--- a/core/bentley/src/BentleyError.ts
+++ b/core/bentley/src/BentleyError.ts
@@ -171,8 +171,8 @@ export enum ChangeSetStatus { // Note: Values must be kept in sync with ChangeSe
   CouldNotOpenDgnDb = CHANGESET_ERROR_BASE + 19,
   /** Cannot merge changes in in an open DgnDb. Close the DgnDb, and process the operation when it is opened. */
   MergeSchemaChangesOnOpen = CHANGESET_ERROR_BASE + 20,
-  /** Cannot reverse or reinstate schema changes in an open DgnDb. Close the DgnDb, and process the operation when it is opened. */
-  ReverseOrReinstateSchemaChangesOnOpen = CHANGESET_ERROR_BASE + 21,
+  /** Cannot reverse or reinstate schema changes. */
+  ReverseOrReinstateSchemaChanges = CHANGESET_ERROR_BASE + 21,
   /** Cannot process changes schema changes in an open DgnDb. Close the DgnDb, and process the operation when it is opened. */
   ProcessSchemaChangesOnOpen = CHANGESET_ERROR_BASE + 22,
   /** Cannot merge changes into a Readonly DgnDb. */
@@ -614,7 +614,7 @@ export class BentleyError extends Error {
       case ChangeSetStatus.WrongDgnDb: return "ChangeSet originated in a different Db";
       case ChangeSetStatus.CouldNotOpenDgnDb: return "Could not open the DgnDb to merge change set";
       case ChangeSetStatus.MergeSchemaChangesOnOpen: return "Cannot merge changes in in an open DgnDb. Close the DgnDb, and process the operation when it is opened";
-      case ChangeSetStatus.ReverseOrReinstateSchemaChangesOnOpen: return "Cannot reverse or reinstate schema changes in an open DgnDb. Close the DgnDb, and process the operation when it is opened";
+      case ChangeSetStatus.ReverseOrReinstateSchemaChanges: return "Cannot reverse or reinstate schema changes.";
       case ChangeSetStatus.ProcessSchemaChangesOnOpen: return "Cannot process changes schema changes in an open DgnDb. Close the DgnDb, and process the operation when it is opened";
       case ChangeSetStatus.CannotMergeIntoReadonly: return "Cannot merge changes into a Readonly DgnDb";
       case ChangeSetStatus.CannotMergeIntoMaster: return "Cannot merge changes into a Master DgnDb";

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -58,6 +58,13 @@ The new behavior is documented as part of the method documentation here:
 
 [IModelDb.Elements.updateElement]($backend)
 
+### Moving properties within an existing ECSchema
+
+ECDb now supports moving properties within the existing class hierarchy. Columns will be remapped or data will be moved to match the new structure.
+Inserting a new base class in the middle of the hierarchy which has properties is now also supported.
+As this requires data modifications during schema updates, we will no longer support reverse and reinstate on schema changesets. Attempts to do so will now raise an error.
+`ChangeStatus.ChangeSetStatus.ReverseOrReinstateSchemaChangesOnOpen` renamed to `ChangeStatus.ChangeSetStatus.ReverseOrReinstateSchemaChanges`.
+
 ## Presentation
 
 ### Setting up default formats


### PR DESCRIPTION
ECDb is getting some updates for which we disabled schema changeset reverse/reinstate.
Raman asked me to update NextVersion and update the error message in imodeljs accordingly.

This goes after pull request https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/120522 in imodel02 which by the time of reading is probably merged already.

Please have a look at the change in BentleyError.ts! This is basically a breaking change, but a very obvious one... is this okay, or should I keep the old identifier instead to not break anybody?