### PR TITLE
Presentation: Store ruleset variables on backend to use them during hierarchy updates

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -186,6 +186,12 @@ export interface ClassInfoJSON {
     name: string;
 }
 
+// @internal (undocumented)
+export interface CommonIpcParams {
+    // (undocumented)
+    clientId: string;
+}
+
 // @public
 export type ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise<string>;
 
@@ -1576,9 +1582,17 @@ export class PresentationError extends BentleyError {
     protected _initName(): string;
 }
 
+// @internal (undocumented)
+export const presentationIpcChannel = "presentationIpcInterface-1.0";
+
 // @alpha (undocumented)
 export enum PresentationIpcEvents {
     Update = "presentation.onUpdate"
+}
+
+// @internal (undocumented)
+export interface PresentationIpcInterface {
+    setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void>;
 }
 
 // @public
@@ -2192,6 +2206,16 @@ export interface RulesetVariable {
 }
 
 // @public
+export interface RulesetVariableJSON {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    type: VariableValueTypes;
+    // (undocumented)
+    value: VariableValueJSON;
+}
+
+// @public
 export type RulesetVariableRpcRequestOptions = PresentationRpcRequestOptions<{
     rulesetId: string;
 }>;
@@ -2307,6 +2331,14 @@ export interface SelectionScopeRequestOptions<TIModel> extends RequestOptions<TI
 
 // @public
 export type SelectionScopeRpcRequestOptions = PresentationRpcRequestOptions<SelectionScopeRequestOptions<never>>;
+
+// @internal (undocumented)
+export interface SetRulesetVariableParams<TVariable> extends CommonIpcParams {
+    // (undocumented)
+    rulesetId: string;
+    // (undocumented)
+    variable: TVariable;
+}
 
 // @public
 export interface SingleSchemaClassSpecification {

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1556,7 +1556,7 @@ export type PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDelet
 export const PRESENTATION_COMMON_ROOT: string;
 
 // @internal (undocumented)
-export const PRESENTATION_IPC_CHANNEL_NAME = "presentationIpcInterface-1.0";
+export const PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface";
 
 // @alpha
 export interface PresentationDataCompareOptions<TIModel, TNodeKey> extends RequestOptionsWithRuleset<TIModel> {

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1555,6 +1555,9 @@ export type PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDelet
 // @internal (undocumented)
 export const PRESENTATION_COMMON_ROOT: string;
 
+// @internal (undocumented)
+export const PRESENTATION_IPC_CHANNEL_NAME = "presentationIpcInterface-1.0";
+
 // @alpha
 export interface PresentationDataCompareOptions<TIModel, TNodeKey> extends RequestOptionsWithRuleset<TIModel> {
     // (undocumented)
@@ -1581,9 +1584,6 @@ export class PresentationError extends BentleyError {
     constructor(errorNumber: PresentationStatus, message?: string, log?: LogFunction, getMetaData?: GetMetaDataFunction);
     protected _initName(): string;
 }
-
-// @internal (undocumented)
-export const presentationIpcChannel = "presentationIpcInterface-1.0";
 
 // @alpha (undocumented)
 export enum PresentationIpcEvents {

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -46,6 +46,7 @@ import { Ruleset } from '@bentley/presentation-common';
 import { RulesetVariable } from '@bentley/presentation-common';
 import { SelectionInfo } from '@bentley/presentation-common';
 import { SelectionScope } from '@bentley/presentation-common';
+import { SetRulesetVariableParams } from '@bentley/presentation-common';
 import { VariableValue } from '@bentley/presentation-common';
 
 // @internal (undocumented)
@@ -243,6 +244,8 @@ export class PresentationManager implements IDisposable {
     getNodesCount(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>): Promise<number>;
     // @alpha
     getPagedDistinctValues(requestOptions: DistinctValuesRequestOptions<IModelConnection, Descriptor, KeySet>): Promise<PagedResponse<DisplayValueGroup>>;
+    // @internal (undocumented)
+    get ipcRequestsHandler(): IpcRequestsHandler | undefined;
     // @alpha
     loadHierarchy(requestOptions: HierarchyRequestOptions<IModelConnection>): Promise<void>;
     // @alpha
@@ -263,6 +266,8 @@ export interface PresentationManagerProps {
     // @alpha
     activeUnitSystem?: PresentationUnitSystem;
     clientId?: string;
+    // @internal (undocumented)
+    ipcRequestsHandler?: IpcRequestsHandler;
     // @internal (undocumented)
     rpcRequestsHandler?: RpcRequestsHandler;
 }

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -18,6 +18,7 @@ public;ClassId = Id64String
 public;ClassInfo
 public;ClassInfo
 public;ClassInfoJSON
+internal;CommonIpcParams
 public;ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise
 public;ConditionContainer
 public;Content
@@ -204,7 +205,9 @@ internal;PRESENTATION_COMMON_ROOT: string
 alpha;PresentationDataCompareOptions
 alpha;PresentationDataCompareRpcOptions = PresentationRpcRequestOptions
 public;PresentationError 
+internal;presentationIpcChannel = "presentationIpcInterface-1.0"
 alpha;PresentationIpcEvents
+internal;PresentationIpcInterface
 public;PresentationRpcInterface 
 public;PresentationRpcRequestOptions
 public;PresentationStatus
@@ -274,6 +277,7 @@ public;RuleBase
 public;Ruleset
 public;RulesetsFactory
 public;RulesetVariable
+public;RulesetVariableJSON
 public;RuleTypes
 public;SameLabelInstanceGroup 
 public;SameLabelInstanceGroupApplicationStage
@@ -286,6 +290,7 @@ public;SelectionInfo
 public;SelectionScope
 public;SelectionScopeRequestOptions
 public;SelectionScopeRpcRequestOptions = PresentationRpcRequestOptions
+internal;SetRulesetVariableParams
 public;SingleSchemaClassSpecification
 public;SortDirection
 public;SortingRule = PropertySortingRule | DisabledSortingRule

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -202,10 +202,10 @@ alpha;PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo | Node
 alpha;PartialHierarchyModification
 alpha;PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON
 internal;PRESENTATION_COMMON_ROOT: string
+internal;PRESENTATION_IPC_CHANNEL_NAME = "presentationIpcInterface-1.0"
 alpha;PresentationDataCompareOptions
 alpha;PresentationDataCompareRpcOptions = PresentationRpcRequestOptions
 public;PresentationError 
-internal;presentationIpcChannel = "presentationIpcInterface-1.0"
 alpha;PresentationIpcEvents
 internal;PresentationIpcInterface
 public;PresentationRpcInterface 

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -202,7 +202,7 @@ alpha;PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo | Node
 alpha;PartialHierarchyModification
 alpha;PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON
 internal;PRESENTATION_COMMON_ROOT: string
-internal;PRESENTATION_IPC_CHANNEL_NAME = "presentationIpcInterface-1.0"
+internal;PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface"
 alpha;PresentationDataCompareOptions
 alpha;PresentationDataCompareRpcOptions = PresentationRpcRequestOptions
 public;PresentationError 

--- a/common/changes/@bentley/presentation-backend/presentation-persisted_ruleset_variables_2021-02-19-09-51.json
+++ b/common/changes/@bentley/presentation-backend/presentation-persisted_ruleset_variables_2021-02-19-09-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Added Ipc handler to allow setting ruleset variables on backend in IpcApps",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/presentation-persisted_ruleset_variables_2021-02-19-09-51.json
+++ b/common/changes/@bentley/presentation-common/presentation-persisted_ruleset_variables_2021-02-19-09-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Added PresentationIpcInterface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-frontend/presentation-persisted_ruleset_variables_2021-02-19-09-51.json
+++ b/common/changes/@bentley/presentation-frontend/presentation-persisted_ruleset_variables_2021-02-19-09-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "Changed ruleset variables storing to store them on backend in IpcApps",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -7,12 +7,12 @@
  */
 
 import { IpcHandler } from "@bentley/imodeljs-backend";
-import { presentationIpcChannel, PresentationIpcInterface, RulesetVariableJSON, SetRulesetVariableParams } from "@bentley/presentation-common";
+import { PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariableJSON, SetRulesetVariableParams } from "@bentley/presentation-common";
 import { Presentation } from "./Presentation";
 
 /** @internal */
 export class PresentationIpcHandler extends IpcHandler implements PresentationIpcInterface {
-  public channelName = presentationIpcChannel;
+  public channelName = PRESENTATION_IPC_CHANNEL_NAME;
 
   public async setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void> {
     const { variable } = params;

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -15,7 +15,7 @@ export class PresentationIpcHandler extends IpcHandler implements PresentationIp
   public channelName = PRESENTATION_IPC_CHANNEL_NAME;
 
   public async setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void> {
-    const { variable } = params;
-    Presentation.getManager(params.clientId).vars(params.rulesetId).setValue(variable.id, variable.type, variable.value);
+    const { clientId, rulesetId, variable } = params;
+    Presentation.getManager(clientId).vars(rulesetId).setValue(variable.id, variable.type, variable.value);
   }
 }

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module RPC
+ */
+
+import { IpcHandler } from "@bentley/imodeljs-backend";
+import { presentationIpcChannel, PresentationIpcInterface, RulesetVariableJSON, SetRulesetVariableParams } from "@bentley/presentation-common";
+import { Presentation } from "./Presentation";
+
+/** @internal */
+export class PresentationIpcHandler extends IpcHandler implements PresentationIpcInterface {
+  public channelName = presentationIpcChannel;
+
+  public async setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void> {
+    const { variable } = params;
+    Presentation.getManager(params.clientId).vars(params.rulesetId).setValue(variable.id, variable.type, variable.value);
+  }
+}

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -27,6 +27,7 @@ import { RulesetVariablesManager, RulesetVariablesManagerImpl } from "./RulesetV
 import { SelectionScopesHelper } from "./SelectionScopesHelper";
 import { UpdatesTracker } from "./UpdatesTracker";
 import { BackendDiagnosticsOptions, getElementKey, WithClientRequestContext } from "./Utils";
+import { PresentationIpcHandler } from "./PresentationIpcHandler";
 
 /**
  * Presentation manager working mode.
@@ -304,6 +305,7 @@ export class PresentationManager {
   private _isOneFrontendPerBackend: boolean;
   private _isDisposed: boolean;
   private _disposeIModelOpenedListener?: () => void;
+  private _disposeIpcHandler?: () => void;
   private _updatesTracker?: UpdatesTracker;
 
   /** Get / set active locale used for localizing presentation data */
@@ -361,6 +363,10 @@ export class PresentationManager {
         pollInterval: props!.updatesPollInterval!, // set if `isChangeTrackingEnabled == true`
       });
     }
+
+    if (IpcHost.isValid) {
+      this._disposeIpcHandler = PresentationIpcHandler.register();
+    }
   }
 
   /**
@@ -379,6 +385,9 @@ export class PresentationManager {
       this._updatesTracker.dispose();
       this._updatesTracker = undefined;
     }
+
+    if (this._disposeIpcHandler)
+      this._disposeIpcHandler();
 
     this._isDisposed = true;
   }

--- a/presentation/backend/src/test/PresentationIpcHandler.test.ts
+++ b/presentation/backend/src/test/PresentationIpcHandler.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import * as moq from "typemoq";
+import * as sinon from "sinon";
+import { RulesetVariableJSON, SetRulesetVariableParams, VariableValueTypes } from "@bentley/presentation-common";
+import { PresentationIpcHandler } from "../presentation-backend/PresentationIpcHandler";
+import { PresentationManager } from "../presentation-backend/PresentationManager";
+import { RulesetVariablesManager } from "../presentation-backend/RulesetVariablesManager";
+import { Presentation } from "../presentation-backend/Presentation";
+
+describe("PresentationIpcHandler", () => {
+  const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+
+  beforeEach(() => {
+    presentationManagerMock.reset();
+    sinon.stub(Presentation, "getManager").returns(presentationManagerMock.object);
+  });
+
+  describe("setRulesetVariable", () => {
+    const testRulesetId = "test-ruleset-id";
+    const variablesManagerMock = moq.Mock.ofType<RulesetVariablesManager>();
+
+    beforeEach(() => {
+      presentationManagerMock.setup((x) => x.vars(testRulesetId)).returns(() => variablesManagerMock.object);
+    });
+
+    it("sets ruleset variable", async () => {
+      const testVariable = { id: "var-id", type: VariableValueTypes.String, value: "test-val" };
+      variablesManagerMock.setup((x) => x.setValue(testVariable.id, testVariable.type, testVariable.value)).verifiable(moq.Times.once());
+
+      const ipcHandler = new PresentationIpcHandler();
+      const params: SetRulesetVariableParams<RulesetVariableJSON> = {
+        clientId: "test-client-id",
+        rulesetId: testRulesetId,
+        variable: testVariable,
+      };
+      await ipcHandler.setRulesetVariable(params);
+      variablesManagerMock.verifyAll();
+    });
+
+  });
+
+});

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -36,6 +36,7 @@ import { RulesetVariablesManagerImpl } from "../presentation-backend/RulesetVari
 import { SelectionScopesHelper } from "../presentation-backend/SelectionScopesHelper";
 import { UpdatesTracker } from "../presentation-backend/UpdatesTracker";
 import { WithClientRequestContext } from "../presentation-backend/Utils";
+import { PresentationIpcHandler } from "../presentation-backend/PresentationIpcHandler";
 
 const deepEqual = require("deep-equal"); // eslint-disable-line @typescript-eslint/no-var-requires
 describe("PresentationManager", () => {
@@ -496,6 +497,16 @@ describe("PresentationManager", () => {
       expect(() => manager.getNativePlatform()).to.throw(PresentationError);
     });
 
+    it("unregisters PresentationIpcHandler if IpcHost is valid", () => {
+      sinon.stub(IpcHost, "isValid").get(() => true);
+      const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
+      const unregisterSpy = sinon.spy();
+      sinon.stub(PresentationIpcHandler, "register").returns(unregisterSpy);
+      const manager = new PresentationManager({ addon: nativePlatformMock.object });
+      manager.dispose();
+      expect(unregisterSpy).to.be.calledOnce;
+    });
+
   });
 
   describe("getRulesetId", () => {
@@ -523,6 +534,7 @@ describe("PresentationManager", () => {
 
     it("returns correct id when input is a ruleset and in one-backend-one-frontend mode", async () => {
       sinon.stub(IpcHost, "isValid").get(() => true);
+      sinon.stub(IpcHost, "handle");
       manager = new PresentationManager({ addon: moq.Mock.ofType<NativePlatformDefinition>().object });
       const ruleset = await createRandomRuleset();
       expect(manager.getRulesetId(ruleset)).to.eq(ruleset.id);

--- a/presentation/common/src/presentation-common.ts
+++ b/presentation/common/src/presentation-common.ts
@@ -21,6 +21,7 @@ export * from "./presentation-common/RulesetVariables";
 export * from "./presentation-common/RulesetsFactory";
 export * from "./presentation-common/Update";
 export * from "./presentation-common/Utils";
+export * from "./presentation-common/PresentationIpcInterface";
 
 /**
  * @module RPC

--- a/presentation/common/src/presentation-common/PresentationIpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationIpcInterface.ts
@@ -9,7 +9,7 @@
 import { RulesetVariableJSON } from "./RulesetVariables";
 
 /** @internal */
-export const PRESENTATION_IPC_CHANNEL_NAME = "presentationIpcInterface-1.0";
+export const PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface";
 
 /** @internal */
 export interface CommonIpcParams {

--- a/presentation/common/src/presentation-common/PresentationIpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationIpcInterface.ts
@@ -9,7 +9,7 @@
 import { RulesetVariableJSON } from "./RulesetVariables";
 
 /** @internal */
-export const presentationIpcChannel = "presentationIpcInterface-1.0";
+export const PRESENTATION_IPC_CHANNEL_NAME = "presentationIpcInterface-1.0";
 
 /** @internal */
 export interface CommonIpcParams {

--- a/presentation/common/src/presentation-common/PresentationIpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationIpcInterface.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Core
+ */
+
+import { RulesetVariableJSON } from "./RulesetVariables";
+
+/** @internal */
+export const presentationIpcChannel = "presentationIpcInterface-1.0";
+
+/** @internal */
+export interface CommonIpcParams {
+  clientId: string;
+}
+
+/** @internal */
+export interface SetRulesetVariableParams<TVariable> extends CommonIpcParams {
+  rulesetId: string;
+  variable: TVariable;
+}
+
+/** @internal */
+export interface PresentationIpcInterface {
+  /** Sets ruleset variable value. */
+  setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void>;
+}

--- a/presentation/common/src/presentation-common/RulesetVariables.ts
+++ b/presentation/common/src/presentation-common/RulesetVariables.ts
@@ -53,3 +53,13 @@ export interface RulesetVariable {
   type: VariableValueTypes;
   value: VariableValue;
 }
+
+/**
+ * JSON representation of [[RulesetVariable]].
+ * @public
+ */
+export interface RulesetVariableJSON {
+  id: string;
+  type: VariableValueTypes;
+  value: VariableValueJSON;
+}

--- a/presentation/frontend/src/presentation-frontend/IpcRequestsHandler.ts
+++ b/presentation/frontend/src/presentation-frontend/IpcRequestsHandler.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AsyncMethodsOf, IpcApp, PromiseReturnType } from "@bentley/imodeljs-frontend";
-import { presentationIpcChannel, PresentationIpcInterface, RulesetVariable, SetRulesetVariableParams } from "@bentley/presentation-common";
+import { PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariable, SetRulesetVariableParams } from "@bentley/presentation-common";
 
 /** @internal */
 export class IpcRequestsHandler {
@@ -19,7 +19,7 @@ export class IpcRequestsHandler {
   }
 
   private async call<T extends AsyncMethodsOf<PresentationIpcInterface>>(methodName: T, ...args: Parameters<PresentationIpcInterface[T]>): Promise<PromiseReturnType<PresentationIpcInterface[T]>> {
-    return IpcApp.callIpcChannel(presentationIpcChannel, methodName, ...args);
+    return IpcApp.callIpcChannel(PRESENTATION_IPC_CHANNEL_NAME, methodName, ...args);
   }
 
   public async setRulesetVariable(params: Omit<SetRulesetVariableParams<RulesetVariable>, "clientId">) {

--- a/presentation/frontend/src/presentation-frontend/IpcRequestsHandler.ts
+++ b/presentation/frontend/src/presentation-frontend/IpcRequestsHandler.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { AsyncMethodsOf, IpcApp, PromiseReturnType } from "@bentley/imodeljs-frontend";
+import { presentationIpcChannel, PresentationIpcInterface, RulesetVariable, SetRulesetVariableParams } from "@bentley/presentation-common";
+
+/** @internal */
+export class IpcRequestsHandler {
+  public readonly clientId: string;
+
+  constructor(clientId: string) {
+    this.clientId = clientId;
+  }
+
+  private injectClientId<T>(params: T) {
+    return { ...params, clientId: this.clientId };
+  }
+
+  private async call<T extends AsyncMethodsOf<PresentationIpcInterface>>(methodName: T, ...args: Parameters<PresentationIpcInterface[T]>): Promise<PromiseReturnType<PresentationIpcInterface[T]>> {
+    return IpcApp.callIpcChannel(presentationIpcChannel, methodName, ...args);
+  }
+
+  public async setRulesetVariable(params: Omit<SetRulesetVariableParams<RulesetVariable>, "clientId">) {
+    return this.call("setRulesetVariable", this.injectClientId(params));
+  }
+}
+

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { BeEvent, Guid, IDisposable, Logger } from "@bentley/bentleyjs-core";
+import { BeEvent, IDisposable, Logger } from "@bentley/bentleyjs-core";
 import { IModelConnection, IpcApp } from "@bentley/imodeljs-frontend";
 import {
   Content, ContentDescriptorRequestOptions, ContentRequestOptions, ContentUpdateInfo, Descriptor, DescriptorOverrides, DisplayLabelRequestOptions,

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -125,8 +125,7 @@ export class PresentationManager implements IDisposable {
       this.activeUnitSystem = props.activeUnitSystem;
     }
 
-    const clientId = props?.clientId ?? Guid.createValue();
-    this._requestsHandler = props?.rpcRequestsHandler ?? new RpcRequestsHandler({ clientId });
+    this._requestsHandler = props?.rpcRequestsHandler ?? new RpcRequestsHandler(props ? { clientId: props.clientId } : undefined);
     this._rulesetVars = new Map<string, RulesetVariablesManager>();
     this._rulesets = RulesetManagerImpl.create();
     this._localizationHelper = new LocalizationHelper();
@@ -135,7 +134,7 @@ export class PresentationManager implements IDisposable {
     if (IpcApp.isValid) {
       // Ipc only works in ipc apps, so the `onUpdate` callback will only be called there.
       this._clearEventListener = IpcApp.addListener(PresentationIpcEvents.Update, this.onUpdate);
-      this._ipcRequestsHandler = props?.ipcRequestsHandler ?? new IpcRequestsHandler(clientId);
+      this._ipcRequestsHandler = props?.ipcRequestsHandler ?? new IpcRequestsHandler(this._requestsHandler.clientId);
     }
   }
 

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -283,8 +283,11 @@ export class PresentationManager implements IDisposable {
     }
     const rulesetId = (typeof foundRulesetOrId === "object") ? foundRulesetOrId.id : foundRulesetOrId;
     const variables = [...(rulesetVariables || [])];
-    if (!IpcApp.isValid)
+    if (!this._ipcRequestsHandler) {
+      // only need to add variables from variables manager if there's no IPC
+      // handler - if there is one, the variables are already known by the backend
       variables.push(...(await this.vars(rulesetId).getAllVariables()));
+    }
 
     return { ...options, rulesetOrId: foundRulesetOrId, rulesetVariables: variables };
   }

--- a/presentation/frontend/src/test/IpcRequestsHandler.test.ts
+++ b/presentation/frontend/src/test/IpcRequestsHandler.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { IpcApp } from "@bentley/imodeljs-frontend";
-import { presentationIpcChannel, RulesetVariable, VariableValueTypes } from "@bentley/presentation-common";
+import { PRESENTATION_IPC_CHANNEL_NAME, RulesetVariable, VariableValueTypes } from "@bentley/presentation-common";
 import { expect } from "chai";
 import sinon from "sinon";
 import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
@@ -23,7 +23,7 @@ describe("IpcRequestsHandler", () => {
       const rulesetId = "test-ruleset-id";
       const variable: RulesetVariable = { id: "var-id", type: VariableValueTypes.String, value: "test-value" };
       await handler.setRulesetVariable({ rulesetId, variable });
-      expect(callChannelStub).to.be.calledOnceWith(presentationIpcChannel, "setRulesetVariable", {
+      expect(callChannelStub).to.be.calledOnceWith(PRESENTATION_IPC_CHANNEL_NAME, "setRulesetVariable", {
         clientId: "test-client-id",
         rulesetId,
         variable,

--- a/presentation/frontend/src/test/IpcRequestsHandler.test.ts
+++ b/presentation/frontend/src/test/IpcRequestsHandler.test.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { IpcApp } from "@bentley/imodeljs-frontend";
+import { presentationIpcChannel, RulesetVariable, VariableValueTypes } from "@bentley/presentation-common";
+import { expect } from "chai";
+import sinon from "sinon";
+import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
+
+describe("IpcRequestsHandler", () => {
+  let handler: IpcRequestsHandler;
+
+  beforeEach(() => {
+    handler = new IpcRequestsHandler("test-client-id");
+  });
+
+  describe("setRulesetVariable", () => {
+
+    it("calls IpcApp.callIpcChannel with injected client id", async () => {
+      const callChannelStub = sinon.stub(IpcApp, "callIpcChannel");
+      const rulesetId = "test-ruleset-id";
+      const variable: RulesetVariable = { id: "var-id", type: VariableValueTypes.String, value: "test-value" };
+      await handler.setRulesetVariable({ rulesetId, variable });
+      expect(callChannelStub).to.be.calledOnceWith(presentationIpcChannel, "setRulesetVariable", {
+        clientId: "test-client-id",
+        rulesetId,
+        variable,
+      });
+    });
+
+  });
+
+});

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -311,6 +311,11 @@ describe("PresentationManager", () => {
 
     it("does not inject ruleset variables into request options in IpcApp", async () => {
       sinon.stub(IpcApp, "isValid").get(() => true);
+      sinon.stub(IpcApp, "addListener");
+      manager.dispose();
+      manager = PresentationManager.create({
+        rpcRequestsHandler: rpcRequestsHandlerMock.object,
+      });
       await manager.getNodesCount({  // eslint-disable-line deprecation/deprecation
         imodel: testData.imodelMock.object,
         rulesetOrId: testData.rulesetId,

--- a/test-apps/presentation-test-app/package.json
+++ b/test-apps/presentation-test-app/package.json
@@ -22,7 +22,7 @@
     "extract": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../generated-docs/extract",
     "lint": "eslint -f visualstudio --config package.json --no-eslintrc ./src/**/*.{ts,tsx} 1>&2",
     "electron": "run-p start:webserver start:electron",
-    "start:electron": "electron ./lib/backend/main.js",
+    "start:electron": "cross-env NODE_ENV=development electron ./lib/backend/main.js",
     "start:webserver": "cross-env BROWSER=none USE_FULL_SOURCEMAP=true EXTEND_ESLINT=true react-scripts start",
     "start:backend": "node --inspect --max-http-header-size=16000 lib/backend/main.js",
     "start:servers": "run-p start:webserver start:backend",

--- a/test-apps/presentation-test-app/src/frontend/index.tsx
+++ b/test-apps/presentation-test-app/src/frontend/index.tsx
@@ -8,8 +8,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Config, Logger, LogLevel, ProcessDetector } from "@bentley/bentleyjs-core";
 import { ElectronApp } from "@bentley/electron-manager/lib/ElectronFrontend";
-import { BentleyCloudRpcManager, BentleyCloudRpcParams, RpcConfiguration } from "@bentley/imodeljs-common";
-import { IModelApp } from "@bentley/imodeljs-frontend";
+import { IModelApp, WebViewerApp } from "@bentley/imodeljs-frontend";
 import { PresentationUnitSystem } from "@bentley/presentation-common";
 // __PUBLISH_EXTRACT_START__ Presentation.Frontend.Imports
 import { Presentation } from "@bentley/presentation-frontend";
@@ -23,21 +22,26 @@ import App from "./components/app/App";
 Logger.initializeToConsole();
 Logger.setLevelDefault(LogLevel.Warning);
 
-// initialize RPC
-(function initRpc() {
-  RpcConfiguration.developmentMode = true;
-  if (!ProcessDetector.isElectronAppFrontend) {
-    const rpcParams: BentleyCloudRpcParams = { info: { title: "presentation-test-app", version: "v1.0" }, uriPrefix: "http://localhost:3001" };
-    // __PUBLISH_EXTRACT_START__ Presentation.Frontend.RpcInterface
-    BentleyCloudRpcManager.initializeClient(rpcParams, rpcs);
-    // __PUBLISH_EXTRACT_END__
-  }
-})();
-
 export class SampleApp {
   private static _ready: Promise<void>;
   public static async startup(): Promise<void> {
-    await ElectronApp.startup({ iModelApp: { rpcInterfaces: rpcs } });
+    const opts = {
+      iModelApp: {
+        rpcInterfaces: rpcs,
+      },
+      webViewerApp: {
+        rpcParams: {
+          uriPrefix: "http://localhost:3001",
+          info: { title: "presentation-test-app", version: "v1.0" },
+        },
+      },
+    };
+
+    if (ProcessDetector.isElectronAppFrontend)
+      await ElectronApp.startup(opts);
+    else
+      await WebViewerApp.startup(opts);
+
     const readyPromises = new Array<Promise<void>>();
 
     const localizationNamespace = IModelApp.i18n.registerNamespace("Sample");


### PR DESCRIPTION
Added PresentationIpc to allow storing ruleset variables in IpcApp. All variables in IpcApp now are stored in backend. This allows them to be used during hierarchy updates after iModel data changes.

Native PR: 145204