### PR TITLE
Allow applications to react to WebGL context loss.

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -7878,6 +7878,8 @@ export abstract class RenderSystem implements IDisposable {
     antialiasSamples?: number;
     // @internal (undocumented)
     collectStatistics(_stats: RenderMemory.Statistics): void;
+    // @beta
+    static contextLossHandler(): Promise<any>;
     // @internal (undocumented)
     createBackgroundMapDrape(_drapedTree: TileTreeReference, _mapTree: MapTileTreeReference): RenderTextureDrape | undefined;
     // @internal

--- a/common/changes/@bentley/imodeljs-frontend/handle-context-loss_2021-02-24-22-03.json
+++ b/common/changes/@bentley/imodeljs-frontend/handle-context-loss_2021-02-24-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Allow applications to react to WebGL context loss by overriding RenderSystem.contextLossHandler.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/public/locales/en/iModelJs.json
+++ b/core/frontend/src/public/locales/en/iModelJs.json
@@ -98,7 +98,7 @@
     "IllegalValue": "Illegal value",
     "Details": "In case you're interested in the details:",
     "ReloadPage": "😞 Oops, something went wrong - please reload the page.",
-    "WebGLContextLost": "The WebGL rendering context was lost. See <a target=\"_blank\" href=\"https://connect-imodeljscompatibility.bentley.com/\">the WebGL compatibility checker</a> for more information.\nClosing other browser tabs before reloading the page may help."
+    "WebGLContextLost": "The WebGL rendering context was lost, most likely as a result of running out of graphics memory.\nSee <a target=\"_blank\" href=\"https://connect-imodeljscompatibility.bentley.com/\">the WebGL compatibility checker</a> for more information.\nClosing other browser tabs before reloading the page may help."
   },
   "Properties": {
     "Angle": "Angle",

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -30,6 +30,7 @@ import { RenderGraphic, RenderGraphicOwner } from "./RenderGraphic";
 import { RenderMemory } from "./RenderMemory";
 import { RenderTarget } from "./RenderTarget";
 import { ScreenSpaceEffectBuilder, ScreenSpaceEffectBuilderParams } from "./ScreenSpaceEffectBuilder";
+import { ToolAdmin } from "../tools/ToolAdmin";
 
 /* eslint-disable no-restricted-syntax */
 // cSpell:ignore deserializing subcat uninstanced wiremesh qorigin trimesh
@@ -464,6 +465,25 @@ export abstract class RenderSystem implements IDisposable {
 
   /** @internal */
   public collectStatistics(_stats: RenderMemory.Statistics): void { }
+
+  /** A function that is invoked after the WebGL context is lost. Context loss is almost always caused by excessive consumption of GPU memory.
+   * After context loss occurs, the RenderSystem will be unable to interact with WebGL by rendering viewports, creating graphics and textures, etc.
+   * By default, this function invokes [[ToolAdmin.exceptionHandler]] with a brief message describing what occurred.
+   * An application can override this behavior as follows:
+   * ```ts
+   * RenderSystem.contextLossHandler = (): Promise<any> => {
+   *  // ...your implementation here...
+   * }
+   * ```
+   * @note Context loss is reported by the browser some short time *after* it has occurred. It is not possible to determine the specific cause.
+   * @see [[TileAdmin.gpuMemoryLimit]] to limit the amount of GPU memory consumed thereby reducing the likelihood of context loss.
+   * @see [[TileAdmin.totalTileContentBytes]] for the amount of GPU memory allocated for tile graphics.
+   * @beta
+   */
+  public static async contextLossHandler(): Promise<any> {
+    const msg = IModelApp.i18n.translate("iModelJs:Errors.WebGLContextLost");
+    return ToolAdmin.exceptionHandler(msg);
+  }
 }
 
 /** A RenderSystem provides access to resources used by the internal WebGL-based rendering system.

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -472,7 +472,7 @@ export abstract class RenderSystem implements IDisposable {
    * An application can override this behavior as follows:
    * ```ts
    * RenderSystem.contextLossHandler = (): Promise<any> => {
-   *  // ...your implementation here...
+   *  // your implementation here.
    * }
    * ```
    * @note Context loss is reported by the browser some short time *after* it has occurred. It is not possible to determine the specific cause.

--- a/core/frontend/src/render/webgl/FeatureOverrides.ts
+++ b/core/frontend/src/render/webgl/FeatureOverrides.ts
@@ -350,7 +350,8 @@ export class FeatureOverrides implements WebGLDisposable {
   }
 
   public bindLUT(uniform: UniformHandle): void {
-    this._lut!.bindSampler(uniform, TextureUnit.FeatureSymbology);
+    if (this._lut)
+      this._lut.bindSampler(uniform, TextureUnit.FeatureSymbology);
   }
 
   public bindUniformSymbologyFlags(uniform: UniformHandle): void {

--- a/core/frontend/src/render/webgl/System.ts
+++ b/core/frontend/src/render/webgl/System.ts
@@ -16,7 +16,6 @@ import { SkyBox } from "../../DisplayStyleState";
 import { IModelApp } from "../../IModelApp";
 import { IModelConnection } from "../../IModelConnection";
 import { MapTileTreeReference, TileTreeReference } from "../../tile/internal";
-import { ToolAdmin } from "../../tools/ToolAdmin";
 import { Viewport } from "../../Viewport";
 import { ViewRect } from "../../ViewRect";
 import { GraphicBranch, GraphicBranchOptions } from "../GraphicBranch";
@@ -704,12 +703,7 @@ export class System extends RenderSystem implements RenderSystemDebugControl, Re
     // Make this System a subscriber to the the IModelConnection onClose event
     this._removeEventListener = IModelConnection.onClose.addListener((imodel) => this.removeIModelMap(imodel));
 
-    canvas.addEventListener("webglcontextlost", async () => this.handleContextLoss(), false);
-  }
-
-  protected async handleContextLoss(): Promise<void> {
-    const msg = IModelApp.i18n.translate("iModelJs:Errors.WebGLContextLost");
-    return ToolAdmin.exceptionHandler(msg);
+    canvas.addEventListener("webglcontextlost", async () => RenderSystem.contextLossHandler(), false);
   }
 
   /** Exposed strictly for tests. */


### PR DESCRIPTION
Add `RenderSystem.contextLossHandler`. By default it behaves the same as previously: produces an "Oops" dialog with an explanation of what occurred and a link to the WebGL compatibility checker.
Tweaked error message to mention GPU memory.
Fix an exception that could occur after context loss but before context loss is reported, causing an ugly "Oops" dialog to appear before the context loss dialog.