### PR TITLE
Fix unstable markup test

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/fix-markup-test_2021-02-24-21-19.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-markup-test_2021-02-24-21-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-markup/fix-markup-test_2021-02-24-21-18.json
+++ b/common/changes/@bentley/imodeljs-markup/fix-markup-test_2021-02-24-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-markup",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -213,7 +213,7 @@ export class IModelHost {
   public static get introspectionClient(): IntrospectionClient | undefined { return this._clientAuthIntrospectionManager?.introspectionClient; }
 
   /** @alpha */
-  public static readonly telemetry: TelemetryManager = new TelemetryManager();
+  public static readonly telemetry = new TelemetryManager();
 
   public static backendVersion = "";
   private static _cacheDir = "";

--- a/core/markup/src/test/Markup.test.ts
+++ b/core/markup/src/test/Markup.test.ts
@@ -44,11 +44,6 @@ describe("Markup", () => {
     assert.equal(text.node.innerHTML, 'test1<tspan dy="10" x="0">test2</tspan><tspan dy="10" x="0">test3</tspan>', "innerHTML");
     assert.equal(text.getMarkup(), val, "getMarkup");
 
-    const domStr = nested.svg();
-    assert.equal(domStr,
-      '<g class="svg-nested"><text transform="matrix(1,0,0,1,20,15)" style="font-family: sans-serif; font-size: 30px; stroke: none; fill: red;">test1<tspan dy="10" x="0">test2</tspan><tspan dy="10" x="0">test3</tspan></text></g>',
-      "writeDataToDom");
-
     let outline = text.getOutline(1);
     let trn = outline.attr("transform");
     assert.equal(trn, "matrix(1,0,0,1,20,15)", "transform of outline");


### PR DESCRIPTION
comparing XML generated from svg is not stable across platforms/version. Everything about what that returns is tested elsewhere, so that part of the test was unnecessary anyway.