### PR TITLE
UI: Add ability to modify tree node ids

### DIFF
--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -2896,6 +2896,7 @@ export interface MutableTreeDataProvider extends ITreeDataProvider {
 export class MutableTreeModel implements TreeModel {
     // (undocumented)
     [immerable]: boolean;
+    changeNodeId(currentId: string, newId: string): boolean;
     clearChildren(parentId: string | undefined): void;
     computeVisibleNodes(): VisibleTreeNodes;
     getChildOffset(parentId: string | undefined, childId: string): number | undefined;
@@ -4102,6 +4103,8 @@ export class SparseTree<T extends Node> {
     removeChild(parentId: string | undefined, childId: string): void;
     // (undocumented)
     setChildren(parentId: string | undefined, children: T[], offset: number): void;
+    // (undocumented)
+    setNodeId(parentId: string | undefined, index: number, newId: string): boolean;
     // (undocumented)
     setNumChildren(parentId: string | undefined, numChildren: number): void;
 }

--- a/common/changes/@bentley/ui-components/ui-components-tree-changenodeid_2021-02-24-09-24.json
+++ b/common/changes/@bentley/ui-components/ui-components-tree-changenodeid_2021-02-24-09-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@bentley/ui-components",
-      "comment": "`MutableTreeModel`: Allow `undefined` child count in `setNumChildren`.",
+      "comment": "`MutableTreeModel`: Add `changeNodeId` method.",
       "type": "none"
     }
   ],

--- a/ui/components/src/test/tree/controlled/TreeModel.test.ts
+++ b/ui/components/src/test/tree/controlled/TreeModel.test.ts
@@ -226,7 +226,65 @@ describe("MutableTreeModel", () => {
       treeModel.insertChild(rootNode.id, childNode, 0);
       treeMock.verifyAll();
     });
+  });
 
+  describe("changeNodeId", () => {
+    beforeEach(() => {
+      treeModel = new MutableTreeModel();
+    });
+
+    it("does nothing when target node does not exist and returns `false`", () => {
+      const resultStatus = treeModel.changeNodeId("testId", "newId");
+      expect(resultStatus).to.be.false;
+      expect(treeModel.getNode("newId")).to.be.undefined;
+    });
+
+    it("does nothing when node with the same id already exists and returns `false`", () => {
+      const existingNode = createTreeModelNodeInput("existingNode");
+      treeModel.insertChild(undefined, existingNode, 0);
+      const targetNode = createTreeModelNodeInput("targetNode");
+      treeModel.insertChild(undefined, targetNode, 1);
+
+      const resultStatus = treeModel.changeNodeId("targetNode", "existingNode");
+
+      expect(resultStatus).to.be.false;
+      expect(treeModel.getNode("existingNode")!.item).to.be.deep.equal(existingNode.item);
+      expect(treeModel.getNode("targetNode")!.item).to.be.deep.equal(targetNode.item);
+    });
+
+    it("does nothing if equal ids are passed", () => {
+      const nodeInput = createTreeModelNodeInput("testId");
+      treeModel.insertChild(undefined, nodeInput, 0);
+      const resultStatus = treeModel.changeNodeId("testId", "testId");
+
+      expect(resultStatus).to.be.true;
+      expect(treeModel.getNode("testId")!.item).to.be.deep.equal(nodeInput.item);
+    });
+
+    it("changes node id", () => {
+      const nodeInput = createTreeModelNodeInput("testId");
+      treeModel.insertChild(undefined, nodeInput, 0);
+      const resultStatus = treeModel.changeNodeId("testId", "newId");
+
+      expect(resultStatus).to.be.true;
+      expect(treeModel.getNode("testId")).to.be.undefined;
+      expect(treeModel.getNode("newId")!.item).to.be.deep.equal(nodeInput.item);
+    });
+
+    it("updates hierarchy", () => {
+      treeModel.setChildren(undefined, [createTreeModelNodeInput("root1")], 0);
+      treeModel.setChildren("root1", [createTreeModelNodeInput("child1")], 0);
+      treeModel.setChildren("child1", [createTreeModelNodeInput("grandchild1")], 0);
+
+      const resultStatus = treeModel.changeNodeId("child1", "updated_id");
+
+      expect(resultStatus).to.be.true;
+      expect(treeModel.getChildren("child1")).to.be.undefined;
+      expect([...treeModel.getChildren(undefined)!]).to.be.deep.equal(["root1"]);
+      expect([...treeModel.getChildren("root1")!]).to.be.deep.equal(["updated_id"]);
+      expect([...treeModel.getChildren("updated_id")!]).to.be.deep.equal(["grandchild1"]);
+      expect(treeModel.getNode("grandchild1")!.parentId).to.be.equal("updated_id");
+    });
   });
 
   describe("setNumChildren", () => {

--- a/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
+++ b/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
@@ -9,8 +9,11 @@ import { Node, SparseArray, SparseTree } from "../../../../ui-components/tree/co
 import { createRandomMutableTreeModelNode, createRandomMutableTreeModelNodes } from "../RandomTreeNodesHelpers";
 
 describe("SparseTree", () => {
+  interface TestNode extends Node {
+    data?: number;
+  }
 
-  let sparseTree: SparseTree<Node>;
+  let sparseTree: SparseTree<TestNode>;
   let rootNode: Node;
 
   beforeEach(() => {
@@ -18,28 +21,25 @@ describe("SparseTree", () => {
     rootNode = { id: faker.random.uuid() };
   });
 
-  const verifyNodes = (actual: SparseArray<string>, expected: Node[]) => {
+  function verifyNodes<T extends Node>(actual: SparseArray<string>, expected: T[]) {
     const actualIds: string[] = [];
     for (const [item] of actual.iterateValues())
       actualIds.push(item);
 
     const expectedIds = expected.map((node) => node.id);
     expect(actualIds).to.deep.eq(expectedIds);
-  };
+  }
 
   describe("getNode", () => {
-
     it("gets node", () => {
       const nodes = createRandomMutableTreeModelNodes();
       sparseTree.setChildren(undefined, nodes, 0);
       const result = sparseTree.getNode(nodes[0].id);
       expect(result).to.deep.eq(nodes[0]);
     });
-
   });
 
   describe("getChildOffset", () => {
-
     it("returns undefined if node is not found", () => {
       expect(sparseTree.getChildOffset(undefined, "childId")).to.be.undefined;
     });
@@ -55,11 +55,9 @@ describe("SparseTree", () => {
       sparseTree.setChildren(undefined, [node], offset);
       expect(sparseTree.getChildOffset(undefined, node.id)).to.be.eq(offset);
     });
-
   });
 
   describe("setChildren", () => {
-
     describe("setting root nodes", () => {
       const rootNodes = createRandomMutableTreeModelNodes();
 
@@ -69,11 +67,9 @@ describe("SparseTree", () => {
         expect(result.getLength()).to.be.eq(rootNodes.length);
         verifyNodes(result, rootNodes);
       });
-
     });
 
     describe("setting child nodes", () => {
-
       let firstChildrenPage: Node[];
       let secondChildrenPage: Node[];
 
@@ -110,13 +106,10 @@ describe("SparseTree", () => {
         expect(result.getLength()).to.be.eq(expectedChildren.length);
         verifyNodes(result, expectedChildren);
       });
-
     });
-
   });
 
   describe("insertChild", () => {
-
     it("inserts root node", () => {
       sparseTree.insertChild(undefined, rootNode, 0);
       const result = sparseTree.getChildren(undefined)!;
@@ -145,43 +138,77 @@ describe("SparseTree", () => {
       expect(result.getLength()).to.be.eq(3);
       verifyNodes(result, [childNodes[0], newNode, childNodes[1]]);
     });
+  });
 
+  describe("setNodeId", () => {
+    it("does nothing when target node does not exist and returns `false`", () => {
+      const resultStatus = sparseTree.setNodeId("test", 0, "newId");
+      expect(resultStatus).to.be.false;
+      expect(sparseTree.getNode("newId")).to.be.undefined;
+    });
+
+    it("does nothing when node with the same id already exists and returns `false`", () => {
+      sparseTree.setChildren(undefined, [{ id: "existingId", data: 1 }, { id: "oldId" }], 0);
+      const resultStatus = sparseTree.setNodeId(undefined, 1, "existingId");
+      expect(resultStatus).to.be.false;
+      verifyNodes(sparseTree.getChildren(undefined)!, [{ id: "existingId", data: 1 }, { id: "oldId" }]);
+    });
+
+    it("does nothing if the new id matches current", () => {
+      sparseTree.setChildren(undefined, [{ id: "existingId", data: 1 }], 0);
+      const resultStatus = sparseTree.setNodeId(undefined, 0, "existingId");
+      expect(resultStatus).to.be.true;
+      verifyNodes(sparseTree.getChildren(undefined)!, [{ id: "existingId", data: 1 }]);
+    });
+
+    it("changes node id", () => {
+      sparseTree.setChildren(undefined, [{ id: "oldId", data: 1 }], 0);
+      const resultStatus = sparseTree.setNodeId(undefined, 0, "newId");
+      expect(resultStatus).to.be.true;
+      expect(sparseTree.getNode("oldId")).to.be.undefined;
+      verifyNodes(sparseTree.getChildren(undefined)!, [{ id: "newId", data: 1 }]);
+    });
+
+    it("updates hierarchy with new id", () => {
+      sparseTree.setChildren(undefined, [{ id: "root" }], 0);
+      sparseTree.setChildren("root", [{ id: "oldId" }], 0);
+      sparseTree.setChildren("oldId", [{ id: "grandchild" }], 0);
+
+      const resultStatus = sparseTree.setNodeId("root", 0, "newId");
+
+      expect(resultStatus).to.be.true;
+      expect(sparseTree.getChildren("child1")).to.be.undefined;
+      verifyNodes(sparseTree.getChildren(undefined)!, [{ id: "root" }]);
+      verifyNodes(sparseTree.getChildren("root")!, [{ id: "newId" }]);
+      verifyNodes(sparseTree.getChildren("newId")!, [{ id: "grandchild" }]);
+    });
   });
 
   describe("setNumChildren", () => {
-
-    let count: number;
-
-    beforeEach(() => {
-      count = faker.random.number();
-    });
-
-    it("sets num for root nodes", () => {
-      sparseTree.setNumChildren(undefined, count);
+    it("sets count for root nodes", () => {
+      sparseTree.setNumChildren(undefined, 10);
       const rootNodes = sparseTree.getChildren(undefined)!;
-      expect(rootNodes.getLength()).to.be.eq(count);
+      expect(rootNodes.getLength()).to.be.eq(10);
     });
 
-    it("sets count for children nodes", () => {
+    it("sets count for non-root nodes", () => {
       sparseTree.setChildren(undefined, [rootNode], 0);
-      sparseTree.setNumChildren(rootNode.id, count);
+      sparseTree.setNumChildren(rootNode.id, 10);
       const childNodes = sparseTree.getChildren(rootNode.id)!;
-      expect(childNodes.getLength()).to.be.eq(count);
+      expect(childNodes.getLength()).to.be.eq(10);
     });
 
     it("clears subtree when setting root node children count", () => {
       sparseTree.setChildren(undefined, [rootNode], 0);
       const childNodes = createRandomMutableTreeModelNodes();
       sparseTree.setChildren(rootNode.id, childNodes, 0);
-      sparseTree.setNumChildren(undefined, count);
+      sparseTree.setNumChildren(undefined, 10);
       const children = sparseTree.getChildren(rootNode.id);
       expect(children).to.be.undefined;
     });
-
   });
 
   describe("removeChild", () => {
-
     it("removes root node", () => {
       const rootNodes = createRandomMutableTreeModelNodes(3);
       sparseTree.setChildren(undefined, rootNodes, 0);
@@ -224,11 +251,9 @@ describe("SparseTree", () => {
       const children = sparseTree.getChildren(rootNode.id);
       expect(children).to.be.undefined;
     });
-
   });
 
   describe("deleteSubtree", () => {
-
     beforeEach(() => {
       sparseTree.setChildren(undefined, [rootNode], 0);
     });
@@ -264,15 +289,18 @@ describe("SparseTree", () => {
       expect(sparseTree.getChildren(rootNode.id)).to.be.undefined;
       expect(sparseTree.getNode(rootNode.id)).to.not.be.undefined;
     });
-
   });
-
 });
 
 describe("SparseArray", () => {
-
   let sparseArray: SparseArray<number>;
-  let testItems: Array<{ index: number, value: number }> = [];
+
+  interface TestItem {
+    index: number;
+    value: number;
+  }
+
+  let testItems: TestItem[] = [];
 
   beforeEach(() => {
     sparseArray = new SparseArray<number>();
@@ -280,7 +308,6 @@ describe("SparseArray", () => {
   });
 
   describe("getLength", () => {
-
     it("gets length of empty array", () => {
       expect(sparseArray.getLength()).to.be.eq(0);
     });
@@ -290,21 +317,17 @@ describe("SparseArray", () => {
       sparseArray.set(1, 2);
       expect(sparseArray.getLength()).to.be.eq(2);
     });
-
   });
 
   describe("setLength", () => {
-
     it("sets length", () => {
       const length = faker.random.number({ min: 1, max: 5 });
       sparseArray.setLength(length);
       expect(sparseArray.getLength()).to.be.eq(length);
     });
-
   });
 
   describe("get", () => {
-
     it("gets undefined if value is not set", () => {
       expect(sparseArray.get(faker.random.number())).to.be.undefined;
     });
@@ -315,11 +338,9 @@ describe("SparseArray", () => {
       const item = sparseArray.get(testItems[0].index);
       expect(item).to.not.be.undefined;
     });
-
   });
 
   describe("getIndex", () => {
-
     it("gets undefined if value is not found", () => {
       expect(sparseArray.getIndex(faker.random.number())).to.be.undefined;
     });
@@ -330,11 +351,9 @@ describe("SparseArray", () => {
       const index = sparseArray.getIndex(testItems[0].value);
       expect(index).to.be.eq(testItems[0].index);
     });
-
   });
 
   describe("set", () => {
-
     it("sets value at specific index", () => {
       sparseArray.set(testItems[0].index, testItems[0].value);
       const item = sparseArray.get(testItems[0].index);
@@ -348,11 +367,9 @@ describe("SparseArray", () => {
       const item = sparseArray.get(testItems[0].index);
       expect(item).to.be.eq(newValue);
     });
-
   });
 
   describe("insert", () => {
-
     it("inserts into empty array at first position", () => {
       sparseArray.insert(0, testItems[0].value);
       expect(sparseArray.getLength()).to.be.eq(1);
@@ -397,11 +414,9 @@ describe("SparseArray", () => {
       expect(sparseArray.get(1)).to.be.eq(insertValue);
       expect(sparseArray.get(2)).to.be.eq(testItems[1].value);
     });
-
   });
 
   describe("remove", () => {
-
     it("tries to remove from empty array", () => {
       sparseArray.remove(0);
       expect(sparseArray.getLength()).to.be.eq(0);
@@ -464,11 +479,9 @@ describe("SparseArray", () => {
       expect(sparseArray.getLength()).to.be.eq(7);
       expect(sparseArray.get(0)).to.be.eq(testItems[0].value);
     });
-
   });
 
   describe("iterateValues", () => {
-
     it("iterates through existing values", () => {
       testItems.forEach((item) => sparseArray.set(item.index, item.value));
       for (const [value, index] of sparseArray.iterateValues()) {
@@ -477,11 +490,9 @@ describe("SparseArray", () => {
         expect(value).to.be.eq(expectedItem!.value);
       }
     });
-
   });
 
   describe("indexer", () => {
-
     it("iterates over all values", () => {
       const firstItem = testItems[0];
       sparseArray.set(firstItem.index, firstItem.value);
@@ -503,7 +514,5 @@ describe("SparseArray", () => {
         current++;
       }
     });
-
   });
-
 });

--- a/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
+++ b/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
@@ -70,6 +70,35 @@ export class SparseTree<T extends Node> {
     this._idToNode[child.id] = child;
   }
 
+  public setNodeId(parentId: string | undefined, index: number, newId: string): boolean {
+    const previousNodeId = this.getChildren(parentId)?.get(index);
+    if (previousNodeId === undefined) {
+      return false;
+    }
+
+    if (previousNodeId === newId) {
+      return true;
+    }
+
+    if (this.getNode(newId) !== undefined) {
+      return false;
+    }
+
+    this._idToNode[newId] = this._idToNode[previousNodeId];
+    delete this._idToNode[previousNodeId];
+
+    this._parentToChildren[newId] = this._parentToChildren[previousNodeId];
+    delete this._parentToChildren[previousNodeId];
+
+    if (parentId === undefined) {
+      this._rootNodes.set(index, newId);
+    } else {
+      this._parentToChildren[parentId].set(index, newId);
+    }
+
+    return true;
+  }
+
   public setNumChildren(parentId: string | undefined, numChildren: number) {
     const children = this.getChildren(parentId, true)!;
     for (const [childId] of children.iterateValues()) {


### PR DESCRIPTION
When node id is changed (by modifying presentation rulesets or other ways), it is cheaper just to update the node id instead of rebuilding part of `TreeModel` hierarchy.