### PR TITLE
Presentation: Track expanded nodes in tree and store them on the backend for faster updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1177,8 +1177,7 @@
       },
       "outFiles": [
         "${workspaceFolder}/test-apps/presentation-test-app/lib/backend/**/*.js",
-        "${workspaceFolder}/{core,clients}/*/lib/**/*.js",
-        "${workspaceFolder}/ui/abstract/lib/**/*.js"
+        "${workspaceFolder}/{core,clients,presentation}/*/lib/**/*.js"
       ],
       "cascadeTerminateToConfigurations": [
         "[FRONTEND] presentation-test-app (electron)"
@@ -1194,8 +1193,7 @@
       "port": 9223,
       "outFiles": [
         "${workspaceFolder}/test-apps/presentation-test-app/lib/**/*.js",
-        "${workspaceFolder}/{core,clients}/*/lib/**/*.js",
-        "${workspaceFolder}/ui/abstract/lib/**/*.js"
+        "${workspaceFolder}/{core,clients,ui,presentation}/*/lib/**/*.js",
       ],
       "cascadeTerminateToConfigurations": [
         "[BACKEND] presentation-test-app (electron)"

--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -110,6 +110,7 @@ export class Presentation {
 
 // @beta
 export enum PresentationBackendLoggerCategory {
+    Ipc = "presentation-backend.Ipc",
     // (undocumented)
     Package = "presentation-backend",
     PresentationManager = "presentation-backend.PresentationManager",

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1593,6 +1593,7 @@ export enum PresentationIpcEvents {
 // @internal (undocumented)
 export interface PresentationIpcInterface {
     setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void>;
+    updateHierarchyState(params: UpdateHierarchyStateParams<NodeKeyJSON>): Promise<void>;
 }
 
 // @public
@@ -2439,6 +2440,18 @@ export type TypeDescription = PrimitiveTypeDescription | ArrayTypeDescription | 
 
 // @alpha (undocumented)
 export const UPDATE_FULL = "FULL";
+
+// @internal (undocumented)
+export interface UpdateHierarchyStateParams<TNodeKey> extends CommonIpcParams {
+    // (undocumented)
+    changeType: "nodesExpanded" | "nodesCollapsed";
+    // (undocumented)
+    imodelKey: string;
+    // (undocumented)
+    nodeKeys: Array<TNodeKey>;
+    // (undocumented)
+    rulesetId: string;
+}
 
 // @alpha (undocumented)
 export interface UpdateInfo {

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -422,11 +422,9 @@ export interface SelectionScopesManagerProps {
 export class StateTracker {
     constructor(ipcRequestsHandler: IpcRequestsHandler);
     // (undocumented)
+    onExpandedNodesChanged(imodel: IModelConnection, rulesetId: string, sourceId: string, expandedNodes: NodeIdentifier[]): Promise<void>;
+    // (undocumented)
     onHierarchyClosed(imodel: IModelConnection, rulesetId: string, sourceId: string): Promise<void>;
-    // (undocumented)
-    onNodesCollapsed(imodel: IModelConnection, rulesetId: string, sourceId: string, collapsedNodes: NodeIdentifier[]): Promise<void>;
-    // (undocumented)
-    onNodesExpanded(imodel: IModelConnection, rulesetId: string, sourceId: string, expandedNodes: NodeIdentifier[]): Promise<void>;
     }
 
 

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -47,6 +47,7 @@ import { RulesetVariable } from '@bentley/presentation-common';
 import { SelectionInfo } from '@bentley/presentation-common';
 import { SelectionScope } from '@bentley/presentation-common';
 import { SetRulesetVariableParams } from '@bentley/presentation-common';
+import { UpdateHierarchyStateParams } from '@bentley/presentation-common';
 import { VariableValue } from '@bentley/presentation-common';
 
 // @internal (undocumented)
@@ -155,6 +156,14 @@ export interface ISelectionProvider {
     selectionChange: SelectionChangeEvent;
 }
 
+// @internal
+export interface NodeIdentifier {
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    key: NodeKey;
+}
+
 // @public
 export class Presentation {
     static get connectivity(): IConnectivityInformationProvider;
@@ -257,6 +266,8 @@ export class PresentationManager implements IDisposable {
     // @internal (undocumented)
     get rpcRequestsHandler(): RpcRequestsHandler;
     rulesets(): RulesetManager;
+    // @internal (undocumented)
+    get stateTracker(): StateTracker | undefined;
     vars(rulesetId: string): RulesetVariablesManager;
 }
 
@@ -270,6 +281,8 @@ export interface PresentationManagerProps {
     ipcRequestsHandler?: IpcRequestsHandler;
     // @internal (undocumented)
     rpcRequestsHandler?: RpcRequestsHandler;
+    // @internal (undocumented)
+    stateTracker?: StateTracker;
 }
 
 // @beta
@@ -404,6 +417,17 @@ export interface SelectionScopesManagerProps {
     localeProvider?: () => string | undefined;
     rpcRequestsHandler: RpcRequestsHandler;
 }
+
+// @internal (undocumented)
+export class StateTracker {
+    constructor(ipcRequestsHandler: IpcRequestsHandler);
+    // (undocumented)
+    onHierarchyClosed(imodel: IModelConnection, rulesetId: string, sourceId: string): Promise<void>;
+    // (undocumented)
+    onNodesCollapsed(imodel: IModelConnection, rulesetId: string, sourceId: string, collapsedNodes: NodeIdentifier[]): Promise<void>;
+    // (undocumented)
+    onNodesExpanded(imodel: IModelConnection, rulesetId: string, sourceId: string, expandedNodes: NodeIdentifier[]): Promise<void>;
+    }
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -307,6 +307,7 @@ public;Subtract
 public;SupplementationInfo
 public;TypeDescription = PrimitiveTypeDescription | ArrayTypeDescription | StructTypeDescription
 alpha;UPDATE_FULL = "FULL"
+internal;UpdateHierarchyStateParams
 alpha;UpdateInfo
 alpha;UpdateInfo
 alpha;UpdateInfoJSON

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -13,6 +13,7 @@ beta;IFavoritePropertiesStorage
 alpha;IModelContentChangeEventArgs
 alpha;IModelHierarchyChangeEventArgs
 public;ISelectionProvider
+internal;NodeIdentifier
 public;Presentation
 beta;PresentationFrontendLoggerCategory
 public;PresentationManager 
@@ -31,3 +32,4 @@ public;SelectionManager
 public;SelectionManagerProps
 public;SelectionScopesManager
 public;SelectionScopesManagerProps
+internal;StateTracker

--- a/common/changes/@bentley/presentation-backend/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
+++ b/common/changes/@bentley/presentation-backend/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Added Ipc method 'updateHierarchyState' to allow storing hierarchy state on backend",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
+++ b/common/changes/@bentley/presentation-common/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Added 'updateHierarchyState' to PresentationIpcInterface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
+++ b/common/changes/@bentley/presentation-components/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "Added expanded nodes tracking in trees using usePresentationTreeNodeLoader with enabled hierarchy auto update",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-frontend/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
+++ b/common/changes/@bentley/presentation-frontend/presentation-expanded_nodes_tracking_2021-02-25-13-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "Added frontend 'StateTracker' for ipc apps. It allows to track and store on the backend expanded nodes for faster updates in trees using usePresentationTreeNodeLoader",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "24278440+saskliutas@users.noreply.github.com"
+}

--- a/presentation/backend/src/presentation-backend/BackendLoggerCategory.ts
+++ b/presentation/backend/src/presentation-backend/BackendLoggerCategory.ts
@@ -20,6 +20,9 @@ export enum PresentationBackendLoggerCategory {
 
   /** The logger category used by Presentation RPC implementation. */
   Rpc = "presentation-backend.Rpc",
+
+  /** The logger category used by Presentation IPC implementation. */
+  Ipc = "presentation-backend.Ipc",
 }
 
 /**

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -57,6 +57,7 @@ export interface NativePlatformDefinition extends IDisposable {
   setRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes, value: VariableValueJSON): NativePlatformResponse<void>;
 
   getUpdateInfo(): NativePlatformResponse<UpdateInfoJSON | undefined>;
+  updateHierarchyState(db: any, rulesetId: string, changeType: "nodesExpanded" | "nodesCollapsed", serializedKeys: string): NativePlatformResponse<void>;
 }
 
 /** @internal */
@@ -190,6 +191,9 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
     }
     public getUpdateInfo() {
       return this.handleResult(this._nativeAddon.getUpdateInfo());
+    }
+    public updateHierarchyState(db: any, rulesetId: string, changeType: "nodesExpanded" | "nodesCollapsed", serializedKeys: string) {
+      return this.handleResult(this._nativeAddon.updateHierarchyState(db, rulesetId, changeType, serializedKeys));
     }
   };
 };

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -25,7 +25,8 @@ export class PresentationIpcHandler extends IpcHandler implements PresentationIp
     const { clientId, imodelKey, rulesetId, changeType, nodeKeys } = params;
     const imodelDb = IModelDb.tryFindByKey(imodelKey);
     if (!imodelDb) {
-      Logger.logError(PresentationBackendLoggerCategory.Ipc, "could not found imodelDb to perform hierarchy state update");
+      Logger.logError(PresentationBackendLoggerCategory.Ipc, "Could not find IModelDb to perform hierarchy state update");
+
       return;
     }
     Presentation.getManager(clientId).getNativePlatform().updateHierarchyState(imodelDb.nativeDb, rulesetId, changeType, JSON.stringify(nodeKeys));

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -6,8 +6,10 @@
  * @module RPC
  */
 
-import { IpcHandler } from "@bentley/imodeljs-backend";
-import { PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariableJSON, SetRulesetVariableParams } from "@bentley/presentation-common";
+import { Logger } from "@bentley/bentleyjs-core";
+import { IModelDb, IpcHandler } from "@bentley/imodeljs-backend";
+import { NodeKeyJSON, PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariableJSON, SetRulesetVariableParams, UpdateHierarchyStateParams } from "@bentley/presentation-common";
+import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { Presentation } from "./Presentation";
 
 /** @internal */
@@ -17,5 +19,15 @@ export class PresentationIpcHandler extends IpcHandler implements PresentationIp
   public async setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void> {
     const { clientId, rulesetId, variable } = params;
     Presentation.getManager(clientId).vars(rulesetId).setValue(variable.id, variable.type, variable.value);
+  }
+
+  public async updateHierarchyState(params: UpdateHierarchyStateParams<NodeKeyJSON>): Promise<void> {
+    const { clientId, imodelKey, rulesetId, changeType, nodeKeys } = params;
+    const imodelDb = IModelDb.tryFindByKey(imodelKey);
+    if (!imodelDb) {
+      Logger.logError(PresentationBackendLoggerCategory.Ipc, "could not found imodelDb to perform hierarchy state update");
+      return;
+    }
+    Presentation.getManager(clientId).getNativePlatform().updateHierarchyState(imodelDb.nativeDb, rulesetId, changeType, JSON.stringify(nodeKeys));
   }
 }

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -257,6 +257,14 @@ describe("default NativePlatform", () => {
     expect(result).to.deep.equal({ result: updates });
   });
 
+  it("calls addon's updateHierarchyState", async () => {
+    addonMock.setup((x) => x.updateHierarchyState(moq.It.isAny(), "test-ruleset-id", "nodesExpanded", "[]"))
+      .returns(() => ({}))
+      .verifiable();
+    nativePlatform.updateHierarchyState({}, "test-ruleset-id", "nodesExpanded", "[]");
+    addonMock.verifyAll();
+  });
+
   it("returns imodel addon from IModelDb", () => {
     const mock = moq.Mock.ofType<IModelDb>();
     mock.setup((x) => x.nativeDb).returns(() => ({} as any)).verifiable(moq.Times.atLeastOnce());

--- a/presentation/backend/src/test/PresentationIpcHandler.test.ts
+++ b/presentation/backend/src/test/PresentationIpcHandler.test.ts
@@ -4,11 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 import * as moq from "typemoq";
 import * as sinon from "sinon";
-import { RulesetVariableJSON, SetRulesetVariableParams, VariableValueTypes } from "@bentley/presentation-common";
+import { NodeKeyJSON, RulesetVariableJSON, SetRulesetVariableParams, UpdateHierarchyStateParams, VariableValueTypes } from "@bentley/presentation-common";
 import { PresentationIpcHandler } from "../presentation-backend/PresentationIpcHandler";
 import { PresentationManager } from "../presentation-backend/PresentationManager";
 import { RulesetVariablesManager } from "../presentation-backend/RulesetVariablesManager";
 import { Presentation } from "../presentation-backend/Presentation";
+import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
+import { IModelDb, IModelJsNative } from "@bentley/imodeljs-backend";
+import { createRandomBaseNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
 
 describe("PresentationIpcHandler", () => {
   const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
@@ -39,7 +42,51 @@ describe("PresentationIpcHandler", () => {
       await ipcHandler.setRulesetVariable(params);
       variablesManagerMock.verifyAll();
     });
-
   });
 
+  describe("updateHierarchyState", () => {
+    const testRulesetId = "test-ruleset-id";
+    const nativeAddonMock = moq.Mock.ofType<NativePlatformDefinition>();
+
+    beforeEach(() => {
+      nativeAddonMock.reset();
+      presentationManagerMock.setup((x) => x.getNativePlatform()).returns(() => nativeAddonMock.object);
+    });
+
+    it("does not call native platform's updateHierarchyState if imodelDb is not found", async () => {
+      nativeAddonMock.setup((x) => x.updateHierarchyState(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
+
+      const ipcHandler = new PresentationIpcHandler();
+      const params: UpdateHierarchyStateParams<NodeKeyJSON> = {
+        clientId: "client-id",
+        rulesetId: testRulesetId,
+        imodelKey: "imodel-key",
+        changeType: "nodesExpanded",
+        nodeKeys: [],
+      };
+      await ipcHandler.updateHierarchyState(params);
+      nativeAddonMock.verifyAll();
+    });
+
+    it("calls native platform's updateHierarchyState", async () => {
+      const imodelDbMock = moq.Mock.ofType<IModelDb>();
+      const nativeDgnDbMock = moq.Mock.ofType<IModelJsNative.DgnDb>();
+      imodelDbMock.setup((x) => x.nativeDb).returns(() => nativeDgnDbMock.object);
+      sinon.stub(IModelDb, "tryFindByKey").returns(imodelDbMock.object);
+
+      const nodeKey: NodeKeyJSON = createRandomBaseNodeKey();
+      nativeAddonMock.setup((x) => x.updateHierarchyState(nativeDgnDbMock.object, testRulesetId, "nodesExpanded", JSON.stringify([nodeKey]))).verifiable(moq.Times.once());
+
+      const ipcHandler = new PresentationIpcHandler();
+      const params: UpdateHierarchyStateParams<NodeKeyJSON> = {
+        clientId: "client-id",
+        rulesetId: testRulesetId,
+        imodelKey: "imodel-key",
+        changeType: "nodesExpanded",
+        nodeKeys: [nodeKey],
+      };
+      await ipcHandler.updateHierarchyState(params);
+      nativeAddonMock.verifyAll();
+    });
+  });
 });

--- a/presentation/common/src/presentation-common/PresentationIpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationIpcInterface.ts
@@ -6,6 +6,7 @@
  * @module Core
  */
 
+import { NodeKeyJSON } from "./hierarchy/Key";
 import { RulesetVariableJSON } from "./RulesetVariables";
 
 /** @internal */
@@ -23,7 +24,18 @@ export interface SetRulesetVariableParams<TVariable> extends CommonIpcParams {
 }
 
 /** @internal */
+export interface UpdateHierarchyStateParams<TNodeKey> extends CommonIpcParams {
+  rulesetId: string;
+  imodelKey: string;
+  changeType: "nodesExpanded" | "nodesCollapsed";
+  nodeKeys: Array<TNodeKey>;
+}
+
+/** @internal */
 export interface PresentationIpcInterface {
   /** Sets ruleset variable value. */
   setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void>;
+
+  /** Updates hierarchy state saved on the backend. Hierarchy state is used when performing updates after iModel data changes */
+  updateHierarchyState(params: UpdateHierarchyStateParams<NodeKeyJSON>): Promise<void>;
 }

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -17,6 +17,7 @@ import {
 import { useDisposable } from "@bentley/ui-core";
 import { PresentationTreeDataProvider, PresentationTreeDataProviderProps } from "../DataProvider";
 import { IPresentationTreeDataProvider } from "../IPresentationTreeDataProvider";
+import { useExpandedNodesTracking } from "./UseExpandedNodesTracking";
 
 /**
  * Properties for [[usePresentationTreeNodeLoader]] hook.
@@ -86,6 +87,7 @@ interface ModelSourceUpdateProps {
 
 function useModelSourceUpdateOnIModelHierarchyUpdate(props: ModelSourceUpdateProps) {
   const { modelSource, dataProvider, reset } = props;
+  useExpandedNodesTracking({ modelSource, dataProvider, enableAutoUpdate: props.enable ?? false });
   const onIModelHierarchyChanged = useCallback(async (args: IModelHierarchyChangeEventArgs) => {
     if (args.rulesetId === dataProvider.rulesetId && args.imodelKey === dataProvider.imodel.key) {
       if (args.updateInfo === UPDATE_FULL)

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -12,12 +12,12 @@ import {
 } from "@bentley/presentation-common";
 import { IModelHierarchyChangeEventArgs, Presentation } from "@bentley/presentation-frontend";
 import {
-  isTreeModelNode, PagedTreeNodeLoader, TreeModelSource, TreeNodeItem, usePagedTreeNodeLoader, useTreeModelSource,
+  PagedTreeNodeLoader, TreeModelSource, usePagedTreeNodeLoader, useTreeModelSource,
 } from "@bentley/ui-components";
 import { useDisposable } from "@bentley/ui-core";
 import { PresentationTreeDataProvider, PresentationTreeDataProviderProps } from "../DataProvider";
 import { IPresentationTreeDataProvider } from "../IPresentationTreeDataProvider";
-import { useExpandedNodesTracking } from "./UseExpandedNodesTracking";
+import { getExpandedNodeItems, useExpandedNodesTracking } from "./UseExpandedNodesTracking";
 
 /**
  * Properties for [[usePresentationTreeNodeLoader]] hook.
@@ -147,12 +147,7 @@ function updateModelSource(_modelSource: TreeModelSource, _hierarchyModification
 }
 
 function getExpandedNodeKeys(modelSource: TreeModelSource, dataProvider: IPresentationTreeDataProvider) {
-  const expandedItems = new Array<TreeNodeItem>();
-  for (const node of modelSource.getVisibleNodes()) {
-    if (isTreeModelNode(node) && node.isExpanded)
-      expandedItems.push(node.item);
-  }
-  return expandedItems.map((item) => dataProvider.getNodeKey(item));
+  return getExpandedNodeItems(modelSource).map((item) => dataProvider.getNodeKey(item));
 }
 
 function createDataProvider(props: PresentationTreeNodeLoaderProps): IPresentationTreeDataProvider {

--- a/presentation/components/src/presentation-components/tree/controlled/UseExpandedNodesTracking.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/UseExpandedNodesTracking.ts
@@ -5,8 +5,8 @@
 
 import { useEffect, useRef } from "react";
 import { Guid } from "@bentley/bentleyjs-core";
-import { TreeModel, TreeModelChanges, TreeModelSource } from "@bentley/ui-components";
-import { NodeIdentifier, Presentation } from "@bentley/presentation-frontend";
+import { isTreeModelNode, TreeModelSource, TreeNodeItem } from "@bentley/ui-components";
+import { Presentation } from "@bentley/presentation-frontend";
 import { IPresentationTreeDataProvider } from "../IPresentationTreeDataProvider";
 
 /** @internal */
@@ -19,7 +19,6 @@ export interface UseExpandedNodesTrackingProps {
 /** @internal */
 export function useExpandedNodesTracking(props: UseExpandedNodesTrackingProps) {
   const { modelSource, dataProvider, enableAutoUpdate } = props;
-  const prevModel = useRef<TreeModel>(modelSource.getModel());
   const componentId = useRef(Guid.createValue());
 
   useEffect(() => {
@@ -27,23 +26,13 @@ export function useExpandedNodesTracking(props: UseExpandedNodesTrackingProps) {
       return;
 
     const sourceId = componentId.current;
-    const removeModelChangeListener = modelSource.onModelChanged.addListener(([model, changes]) => {
-      if (!Presentation.presentation.stateTracker) {
-        prevModel.current = model;
+    const removeModelChangeListener = modelSource.onModelChanged.addListener(() => {
+      if (!Presentation.presentation.stateTracker)
         return;
-      }
 
-      const { expandedNodes, collapsedNodes } = getExpandedCollapsedNodes(prevModel.current, model, changes, dataProvider);
-      prevModel.current = model;
-
-      if (expandedNodes.length !== 0) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        Presentation.presentation.stateTracker.onNodesExpanded(dataProvider.imodel, dataProvider.rulesetId, sourceId, expandedNodes);
-      }
-      if (collapsedNodes.length !== 0) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        Presentation.presentation.stateTracker.onNodesCollapsed(dataProvider.imodel, dataProvider.rulesetId, sourceId, collapsedNodes);
-      }
+      const expandedNodes = getExpandedNodeItems(modelSource).map((item) => ({ id: item.id, key: dataProvider.getNodeKey(item) }));
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      Presentation.presentation.stateTracker.onExpandedNodesChanged(dataProvider.imodel, dataProvider.rulesetId, sourceId, expandedNodes);
     });
 
     return () => {
@@ -54,48 +43,12 @@ export function useExpandedNodesTracking(props: UseExpandedNodesTrackingProps) {
   }, [modelSource, dataProvider, enableAutoUpdate]);
 }
 
-function getExpandedCollapsedNodes(prevModel: TreeModel, currModel: TreeModel, changes: TreeModelChanges, dataProvider: IPresentationTreeDataProvider) {
-  const expandedNodes: NodeIdentifier[] = [];
-  const collapsedNodes: NodeIdentifier[] = [];
-  // model was empty check if expanded root nodes were added
-  if (prevModel.getRootNode().numChildren === undefined) {
-    for (const nodeId of changes.addedNodeIds) {
-      const node = currModel.getNode(nodeId);
-      // istanbul ignore if
-      if (!node)
-        continue;
-
-      if (node.isExpanded)
-        expandedNodes.push({ id: node.id, key: dataProvider.getNodeKey(node.item) });
-    }
+/** @internal */
+export function getExpandedNodeItems(modelSource: TreeModelSource) {
+  const expandedItems = new Array<TreeNodeItem>();
+  for (const node of modelSource.getVisibleNodes()) {
+    if (isTreeModelNode(node) && node.isExpanded)
+      expandedItems.push(node.item);
   }
-
-  // check modified nodes
-  for (const nodeId of changes.modifiedNodeIds) {
-    const prevNode = prevModel.getNode(nodeId);
-    const currNode = currModel.getNode(nodeId);
-    // istanbul ignore if
-    if (!prevNode || !currNode)
-      continue;
-
-    if (!prevNode.isExpanded && currNode.isExpanded) {
-      expandedNodes.push({ id: currNode.id, key: dataProvider.getNodeKey(currNode.item) });
-      // add all child nodes of this node that are already in the model and are expanded
-      expandedNodes.push(...collectExpandedChildren(currModel, currNode.id, dataProvider));
-    } else if (prevNode.isExpanded && !currNode.isExpanded) {
-      collapsedNodes.push({ id: currNode.id, key: dataProvider.getNodeKey(currNode.item) });
-      // add all child nodes of this node that were in the model and were expanded
-      collapsedNodes.push(...collectExpandedChildren(prevModel, prevNode.id, dataProvider));
-    }
-  }
-  return { expandedNodes, collapsedNodes };
-}
-
-function collectExpandedChildren(model: TreeModel, parentId: string, dataProvider: IPresentationTreeDataProvider) {
-  const expandedNodes: NodeIdentifier[] = [];
-  for (const node of model.iterateTreeModelNodes(parentId)) {
-    if (node.isExpanded)
-      expandedNodes.push({ id: node.id, key: dataProvider.getNodeKey(node.item) });
-  }
-  return expandedNodes;
+  return expandedItems;
 }

--- a/presentation/components/src/presentation-components/tree/controlled/UseExpandedNodesTracking.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/UseExpandedNodesTracking.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { useEffect, useRef } from "react";
+import { Guid } from "@bentley/bentleyjs-core";
+import { TreeModel, TreeModelChanges, TreeModelSource } from "@bentley/ui-components";
+import { NodeIdentifier, Presentation } from "@bentley/presentation-frontend";
+import { IPresentationTreeDataProvider } from "../IPresentationTreeDataProvider";
+
+/** @internal */
+export interface UseExpandedNodesTrackingProps {
+  modelSource: TreeModelSource;
+  dataProvider: IPresentationTreeDataProvider;
+  enableAutoUpdate: boolean;
+}
+
+/** @internal */
+export function useExpandedNodesTracking(props: UseExpandedNodesTrackingProps) {
+  const { modelSource, dataProvider, enableAutoUpdate } = props;
+  const prevModel = useRef<TreeModel>(modelSource.getModel());
+  const componentId = useRef(Guid.createValue());
+
+  useEffect(() => {
+    if (!enableAutoUpdate)
+      return;
+
+    const sourceId = componentId.current;
+    const removeModelChangeListener = modelSource.onModelChanged.addListener(([model, changes]) => {
+      if (!Presentation.presentation.stateTracker) {
+        prevModel.current = model;
+        return;
+      }
+
+      const { expandedNodes, collapsedNodes } = getExpandedCollapsedNodes(prevModel.current, model, changes, dataProvider);
+      prevModel.current = model;
+
+      if (expandedNodes.length !== 0) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        Presentation.presentation.stateTracker.onNodesExpanded(dataProvider.imodel, dataProvider.rulesetId, sourceId, expandedNodes);
+      }
+      if (collapsedNodes.length !== 0) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        Presentation.presentation.stateTracker.onNodesCollapsed(dataProvider.imodel, dataProvider.rulesetId, sourceId, collapsedNodes);
+      }
+    });
+
+    return () => {
+      removeModelChangeListener();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      Presentation.presentation.stateTracker?.onHierarchyClosed(dataProvider.imodel, dataProvider.rulesetId, sourceId);
+    };
+  }, [modelSource, dataProvider, enableAutoUpdate]);
+}
+
+function getExpandedCollapsedNodes(prevModel: TreeModel, currModel: TreeModel, changes: TreeModelChanges, dataProvider: IPresentationTreeDataProvider) {
+  const expandedNodes: NodeIdentifier[] = [];
+  const collapsedNodes: NodeIdentifier[] = [];
+  // model was empty check if expanded root nodes were added
+  if (prevModel.getRootNode().numChildren === undefined) {
+    for (const nodeId of changes.addedNodeIds) {
+      const node = currModel.getNode(nodeId);
+      // istanbul ignore if
+      if (!node)
+        continue;
+
+      if (node.isExpanded)
+        expandedNodes.push({ id: node.id, key: dataProvider.getNodeKey(node.item) });
+    }
+  }
+
+  // check modified nodes
+  for (const nodeId of changes.modifiedNodeIds) {
+    const prevNode = prevModel.getNode(nodeId);
+    const currNode = currModel.getNode(nodeId);
+    // istanbul ignore if
+    if (!prevNode || !currNode)
+      continue;
+
+    if (!prevNode.isExpanded && currNode.isExpanded) {
+      expandedNodes.push({ id: currNode.id, key: dataProvider.getNodeKey(currNode.item) });
+      // add all child nodes of this node that are already in the model and are expanded
+      expandedNodes.push(...collectExpandedChildren(currModel, currNode.id, dataProvider));
+    } else if (prevNode.isExpanded && !currNode.isExpanded) {
+      collapsedNodes.push({ id: currNode.id, key: dataProvider.getNodeKey(currNode.item) });
+      // add all child nodes of this node that were in the model and were expanded
+      collapsedNodes.push(...collectExpandedChildren(prevModel, prevNode.id, dataProvider));
+    }
+  }
+  return { expandedNodes, collapsedNodes };
+}
+
+function collectExpandedChildren(model: TreeModel, parentId: string, dataProvider: IPresentationTreeDataProvider) {
+  const expandedNodes: NodeIdentifier[] = [];
+  for (const node of model.iterateTreeModelNodes(parentId)) {
+    if (node.isExpanded)
+      expandedNodes.push({ id: node.id, key: dataProvider.getNodeKey(node.item) });
+  }
+  return expandedNodes;
+}

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -12,7 +12,7 @@ import { RegisteredRuleset, Ruleset, VariableValue, VariableValueTypes } from "@
 import { IModelHierarchyChangeEventArgs, Presentation, PresentationManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
 import { PropertyRecord } from "@bentley/ui-abstract";
 import { TreeDataChangesListener, TreeModelNodeInput, TreeNodeItem } from "@bentley/ui-components";
-import { renderHook } from "@testing-library/react-hooks";
+import { cleanup, renderHook } from "@testing-library/react-hooks";
 import { IPresentationTreeDataProvider } from "../../../presentation-components";
 import { PresentationTreeNodeLoaderProps, usePresentationTreeNodeLoader } from "../../../presentation-components/tree/controlled/TreeHooks";
 import { createRandomTreeNodeItem, mockPresentationManager } from "../../_helpers/UiComponents";
@@ -42,10 +42,12 @@ describe("usePresentationNodeLoader", () => {
     onIModelHierarchyChanged = mocks.presentationManager.object.onIModelHierarchyChanged;
     onRulesetModified = mocks.rulesetsManager.object.onRulesetModified;
     onRulesetVariableChanged = mocks.rulesetVariablesManager.object.onVariableChanged;
+    mocks.presentationManager.setup((x) => x.stateTracker).returns(() => undefined);
     Presentation.setPresentationManager(mocks.presentationManager.object);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await cleanup();
     Presentation.terminate();
   });
 

--- a/presentation/components/src/test/tree/controlled/UseExpandedNodesTracking.test.ts
+++ b/presentation/components/src/test/tree/controlled/UseExpandedNodesTracking.test.ts
@@ -78,7 +78,8 @@ describe("UseExpandedNodesTracking", () => {
     expect(addListenerSpy).to.be.not.called;
   });
 
-  it("adds and removers 'onModelChange' event listener if auto update is enabled", () => {
+  it("adds and removes 'onModelChange' event listener if auto update is enabled", () => {
+
     const addListenerSpy = sinon.spy(modelSource.onModelChanged, "addListener");
     const removeListenerSpy = sinon.spy(modelSource.onModelChanged, "removeListener");
     const { unmount } = renderHook(

--- a/presentation/components/src/test/tree/controlled/UseExpandedNodesTracking.test.ts
+++ b/presentation/components/src/test/tree/controlled/UseExpandedNodesTracking.test.ts
@@ -103,35 +103,35 @@ describe("UseExpandedNodesTracking", () => {
     stateTrackerMock.verifyAll();
   });
 
-  it("calls 'onNodeExpanded' when expanded root node is added to model", () => {
+  it("calls 'onExpandedNodesChanged' with root node when expanded root node is added to model", () => {
     const node = createNodeItem("root-1");
     renderHook(
       useExpandedNodesTracking,
       { initialProps },
     );
 
-    stateTrackerMock.setup(async (x) => x.onNodesExpanded(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
+    stateTrackerMock.setup(async (x) => x.onExpandedNodesChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
     modelSource.modifyModel((model) => {
       model.setChildren(undefined, [createTreeModelInput(node, true)], 0);
     });
     stateTrackerMock.verifyAll();
   });
 
-  it("does not call 'onNodeExpanded' when non expanded root node is added to model", () => {
+  it("call 'onExpandedNodesChanged' without nodes when non expanded root node is added to model", () => {
     const node = createNodeItem("root-1");
     renderHook(
       useExpandedNodesTracking,
       { initialProps },
     );
 
-    stateTrackerMock.setup(async (x) => x.onNodesExpanded(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
+    stateTrackerMock.setup(async (x) => x.onExpandedNodesChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [])).verifiable(moq.Times.once());
     modelSource.modifyModel((model) => {
       model.setChildren(undefined, [createTreeModelInput(node, false)], 0);
     });
     stateTrackerMock.verifyAll();
   });
 
-  it("calls 'onNodeExpanded' when existing node is expanded", () => {
+  it("calls 'onExpandedNodesChanged' with existing node that was expanded", () => {
     const node = createNodeItem("root-1");
     modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node)], 0); });
     renderHook(
@@ -139,14 +139,14 @@ describe("UseExpandedNodesTracking", () => {
       { initialProps },
     );
 
-    stateTrackerMock.setup(async (x) => x.onNodesExpanded(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
+    stateTrackerMock.setup(async (x) => x.onExpandedNodesChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
     modelSource.modifyModel((model) => {
       model.getNode(node.id)!.isExpanded = true;
     });
     stateTrackerMock.verifyAll();
   });
 
-  it("calls 'onNodeExpanded' with expanded children nodes when parent is expanded", () => {
+  it("calls 'onExpandedNodesChanged' with expanded children nodes and parent when parent is expanded", () => {
     const node = createNodeItem("root-1");
     const children = [createNodeItem("child-1"), createNodeItem("child-2")];
     modelSource.modifyModel((model) => {
@@ -158,29 +158,14 @@ describe("UseExpandedNodesTracking", () => {
       { initialProps },
     );
 
-    stateTrackerMock.setup(async (x) => x.onNodesExpanded(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }, { id: children[1].id, key: children[1].key }])).verifiable(moq.Times.once());
+    stateTrackerMock.setup(async (x) => x.onExpandedNodesChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }, { id: children[1].id, key: children[1].key }])).verifiable(moq.Times.once());
     modelSource.modifyModel((model) => {
       model.getNode(node.id)!.isExpanded = true;
     });
     stateTrackerMock.verifyAll();
   });
 
-  it("does not call 'onNodesExpanded' when expanded node is modified", () => {
-    const node = createNodeItem("root-1");
-    modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, false)], 0); });
-    renderHook(
-      useExpandedNodesTracking,
-      { initialProps }
-    );
-
-    stateTrackerMock.setup(async (x) => x.onNodesExpanded(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
-    modelSource.modifyModel((model) => {
-      model.getNode(node.id)!.isSelected = true;
-    });
-    stateTrackerMock.verifyAll();
-  });
-
-  it("calls 'onNodesCollapsed' when node is collapsed", () => {
+  it("calls 'onExpandedNodesChanged' without nodes when node is collapsed", () => {
     const node = createNodeItem("root-1");
     modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, true)], 0); });
     renderHook(
@@ -188,14 +173,14 @@ describe("UseExpandedNodesTracking", () => {
       { initialProps }
     );
 
-    stateTrackerMock.setup(async (x) => x.onNodesCollapsed(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
+    stateTrackerMock.setup(async (x) => x.onExpandedNodesChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [])).verifiable(moq.Times.once());
     modelSource.modifyModel((model) => {
       model.getNode(node.id)!.isExpanded = false;
     });
     stateTrackerMock.verifyAll();
   });
 
-  it("calls 'onNodesCollapsed' with expanded child nodes when parent is collapsed", () => {
+  it("calls 'onExpandedNodesChanged' without nodes when parent with expanded child nodes is collapsed", () => {
     const node = createNodeItem("root-1");
     const children = [createNodeItem("child-1"), createNodeItem("child-2")];
     modelSource.modifyModel((model) => {
@@ -207,24 +192,9 @@ describe("UseExpandedNodesTracking", () => {
       { initialProps }
     );
 
-    stateTrackerMock.setup(async (x) => x.onNodesCollapsed(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }, { id: children[1].id, key: children[1].key }])).verifiable(moq.Times.once());
+    stateTrackerMock.setup(async (x) => x.onExpandedNodesChanged(imodelMock.object, rulesetId, moq.It.isAnyString(), [])).verifiable(moq.Times.once());
     modelSource.modifyModel((model) => {
       model.getNode(node.id)!.isExpanded = false;
-    });
-    stateTrackerMock.verifyAll();
-  });
-
-  it("does not call 'onNodesCollapsed' when expanded node is modified", () => {
-    const node = createNodeItem("root-1");
-    modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, true)], 0); });
-    renderHook(
-      useExpandedNodesTracking,
-      { initialProps }
-    );
-
-    stateTrackerMock.setup(async (x) => x.onNodesCollapsed(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
-    modelSource.modifyModel((model) => {
-      model.getNode(node.id)!.isSelected = true;
     });
     stateTrackerMock.verifyAll();
   });

--- a/presentation/components/src/test/tree/controlled/UseExpandedNodesTracking.test.ts
+++ b/presentation/components/src/test/tree/controlled/UseExpandedNodesTracking.test.ts
@@ -1,0 +1,230 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as moq from "typemoq";
+import { cleanup, renderHook } from "@testing-library/react-hooks";
+import { useExpandedNodesTracking, UseExpandedNodesTrackingProps } from "../../../presentation-components/tree/controlled/UseExpandedNodesTracking";
+import { TreeModelNodeInput, TreeModelSource, TreeNodeItem } from "@bentley/ui-components";
+import { IPresentationTreeDataProvider } from "../../../presentation-components";
+import { NodeKey } from "@bentley/presentation-common";
+import { mockPresentationManager } from "../../_helpers/UiComponents";
+import { Presentation, StateTracker } from "@bentley/presentation-frontend";
+import { createRandomECInstancesNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
+import { createLabelRecord } from "../../../presentation-components/common/Utils";
+import { IModelConnection } from "@bentley/imodeljs-frontend";
+
+interface TestTreeNodeItem extends TreeNodeItem {
+  key: NodeKey;
+}
+
+function createNodeItem(nodeId: string): TestTreeNodeItem {
+  return { id: nodeId, label: createLabelRecord({ displayValue: nodeId, typeName: "string", rawValue: nodeId }, nodeId), key: createRandomECInstancesNodeKey() };
+}
+
+function createTreeModelInput(node: TestTreeNodeItem, isExpanded?: boolean): TreeModelNodeInput {
+  return {
+    id: node.id,
+    isExpanded: isExpanded ?? false,
+    isLoading: false,
+    isSelected: false,
+    label: node.label,
+    item: node,
+  };
+}
+
+describe("UseExpandedNodesTracking", () => {
+  const dataProviderMock = moq.Mock.ofType<IPresentationTreeDataProvider>();
+  const imodelMock = moq.Mock.ofType<IModelConnection>();
+  const stateTrackerMock = moq.Mock.ofType<StateTracker>();
+  const rulesetId = "ruleset-id";
+  let modelSource: TreeModelSource;
+  let initialProps: UseExpandedNodesTrackingProps;
+
+  beforeEach(() => {
+    stateTrackerMock.reset();
+    dataProviderMock.reset();
+    dataProviderMock.setup((x) => x.getNodeKey(moq.It.isAny())).returns((node) => (node as TestTreeNodeItem).key);
+    dataProviderMock.setup((x) => x.imodel).returns(() => imodelMock.object);
+    dataProviderMock.setup((x) => x.rulesetId).returns(() => rulesetId);
+
+    modelSource = new TreeModelSource();
+    initialProps = {
+      modelSource,
+      dataProvider: dataProviderMock.object,
+      enableAutoUpdate: true,
+    };
+
+    const presentationMocks = mockPresentationManager();
+    presentationMocks.presentationManager.setup((x) => x.stateTracker).returns(() => stateTrackerMock.object);
+    Presentation.setPresentationManager(presentationMocks.presentationManager.object);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    Presentation.terminate();
+  });
+
+  it("does not add 'onModelChange' event listener if auto update is disabled", () => {
+    const addListenerSpy = sinon.spy(modelSource.onModelChanged, "addListener");
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps: { ...initialProps, enableAutoUpdate: false } },
+    );
+
+    expect(addListenerSpy).to.be.not.called;
+  });
+
+  it("adds and removers 'onModelChange' event listener if auto update is enabled", () => {
+    const addListenerSpy = sinon.spy(modelSource.onModelChanged, "addListener");
+    const removeListenerSpy = sinon.spy(modelSource.onModelChanged, "removeListener");
+    const { unmount } = renderHook(
+      useExpandedNodesTracking,
+      { initialProps },
+    );
+
+    expect(addListenerSpy).to.be.calledOnce;
+    unmount();
+    expect(removeListenerSpy).to.be.calledOnce;
+  });
+
+  it("calls 'onHierarchyClosed' when unmounted", () => {
+    const { unmount } = renderHook(
+      useExpandedNodesTracking,
+      { initialProps },
+    );
+
+    stateTrackerMock.setup(async (x) => x.onHierarchyClosed(imodelMock.object, rulesetId, moq.It.isAnyString())).verifiable(moq.Times.once());
+    unmount();
+    stateTrackerMock.verifyAll();
+  });
+
+  it("calls 'onNodeExpanded' when expanded root node is added to model", () => {
+    const node = createNodeItem("root-1");
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps },
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesExpanded(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
+    modelSource.modifyModel((model) => {
+      model.setChildren(undefined, [createTreeModelInput(node, true)], 0);
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("does not call 'onNodeExpanded' when non expanded root node is added to model", () => {
+    const node = createNodeItem("root-1");
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps },
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesExpanded(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
+    modelSource.modifyModel((model) => {
+      model.setChildren(undefined, [createTreeModelInput(node, false)], 0);
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("calls 'onNodeExpanded' when existing node is expanded", () => {
+    const node = createNodeItem("root-1");
+    modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node)], 0); });
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps },
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesExpanded(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
+    modelSource.modifyModel((model) => {
+      model.getNode(node.id)!.isExpanded = true;
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("calls 'onNodeExpanded' with expanded children nodes when parent is expanded", () => {
+    const node = createNodeItem("root-1");
+    const children = [createNodeItem("child-1"), createNodeItem("child-2")];
+    modelSource.modifyModel((model) => {
+      model.setChildren(undefined, [createTreeModelInput(node)], 0);
+      model.setChildren(node.id, [createTreeModelInput(children[0], false), createTreeModelInput(children[1], true)], 0);
+    });
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps },
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesExpanded(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }, { id: children[1].id, key: children[1].key }])).verifiable(moq.Times.once());
+    modelSource.modifyModel((model) => {
+      model.getNode(node.id)!.isExpanded = true;
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("does not call 'onNodesExpanded' when expanded node is modified", () => {
+    const node = createNodeItem("root-1");
+    modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, false)], 0); });
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps }
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesExpanded(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
+    modelSource.modifyModel((model) => {
+      model.getNode(node.id)!.isSelected = true;
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("calls 'onNodesCollapsed' when node is collapsed", () => {
+    const node = createNodeItem("root-1");
+    modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, true)], 0); });
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps }
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesCollapsed(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }])).verifiable(moq.Times.once());
+    modelSource.modifyModel((model) => {
+      model.getNode(node.id)!.isExpanded = false;
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("calls 'onNodesCollapsed' with expanded child nodes when parent is collapsed", () => {
+    const node = createNodeItem("root-1");
+    const children = [createNodeItem("child-1"), createNodeItem("child-2")];
+    modelSource.modifyModel((model) => {
+      model.setChildren(undefined, [createTreeModelInput(node, true)], 0);
+      model.setChildren(node.id, [createTreeModelInput(children[0], false), createTreeModelInput(children[1], true)], 0);
+    });
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps }
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesCollapsed(imodelMock.object, rulesetId, moq.It.isAnyString(), [{ id: node.id, key: node.key }, { id: children[1].id, key: children[1].key }])).verifiable(moq.Times.once());
+    modelSource.modifyModel((model) => {
+      model.getNode(node.id)!.isExpanded = false;
+    });
+    stateTrackerMock.verifyAll();
+  });
+
+  it("does not call 'onNodesCollapsed' when expanded node is modified", () => {
+    const node = createNodeItem("root-1");
+    modelSource.modifyModel((model) => { model.setChildren(undefined, [createTreeModelInput(node, true)], 0); });
+    renderHook(
+      useExpandedNodesTracking,
+      { initialProps }
+    );
+
+    stateTrackerMock.setup(async (x) => x.onNodesCollapsed(moq.It.isAny(), moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).verifiable(moq.Times.never());
+    modelSource.modifyModel((model) => {
+      model.getNode(node.id)!.isSelected = true;
+    });
+    stateTrackerMock.verifyAll();
+  });
+});

--- a/presentation/frontend/src/presentation-frontend.ts
+++ b/presentation/frontend/src/presentation-frontend.ts
@@ -19,6 +19,7 @@ export {
   FavoritePropertiesScope, getFieldInfos, createFieldOrderInfos,
 } from "./presentation-frontend/favorite-properties/FavoritePropertiesManager";
 export { IFavoritePropertiesStorage } from "./presentation-frontend/favorite-properties/FavoritePropertiesStorage";
+export { NodeIdentifier, StateTracker } from "./presentation-frontend/StateTracker";
 
 /**
  * @module Logging

--- a/presentation/frontend/src/presentation-frontend/IpcRequestsHandler.ts
+++ b/presentation/frontend/src/presentation-frontend/IpcRequestsHandler.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AsyncMethodsOf, IpcApp, PromiseReturnType } from "@bentley/imodeljs-frontend";
-import { PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariable, SetRulesetVariableParams } from "@bentley/presentation-common";
+import { NodeKey, PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariable, SetRulesetVariableParams, UpdateHierarchyStateParams } from "@bentley/presentation-common";
 
 /** @internal */
 export class IpcRequestsHandler {
@@ -24,6 +24,10 @@ export class IpcRequestsHandler {
 
   public async setRulesetVariable(params: Omit<SetRulesetVariableParams<RulesetVariable>, "clientId">) {
     return this.call("setRulesetVariable", this.injectClientId(params));
+  }
+
+  public async updateHierarchyState(params: Omit<UpdateHierarchyStateParams<NodeKey>, "clientId">) {
+    return this.call("updateHierarchyState", this.injectClientId({ ...params, nodeKeys: params.nodeKeys.map(NodeKey.toJSON) }));
   }
 }
 

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -23,6 +23,7 @@ import { IpcRequestsHandler } from "./IpcRequestsHandler";
 import { RulesetManager, RulesetManagerImpl } from "./RulesetManager";
 import { RulesetVariablesManager, RulesetVariablesManagerImpl } from "./RulesetVariablesManager";
 import { TRANSIENT_ELEMENT_CLASSNAME } from "./selection/SelectionManager";
+import { StateTracker } from "./StateTracker";
 
 /**
  * Data structure that describes IModel hierarchy change event arguments.
@@ -84,6 +85,9 @@ export interface PresentationManagerProps {
 
   /** @internal */
   ipcRequestsHandler?: IpcRequestsHandler;
+
+  /** @internal */
+  stateTracker?: StateTracker;
 }
 
 /**
@@ -100,6 +104,7 @@ export class PresentationManager implements IDisposable {
   private _clearEventListener?: () => void;
   private _connections: Map<IModelConnection, Promise<void>>;
   private _ipcRequestsHandler?: IpcRequestsHandler;
+  private _stateTracker?: StateTracker;
 
   /**
    * An event raised when hierarchies created using specific ruleset change
@@ -135,6 +140,7 @@ export class PresentationManager implements IDisposable {
       // Ipc only works in ipc apps, so the `onUpdate` callback will only be called there.
       this._clearEventListener = IpcApp.addListener(PresentationIpcEvents.Update, this.onUpdate);
       this._ipcRequestsHandler = props?.ipcRequestsHandler ?? new IpcRequestsHandler(this._requestsHandler.clientId);
+      this._stateTracker = props?.stateTracker ?? new StateTracker(this._ipcRequestsHandler);
     }
   }
 
@@ -238,6 +244,9 @@ export class PresentationManager implements IDisposable {
 
   /** @internal */
   public get ipcRequestsHandler() { return this._ipcRequestsHandler; }
+
+  /** @internal */
+  public get stateTracker() { return this._stateTracker; }
 
   /**
    * Get rulesets manager

--- a/presentation/frontend/src/presentation-frontend/StateTracker.ts
+++ b/presentation/frontend/src/presentation-frontend/StateTracker.ts
@@ -106,9 +106,7 @@ export class StateTracker {
       addedKeys.push(expandedNode.key);
     }
 
-    if (removedKeys.length !== 0)
-      await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesCollapsed", removedKeys);
-    if (addedKeys.length !== 0)
-      await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesExpanded", addedKeys);
+    await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesCollapsed", removedKeys);
+    await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesExpanded", addedKeys);
   }
 }

--- a/presentation/frontend/src/presentation-frontend/StateTracker.ts
+++ b/presentation/frontend/src/presentation-frontend/StateTracker.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Core
+ */
+
+import { IModelConnection } from "@bentley/imodeljs-frontend";
+import { NodeKey } from "@bentley/presentation-common";
+import { IpcRequestsHandler } from "./IpcRequestsHandler";
+
+/**
+ * Data structure that describes information used by [[StateTracker]] to identify node.
+ * @internal
+ */
+export interface NodeIdentifier {
+  id: string;
+  key: NodeKey;
+}
+
+/**
+ * Data structure that describes expanded node.
+ */
+interface ExpandedNode {
+  key: NodeKey;
+  /** Set of source ids in which this node is expanded. */
+  expandedIn: Set<string>;
+}
+
+/** Maps node ids to expanded nodes. */
+type ExpandedHierarchy = Map<string, ExpandedNode>;
+
+/** @internal */
+export class StateTracker {
+  private _expandedHierarchies: Map<string, ExpandedHierarchy>;
+  private _ipcRequestsHandler: IpcRequestsHandler;
+
+  constructor(ipcRequestsHandler: IpcRequestsHandler) {
+    this._ipcRequestsHandler = ipcRequestsHandler;
+    this._expandedHierarchies = new Map<string, ExpandedHierarchy>();
+  }
+
+  private async updateHierarchyStateIfNeeded(imodelKey: string, rulesetId: string, changeType: "nodesExpanded" | "nodesCollapsed", nodeKeys: NodeKey[]) {
+    if (nodeKeys.length === 0)
+      return;
+    await this._ipcRequestsHandler.updateHierarchyState({ imodelKey, rulesetId, changeType, nodeKeys });
+  }
+
+  public async onNodesExpanded(imodel: IModelConnection, rulesetId: string, sourceId: string, expandedNodes: NodeIdentifier[]) {
+    let hierarchy = this._expandedHierarchies.get(rulesetId);
+    if (!hierarchy) {
+      hierarchy = new Map<string, ExpandedNode>();
+      this._expandedHierarchies.set(rulesetId, hierarchy);
+    }
+
+    const newKeys: NodeKey[] = [];
+    // add new expanded nodes
+    for (const expandedNode of expandedNodes) {
+      const existingNode = hierarchy.get(expandedNode.id);
+      // this node is already expanded just add current source to the list of sources that have this node expanded
+      if (existingNode) {
+        existingNode.expandedIn.add(sourceId);
+        continue;
+      }
+
+      hierarchy.set(expandedNode.id, { key: expandedNode.key, expandedIn: new Set<string>([sourceId]) });
+      newKeys.push(expandedNode.key);
+    }
+
+    await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesExpanded", newKeys);
+  }
+
+  public async onNodesCollapsed(imodel: IModelConnection, rulesetId: string, sourceId: string, collapsedNodes: NodeIdentifier[]) {
+    const hierarchy = this._expandedHierarchies.get(rulesetId);
+    if (!hierarchy)
+      return;
+
+    const removedKeys: NodeKey[] = [];
+    for (const collapsedNode of collapsedNodes) {
+      const existingNode = hierarchy.get(collapsedNode.id);
+      if (!existingNode)
+        continue;
+
+      // remove current source from the list of sources that have this node expanded
+      existingNode.expandedIn.delete(sourceId);
+      // if there are other sources that have this node expanded leave it
+      if (existingNode.expandedIn.size !== 0)
+        continue;
+
+      hierarchy.delete(collapsedNode.id);
+      removedKeys.push(collapsedNode.key);
+    }
+
+    // if hierarchy does not have any nodes remove it
+    if (hierarchy.size === 0)
+      this._expandedHierarchies.delete(rulesetId);
+
+    await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesCollapsed", removedKeys);
+  }
+
+  public async onHierarchyClosed(imodel: IModelConnection, rulesetId: string, sourceId: string) {
+    const hierarchy = this._expandedHierarchies.get(rulesetId);
+    if (!hierarchy)
+      return;
+
+    const removedKeys: NodeKey[] = [];
+    for (const [nodeId, expandedNode] of hierarchy) {
+      expandedNode.expandedIn.delete(sourceId);
+      // if there are other sources that have this node expanded leave it.
+      if (expandedNode.expandedIn.size !== 0)
+        continue;
+
+      hierarchy.delete(nodeId);
+      removedKeys.push(expandedNode.key);
+    }
+
+    if (hierarchy.size === 0)
+      this._expandedHierarchies.delete(rulesetId);
+
+    await this.updateHierarchyStateIfNeeded(imodel.key, rulesetId, "nodesCollapsed", removedKeys);
+  }
+}

--- a/presentation/frontend/src/test/IpcRequestsHandler.test.ts
+++ b/presentation/frontend/src/test/IpcRequestsHandler.test.ts
@@ -4,7 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { IpcApp } from "@bentley/imodeljs-frontend";
-import { PRESENTATION_IPC_CHANNEL_NAME, RulesetVariable, VariableValueTypes } from "@bentley/presentation-common";
+import { NodeKey, PRESENTATION_IPC_CHANNEL_NAME, RulesetVariable, VariableValueTypes } from "@bentley/presentation-common";
+import { createRandomECInstancesNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
 import { expect } from "chai";
 import sinon from "sinon";
 import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
@@ -17,7 +18,6 @@ describe("IpcRequestsHandler", () => {
   });
 
   describe("setRulesetVariable", () => {
-
     it("calls IpcApp.callIpcChannel with injected client id", async () => {
       const callChannelStub = sinon.stub(IpcApp, "callIpcChannel");
       const rulesetId = "test-ruleset-id";
@@ -29,7 +29,21 @@ describe("IpcRequestsHandler", () => {
         variable,
       });
     });
-
   });
 
+  describe("updateHierarchyState", () => {
+    it("calls IpcApp.callIpcChannel with injected client id", async () => {
+      const callChannelStub = sinon.stub(IpcApp, "callIpcChannel");
+      const rulesetId = "ruleset-id";
+      const nodeKeys = [createRandomECInstancesNodeKey()];
+      await handler.updateHierarchyState({ imodelKey: "imodel-key", rulesetId, changeType: "nodesExpanded", nodeKeys });
+      expect(callChannelStub).to.be.calledOnceWith(PRESENTATION_IPC_CHANNEL_NAME, "updateHierarchyState", {
+        clientId: "test-client-id",
+        imodelKey: "imodel-key",
+        rulesetId,
+        changeType: "nodesExpanded",
+        nodeKeys: nodeKeys.map(NodeKey.toJSON),
+      });
+    });
+  });
 });

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -31,6 +31,7 @@ import { RulesetManagerImpl } from "../presentation-frontend/RulesetManager";
 import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager";
 import { TRANSIENT_ELEMENT_CLASSNAME } from "../presentation-frontend/selection/SelectionManager";
 import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
+import { StateTracker } from "../presentation-frontend/StateTracker";
 
 describe("PresentationManager", () => {
 
@@ -139,6 +140,14 @@ describe("PresentationManager", () => {
       sinon.stub(IpcApp, "addListener");
       const mgr = PresentationManager.create();
       expect(mgr.rpcRequestsHandler.clientId).to.eq(mgr.ipcRequestsHandler?.clientId);
+    });
+
+    it("sets custom StateTracker if supplied with props", async () => {
+      sinon.stub(IpcApp, "isValid").get(() => true);
+      sinon.stub(IpcApp, "addListener");
+      const tracker = moq.Mock.ofType<StateTracker>();
+      const mgr = PresentationManager.create({ stateTracker: tracker.object });
+      expect(mgr.stateTracker).to.eq(tracker.object);
     });
 
     it("starts listening to update events", async () => {

--- a/presentation/frontend/src/test/StateTracker.test.ts
+++ b/presentation/frontend/src/test/StateTracker.test.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { IModelConnection } from "@bentley/imodeljs-frontend";
+import { NodeKey } from "@bentley/presentation-common";
+import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
+import { createRandomECInstancesNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
+import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
+import { NodeIdentifier, StateTracker } from "../presentation-frontend/StateTracker";
+
+describe("StateTracker", () => {
+  let tracker: StateTracker;
+  const ipcHandlerMock = moq.Mock.ofType<IpcRequestsHandler>();
+  const imodelMock = moq.Mock.ofType<IModelConnection>();
+  const testRulesetId = "ruleset-id";
+  const testSourceId = "source-id";
+
+  function createNodeIdentifier(id: string, key: NodeKey) {
+    return { id, key };
+  }
+
+  async function expandNodes(nodes: NodeIdentifier[], sourceId?: string) {
+    await tracker.onNodesExpanded(imodelMock.object, testRulesetId, sourceId ?? testSourceId, nodes);
+    ipcHandlerMock.reset();
+  }
+
+  beforeEach(() => {
+    ipcHandlerMock.reset();
+    imodelMock.reset();
+    imodelMock.setup((x) => x.key).returns(() => "imodel-key");
+    tracker = new StateTracker(ipcHandlerMock.object);
+  });
+
+  describe("onNodesExpanded", () => {
+    it("does not call 'updateHierarchyState' if called without node keys", async () => {
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.never());
+      await tracker.onNodesExpanded(imodelMock.object, testRulesetId, testSourceId, []);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("calls 'updateHierarchyState' with expanded nodes", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey()), createNodeIdentifier("node-2", createRandomECInstancesNodeKey())];
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isObjectWith({
+        imodelKey: "imodel-key",
+        changeType: "nodesExpanded",
+        nodeKeys: nodes.map((n) => NodeKey.toJSON(n.key)),
+        rulesetId: testRulesetId,
+      }))).verifiable(moq.Times.once());
+      await tracker.onNodesExpanded(imodelMock.object, testRulesetId, testSourceId, nodes);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("does not call 'updateHierarchyState' if same node expanded in different source", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey())];
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.once());
+      await tracker.onNodesExpanded(imodelMock.object, testRulesetId, testSourceId, nodes);
+      await tracker.onNodesExpanded(imodelMock.object, testRulesetId, "other-source-id", nodes);
+      ipcHandlerMock.verifyAll();
+    });
+  });
+
+  describe("onNodesCollapsed", () => {
+    it("does not call 'updateHierarchiesState' if no nodes were expanded", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey())];
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.never());
+      await tracker.onNodesCollapsed(imodelMock.object, testRulesetId, testSourceId, nodes);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("calls 'updateHierarchiesState' with collapsed nodes", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey())];
+      await expandNodes(nodes);
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isObjectWith({
+        imodelKey: "imodel-key",
+        rulesetId: testRulesetId,
+        changeType: "nodesCollapsed",
+        nodeKeys: nodes.map((n) => NodeKey.toJSON(n.key)),
+      }))).verifiable(moq.Times.once());
+      await tracker.onNodesCollapsed(imodelMock.object, testRulesetId, testSourceId, nodes);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("does not call 'updateHierarchiesState' if node is expanded in other source", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey())];
+      await expandNodes(nodes);
+      await expandNodes(nodes, "other-source-id");
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.never());
+      await tracker.onNodesCollapsed(imodelMock.object, testRulesetId, "other-source-id", nodes);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("does not call 'updateHierarchiesState' if node is not expanded", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey()), createNodeIdentifier("node-2", createRandomECInstancesNodeKey())];
+      await expandNodes([nodes[0]]);
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.never());
+      await tracker.onNodesCollapsed(imodelMock.object, testRulesetId, testSourceId, [nodes[1]]);
+      ipcHandlerMock.verifyAll();
+    });
+  });
+
+  describe("onHierarchyClosed", () => {
+    it("does not call 'updateHierarchyState' if no nodes were expanded", async () => {
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.never());
+      await tracker.onHierarchyClosed(imodelMock.object, testRulesetId, testSourceId);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("calls 'updateHierarchyState' with nodes from closed hierarchy", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey()), createNodeIdentifier("node-2", createRandomECInstancesNodeKey())];
+      await expandNodes(nodes);
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isObjectWith({
+        imodelKey: "imodel-key",
+        changeType: "nodesCollapsed",
+        nodeKeys: nodes.map((n) => NodeKey.toJSON(n.key)),
+        rulesetId: testRulesetId,
+      }))).verifiable(moq.Times.once());
+      await tracker.onHierarchyClosed(imodelMock.object, testRulesetId, testSourceId);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("does not call 'updateHierarchyState' if nodes expanded in other sources", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey()), createNodeIdentifier("node-2", createRandomECInstancesNodeKey())];
+      await expandNodes(nodes);
+      await expandNodes(nodes, "other-source-id");
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isAny())).verifiable(moq.Times.never());
+      await tracker.onHierarchyClosed(imodelMock.object, testRulesetId, testSourceId);
+      ipcHandlerMock.verifyAll();
+    });
+
+    it("calls 'updateHierarchyState' only with a nodes that were not expanded in other sources", async () => {
+      const nodes = [createNodeIdentifier("node-1", createRandomECInstancesNodeKey()), createNodeIdentifier("node-2", createRandomECInstancesNodeKey())];
+      await expandNodes([nodes[0]]);
+      await expandNodes(nodes, "other-source-id");
+      // nodes[0] expanded in both sources nodes[1] expanded just in 'other-source-id'
+      ipcHandlerMock.setup(async (x) => x.updateHierarchyState(moq.It.isObjectWith({
+        imodelKey: "imodel-key",
+        changeType: "nodesCollapsed",
+        nodeKeys: [NodeKey.toJSON(nodes[1].key)],
+        rulesetId: testRulesetId,
+      }))).verifiable(moq.Times.once());
+      await tracker.onHierarchyClosed(imodelMock.object, testRulesetId, "other-source-id");
+      ipcHandlerMock.verifyAll();
+    });
+  });
+});


### PR DESCRIPTION
Added ability to track expanded nodes in trees using `usePresentationTreeNodeLoader`. These nodes are stored on a backend in IpcApp cases and used during hierarchy updates after iModel data changes. Having set of expanded nodes during hierarchy updates on a backend allows to avoid updating hierarchy parts that are under collapsed nodes and not visibile in any tree component. 

[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/146858)