### PR TITLE
UI/ModelsTree: Fix getting elements' display status

### DIFF
--- a/common/changes/@bentley/ui-framework/ui-models-tree-fix-getting-elements-display-status_2021-02-10-10-14.json
+++ b/common/changes/@bentley/ui-framework/ui-models-tree-fix-getting-elements-display-status_2021-02-10-10-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "ModelsTree: Fix getting display status of element nodes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-GroupedByClass.PresentationRuleSet.json
+++ b/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-GroupedByClass.PresentationRuleSet.json
@@ -369,6 +369,9 @@
       "condition": "ContentDisplayType = \"AssemblyElementsRequest\"",
       "specifications": [
         {
+          "specType": "SelectedNodeInstances"
+        },
+        {
           "specType": "ContentRelatedInstances",
           "relationshipPaths": [
             {

--- a/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree.PresentationRuleSet.json
+++ b/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree.PresentationRuleSet.json
@@ -364,6 +364,9 @@
       "condition": "ContentDisplayType = \"AssemblyElementsRequest\"",
       "specifications": [
         {
+          "specType": "SelectedNodeInstances"
+        },
+        {
           "specType": "ContentRelatedInstances",
           "relationshipPaths": [
             {

--- a/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.GroupedByClass.json
+++ b/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.GroupedByClass.json
@@ -369,6 +369,9 @@
       "condition": "ContentDisplayType = \"AssemblyElementsRequest\"",
       "specifications": [
         {
+          "specType": "SelectedNodeInstances"
+        },
+        {
           "specType": "ContentRelatedInstances",
           "relationshipPaths": [
             {

--- a/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.json
+++ b/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.json
@@ -364,6 +364,9 @@
       "condition": "ContentDisplayType = \"AssemblyElementsRequest\"",
       "specifications": [
         {
+          "specType": "SelectedNodeInstances"
+        },
+        {
           "specType": "ContentRelatedInstances",
           "relationshipPaths": [
             {


### PR DESCRIPTION
Need to additionally include "SelectedNodeInstances" spec when requesting assembly elements ids, otherwise the element itself is not included. 