### PR TITLE
IPC apps can query thread pool concurrency

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4100,6 +4100,7 @@ export interface IpcAppFunctions {
     pullAndMergeChanges: (key: string) => Promise<IModelConnectionProps>;
     // (undocumented)
     pushChanges: (key: string, description: string) => Promise<IModelConnectionProps>;
+    queryConcurrency: (pool: "io" | "cpu") => Promise<number>;
     // (undocumented)
     reinstateTxn: (key: string) => Promise<IModelStatus>;
     // (undocumented)

--- a/common/changes/@bentley/imodeljs-backend/query-hw-concurrency_2021-02-26-21-44.json
+++ b/common/changes/@bentley/imodeljs-backend/query-hw-concurrency_2021-02-26-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Add IpcHost.queryConcurrency.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/query-hw-concurrency_2021-02-26-21-44.json
+++ b/common/changes/@bentley/imodeljs-common/query-hw-concurrency_2021-02-26-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Add IpcAppFunctions.queryConcurrency.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -209,5 +209,9 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
     const imodel = IModelDb.findByKey(key);
     return imodel.nativeDb.reinstateTxn();
   }
+
+  public async queryConcurrency(pool: "io" | "cpu"): Promise<number> {
+    return IModelJsNative.queryConcurrency(pool);
+  }
 }
 

--- a/core/common/src/IpcAppProps.ts
+++ b/core/common/src/IpcAppProps.ts
@@ -93,5 +93,8 @@ export interface IpcAppFunctions {
   reverseSingleTxn: (key: string) => Promise<IModelStatus>;
   reverseAllTxn: (key: string) => Promise<IModelStatus>;
   reinstateTxn: (key: string) => Promise<IModelStatus>;
+
+  /** Query the number of concurrent threads supported by the host's IO or CPU thread pool. */
+  queryConcurrency: (pool: "io" | "cpu") => Promise<number>;
 }
 


### PR DESCRIPTION
Apps that use IPC to communicate with the backend will use this to throttle calls to `IModelTileRpcInterface.requestTileContent` to match the number of tile generation workers available on backend.

[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/147381)