### PR TITLE
Fix Viewport.requestRedraw

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-request-redraw_2021-02-15-22-15.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-request-redraw_2021-02-15-22-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix Viewport.requestRedraw failing to request next animation frame.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -343,6 +343,7 @@ export abstract class Viewport implements IDisposable {
    */
   public requestRedraw(): void {
     this._redrawPending = true;
+    IModelApp.requestNextAnimation();
   }
 
   private _animator?: Animator;


### PR DESCRIPTION
It needs to request the next animation frame. Showed up in [screen-space effect sample](https://github.com/imodeljs/frontend-sample-showcase/pull/148#discussion_r576258383) where adjusting the effect parameters did not immediately update the screen.