### PR TITLE
Fix inconsistent image tests for view attachments

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -2476,6 +2476,8 @@ export class DrawingViewState extends ViewState2d {
     isDrawingView(): this is DrawingViewState;
     // @internal (undocumented)
     load(): Promise<void>;
+    // @internal (undocumented)
+    get secondaryViewports(): Iterable<import("./Viewport").Viewport>;
     // @internal
     get sectionDrawingInfo(): SectionDrawingInfo;
     // @internal
@@ -8751,6 +8753,8 @@ export class SheetViewState extends ViewState2d {
     isDrawingView(): this is DrawingViewState;
     // @internal
     load(): Promise<void>;
+    // @internal (undocumented)
+    get secondaryViewports(): Iterable<Viewport>;
     readonly sheetSize: Point2d;
     // (undocumented)
     toProps(): ViewStateProps;
@@ -12400,6 +12404,8 @@ export abstract class ViewState extends ElementState {
     abstract savePose(): ViewPose;
     // @internal
     get scheduleScript(): RenderScheduleState.Script | undefined;
+    // @internal
+    get secondaryViewports(): Iterable<Viewport>;
     setAspectRatioSkew(val: number): void;
     setAuxiliaryCoordinateSystem(acs?: AuxCoordSystemState): void;
     setCategorySelector(categories: CategorySelectorState): void;

--- a/common/changes/@bentley/imodeljs-frontend/dpta-await-secondary-tiles_2021-02-22-14-03.json
+++ b/common/changes/@bentley/imodeljs-frontend/dpta-await-secondary-tiles_2021-02-22-14-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/DrawingViewState.ts
+++ b/core/frontend/src/DrawingViewState.ts
@@ -449,4 +449,9 @@ export class DrawingViewState extends ViewState2d {
   public get areAllTileTreesLoaded(): boolean {
     return super.areAllTileTreesLoaded && (!this._attachment || this._attachment.view.areAllTileTreesLoaded);
   }
+
+  /** @internal */
+  public get secondaryViewports() {
+    return this._attachment ? [ this._attachment.viewport ] : super.secondaryViewports;
+  }
 }

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -1080,6 +1080,14 @@ export abstract class ViewState extends ElementState {
     // So a non-empty list of event listener removal functions indicates we are currently attached to a viewport.
     return this._unregisterCategorySelectorListeners.length > 0;
   }
+
+  /** Returns an iterator over additional Viewports used to construct this view's scene. e.g., those used for ViewAttachments and section drawings.
+   * This exists chiefly for display-performance-test-app to determine when all tiles required for the view have been loaded.
+   * @internal
+   */
+  public get secondaryViewports(): Iterable<Viewport> {
+    return [];
+  }
 }
 
 /** Defines the state of a view of 3d models.


### PR DESCRIPTION
display-performance-test-app waits for all tiles required by its viewport to be loaded before it saves the image and begins recording performance metrics. However, view attachments on sheets (and 3d section drawing attachments) use secondary offscreen viewports to select their tiles, which may still have outstanding tile requests while the onscreen viewport reports its own tiles have finished loading.

- Add `@internal` `ViewState.secondaryViewports` to iterate offscreen viewports used to construct the view's scene.
- `waitForTilesToLoad` checks outstanding requests for secondary viewports.
- When dpta logs the Ids of selected tiles, it includes those selected by secondary viewports.