### PR TITLE
Presentation: Highlight GroupInformationElement members

### DIFF
--- a/common/changes/@bentley/presentation-frontend/presentation-hilite-rules-for-GroupInformationElement_2021-02-19-09-19.json
+++ b/common/changes/@bentley/presentation-frontend/presentation-hilite-rules-for-GroupInformationElement_2021-02-19-09-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "HiliteSetProvider: return geometric elements grouped by BisCore.GroupInformationElement",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -139,6 +139,10 @@ To react to the changes, add an `await` before each `IModelExporter.export*` and
 
 ## Presentation
 
+### Highlighting members of GroupInformationElement
+
+Presentation rules used by [HiliteSetProvider]($presentation-frontend) have been modified to return geometric elements grouped by *BisCore.GroupInformationElement* instances.
+
 ### Setting up default formats
 
 A new feature was introduced, which allows supplying default unit formats to use for formatting properties that don't have a presentation unit for requested unit system. The formats are set when initializing [Presentation]($presentation-backend) and passing `PresentationManagerProps.defaultFormats`.

--- a/presentation/frontend/src/presentation-frontend/selection/HiliteRules.json
+++ b/presentation/frontend/src/presentation-frontend/selection/HiliteRules.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../node_modules/@bentley/presentation-common/Ruleset.schema.json",
+  "$schema": "../../../node_modules/@bentley/presentation-common/Ruleset.schema.json",
   "id": "presentation-frontend/HiliteRules",
   "rules": [
     {
@@ -9,22 +9,33 @@
       "specifications": [
         {
           "specType": "ContentRelatedInstances",
-          "relationships": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "ElementOwnsChildElements"
+          "relationshipPaths": [
+            [
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsChildElements"
+                },
+                "direction": "Forward",
+                "targetClass": {
+                  "schemaName": "BisCore",
+                  "className": "Subject"
+                },
+                "count": "*"
+              },
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsChildElements"
+                },
+                "direction": "Forward",
+                "targetClass": {
+                  "schemaName": "BisCore",
+                  "className": "PhysicalPartition"
+                }
+              }
             ]
-          },
-          "requiredDirection": "Forward",
-          "relatedClasses": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "Subject",
-              "PhysicalPartition"
-            ]
-          },
-          "isRecursive": true,
-          "instanceFilter": "this.IsOfClass(\"PhysicalPartition\", \"BisCore\")"
+          ]
         }
       ]
     },
@@ -52,19 +63,15 @@
       "specifications": [
         {
           "specType": "ContentRelatedInstances",
-          "relationships": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "CategoryOwnsSubCategories"
-            ]
-          },
-          "requiredDirection": "Forward",
-          "relatedClasses": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "SubCategory"
-            ]
-          }
+          "relationshipPaths": [
+            {
+              "relationship": {
+                "schemaName": "BisCore",
+                "className": "CategoryOwnsSubCategories"
+              },
+              "direction": "Forward"
+            }
+          ]
         }
       ]
     },
@@ -87,28 +94,76 @@
     },
     {
       "ruleType": "Content",
+      "condition": "ContentDisplayType = \"Graphics\" ANDALSO SelectedNode.IsOfClass(\"GroupInformationElement\", \"BisCore\")",
+      "onlyIfNotHandled": true,
+      "specifications": [
+        {
+          "specType": "ContentRelatedInstances",
+          "relationshipPaths": [
+            [
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementGroupsMembers"
+                },
+                "direction": "Forward"
+              },
+              {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsChildElements"
+                },
+                "direction": "Forward",
+                "count": "*"
+              }
+            ]
+          ],
+          "instanceFilter": "this.IsOfClass(\"GeometricElement\", \"BisCore\")"
+        }
+      ]
+    },
+    {
+      "ruleType": "Content",
       "condition": "ContentDisplayType = \"Graphics\" ANDALSO SelectedNode.IsOfClass(\"GeometricElement\", \"BisCore\")",
       "onlyIfNotHandled": true,
       "specifications": [
         {
           "specType": "ContentRelatedInstances",
-          "relationships": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "ElementOwnsChildElements"
-            ]
-          },
-          "requiredDirection": "Forward",
-          "relatedClasses": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "Element"
-            ]
-          },
-          "isRecursive": true
+          "relationshipPaths": [
+            {
+              "relationship": {
+                "schemaName": "BisCore",
+                "className": "ElementOwnsChildElements"
+              },
+              "direction": "Forward",
+              "count": "*"
+            }
+          ],
+          "instanceFilter": "this.IsOfClass(\"GeometricElement\", \"BisCore\")"
         },
         {
           "specType": "SelectedNodeInstances"
+        }
+      ]
+    },
+    {
+      "ruleType": "Content",
+      "condition": "ContentDisplayType = \"Graphics\" ANDALSO SelectedNode.IsOfClass(\"Element\", \"BisCore\")",
+      "onlyIfNotHandled": true,
+      "specifications": [
+        {
+          "specType": "ContentRelatedInstances",
+          "relationshipPaths": [
+            {
+              "relationship": {
+                "schemaName": "BisCore",
+                "className": "ElementOwnsChildElements"
+              },
+              "direction": "Forward",
+              "count": "*"
+            }
+          ],
+          "instanceFilter": "this.IsOfClass(\"GeometricElement\", \"BisCore\")"
         }
       ]
     }


### PR DESCRIPTION
- Change deprecated rules to newer replacements.
- Highlight members of `BisCore.GroupInformationElement`