### PR TITLE
Workaround for null tile tree range

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/workaround-null-tile-tree-range_2021-02-26-10-49.json
+++ b/common/changes/@bentley/imodeljs-frontend/workaround-null-tile-tree-range_2021-02-26-10-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Add workaround for bogus transform in tile tree for empty model.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/tile/IModelTileTree.ts
+++ b/core/frontend/src/tile/IModelTileTree.ts
@@ -47,6 +47,12 @@ export interface IModelTileTreeParams extends TileTreeParams {
 /** @internal */
 export function iModelTileTreeParamsFromJSON(props: IModelTileTreeProps, iModel: IModelConnection, modelId: Id64String, options: IModelTileTreeOptions): IModelTileTreeParams {
   const location = Transform.fromJSON(props.location);
+
+  // Note: this is a temporary workaround. For an empty model, the tile tree's location has Number.MAX_VALUE for all components of the origin. They should be zero.
+  // Proper fix will be made in native code.
+  if (location.origin.x === Number.MAX_VALUE)
+    location.origin.setZero();
+
   const { formatVersion, id, rootTile, contentIdQualifier, maxInitialTilesToSkip, geometryGuid } = props;
 
   let contentRange;


### PR DESCRIPTION
For an empty model the addon produces TileTreeProps with the components of location.origin set to `Number.MAX_VALUE`. This produces a [bug](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/554800) affecting SYNCHRO Modeler.
This is a workaround for 2.12 - the version on which SYNCHRO intends to release soon. The proper fix will be applied in the addon in 2.14.