### PR TITLE
UI: Allow setting child node count to undefined in TreeModel

### DIFF
--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -2908,7 +2908,7 @@ export class MutableTreeModel implements TreeModel {
     iterateTreeModelNodes(parentId?: string): IterableIterator<MutableTreeModelNode>;
     removeChild(parentId: string | undefined, childId: string): void;
     setChildren(parentId: string | undefined, nodeInputs: TreeModelNodeInput[], offset: number): void;
-    setNumChildren(parentId: string | undefined, numChildren: number): void;
+    setNumChildren(parentId: string | undefined, numChildren: number | undefined): void;
     }
 
 // @beta

--- a/common/changes/@bentley/ui-components/ui-components-tree-setnumchildren_2021-02-23-10-00.json
+++ b/common/changes/@bentley/ui-components/ui-components-tree-setnumchildren_2021-02-23-10-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "`TreeModel`: Allow `undefined` child count in `setNumChildren`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/ui/components/src/ui-components/tree/controlled/TreeModel.ts
+++ b/ui/components/src/ui-components/tree/controlled/TreeModel.ts
@@ -287,16 +287,18 @@ export class MutableTreeModel implements TreeModel {
   }
 
   /**
-   * Sets number of how many child nodes the parent will have.
-   * If parent already has some nodes they are removed.
+   * Sets the number of child nodes a parent is expected to contain. All child nodes of this parent will be subsequently
+   * removed.
    */
-  public setNumChildren(parentId: string | undefined, numChildren: number) {
+  public setNumChildren(parentId: string | undefined, numChildren: number | undefined): void {
     const parentNode = parentId === undefined ? this._rootNode : this._tree.getNode(parentId);
-    if (parentNode !== undefined) {
-      (parentNode.numChildren as number) = numChildren;
+    if (parentNode === undefined) {
+      return;
     }
 
-    this._tree.setNumChildren(parentId, numChildren);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    (parentNode.numChildren as number | undefined) = numChildren;
+    this._tree.setNumChildren(parentId, numChildren ?? 0);
   }
 
   /** Removes children specified by id.


### PR DESCRIPTION
This change introduces some way to erase the amount of child nodes a parent is expected to contain.