### PR TITLE
Presentation: Handle partial hierarchy updates without losing tree state.

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1327,6 +1327,8 @@ export interface Node {
 // @public (undocumented)
 export namespace Node {
     export function fromJSON(json: NodeJSON | string): Node;
+    // @internal (undocumented)
+    export function fromPartialJson(json: PartialNodeJson): PartialNode;
     // @internal
     export function listFromJSON(json: NodeJSON[] | string): Node[];
     // @internal
@@ -1334,6 +1336,8 @@ export namespace Node {
     // @internal
     export function reviver(key: string, value: any): any;
     export function toJSON(node: Node): NodeJSON;
+    // @internal (undocumented)
+    export function toPartialJson(node: PartialNode): PartialNodeJson;
 }
 
 // @public
@@ -1348,7 +1352,7 @@ export interface NodeArtifactsRule extends RuleBase, ConditionContainer {
 // @alpha (undocumented)
 export interface NodeDeletionInfo {
     // (undocumented)
-    node: Node;
+    target: NodeKey;
     // (undocumented)
     type: "Delete";
 }
@@ -1356,7 +1360,7 @@ export interface NodeDeletionInfo {
 // @alpha (undocumented)
 export interface NodeDeletionInfoJSON {
     // (undocumented)
-    node: NodeJSON;
+    target: NodeKeyJSON;
     // (undocumented)
     type: "Delete";
 }
@@ -1365,6 +1369,8 @@ export interface NodeDeletionInfoJSON {
 export interface NodeInsertionInfo {
     // (undocumented)
     node: Node;
+    // (undocumented)
+    parent?: string;
     // (undocumented)
     position: number;
     // (undocumented)
@@ -1375,6 +1381,8 @@ export interface NodeInsertionInfo {
 export interface NodeInsertionInfoJSON {
     // (undocumented)
     node: NodeJSON;
+    // (undocumented)
+    parent?: string;
     // (undocumented)
     position: number;
     // (undocumented)
@@ -1495,13 +1503,9 @@ export interface NodePathFilteringDataJSON {
 // @alpha (undocumented)
 export interface NodeUpdateInfo {
     // (undocumented)
-    changes: Array<{
-        name: string;
-        old: unknown;
-        new: unknown;
-    }>;
+    changes: PartialNode;
     // (undocumented)
-    node: Node;
+    target: NodeKey;
     // (undocumented)
     type: "Update";
 }
@@ -1509,13 +1513,9 @@ export interface NodeUpdateInfo {
 // @alpha (undocumented)
 export interface NodeUpdateInfoJSON {
     // (undocumented)
-    changes: Array<{
-        name: string;
-        old: unknown;
-        new: unknown;
-    }>;
+    changes: PartialNodeJson;
     // (undocumented)
-    node: NodeJSON;
+    target: NodeKeyJSON;
     // (undocumented)
     type: "Update";
 }
@@ -1551,6 +1551,12 @@ export namespace PartialHierarchyModification {
 
 // @alpha (undocumented)
 export type PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON;
+
+// @alpha (undocumented)
+export type PartialNode = AllOrNone<Partial<Node>, "key" | "label">;
+
+// @alpha (undocumented)
+export type PartialNodeJson = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
 
 // @internal (undocumented)
 export const PRESENTATION_COMMON_ROOT: string;

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1328,7 +1328,7 @@ export interface Node {
 export namespace Node {
     export function fromJSON(json: NodeJSON | string): Node;
     // @internal (undocumented)
-    export function fromPartialJson(json: PartialNodeJson): PartialNode;
+    export function fromPartialJSON(json: PartialNodeJSON): PartialNode;
     // @internal
     export function listFromJSON(json: NodeJSON[] | string): Node[];
     // @internal
@@ -1337,7 +1337,7 @@ export namespace Node {
     export function reviver(key: string, value: any): any;
     export function toJSON(node: Node): NodeJSON;
     // @internal (undocumented)
-    export function toPartialJson(node: PartialNode): PartialNodeJson;
+    export function toPartialJSON(node: PartialNode): PartialNodeJSON;
 }
 
 // @public
@@ -1370,7 +1370,7 @@ export interface NodeInsertionInfo {
     // (undocumented)
     node: Node;
     // (undocumented)
-    parent?: string;
+    parent?: NodeKey;
     // (undocumented)
     position: number;
     // (undocumented)
@@ -1382,7 +1382,7 @@ export interface NodeInsertionInfoJSON {
     // (undocumented)
     node: NodeJSON;
     // (undocumented)
-    parent?: string;
+    parent?: NodeKeyJSON;
     // (undocumented)
     position: number;
     // (undocumented)
@@ -1513,7 +1513,7 @@ export interface NodeUpdateInfo {
 // @alpha (undocumented)
 export interface NodeUpdateInfoJSON {
     // (undocumented)
-    changes: PartialNodeJson;
+    changes: PartialNodeJSON;
     // (undocumented)
     target: NodeKeyJSON;
     // (undocumented)
@@ -1556,7 +1556,7 @@ export type PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDelet
 export type PartialNode = AllOrNone<Partial<Node>, "key" | "label">;
 
 // @alpha (undocumented)
-export type PartialNodeJson = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
+export type PartialNodeJSON = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
 
 // @internal (undocumented)
 export const PRESENTATION_COMMON_ROOT: string;

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -170,9 +170,11 @@ public;NestedContentValue
 public;NestedContentValueJSON
 public;Node
 public;Node
+internal;fromPartialJson(json: PartialNodeJson): PartialNode
 internal;listFromJSON(json: NodeJSON[] | string): Node[]
 internal;listReviver(key: string, value: any): any
 internal;reviver(key: string, value: any): any
+internal;toPartialJson(node: PartialNode): PartialNodeJson
 public;NodeArtifactsRule 
 alpha;NodeDeletionInfo
 alpha;NodeDeletionInfoJSON
@@ -201,6 +203,8 @@ public;PageOptions
 alpha;PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo | NodeUpdateInfo
 alpha;PartialHierarchyModification
 alpha;PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON
+alpha;PartialNode = AllOrNone
+alpha;PartialNodeJson = AllOrNone
 internal;PRESENTATION_COMMON_ROOT: string
 internal;PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface"
 alpha;PresentationDataCompareOptions

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -170,11 +170,11 @@ public;NestedContentValue
 public;NestedContentValueJSON
 public;Node
 public;Node
-internal;fromPartialJson(json: PartialNodeJson): PartialNode
+internal;fromPartialJSON(json: PartialNodeJSON): PartialNode
 internal;listFromJSON(json: NodeJSON[] | string): Node[]
 internal;listReviver(key: string, value: any): any
 internal;reviver(key: string, value: any): any
-internal;toPartialJson(node: PartialNode): PartialNodeJson
+internal;toPartialJSON(node: PartialNode): PartialNodeJSON
 public;NodeArtifactsRule 
 alpha;NodeDeletionInfo
 alpha;NodeDeletionInfoJSON
@@ -204,7 +204,7 @@ alpha;PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo | Node
 alpha;PartialHierarchyModification
 alpha;PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON
 alpha;PartialNode = AllOrNone
-alpha;PartialNodeJson = AllOrNone
+alpha;PartialNodeJSON = AllOrNone
 internal;PRESENTATION_COMMON_ROOT: string
 internal;PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface"
 alpha;PresentationDataCompareOptions

--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -5164,7 +5164,7 @@ export interface TreeModelRootNode {
 
 // @beta
 export class TreeModelSource {
-    constructor();
+    constructor(_model?: MutableTreeModel);
     getModel(): TreeModel;
     getVisibleNodes(): VisibleTreeNodes;
     modifyModel(callback: (model: MutableTreeModel) => void): void;

--- a/common/changes/@bentley/presentation-backend/ui-tree-updates_2021-03-01-14-05.json
+++ b/common/changes/@bentley/presentation-backend/ui-tree-updates_2021-03-01-14-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/ui-tree-updates_2021-03-01-14-05.json
+++ b/common/changes/@bentley/presentation-common/ui-tree-updates_2021-03-01-14-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/ui-tree-updates_2021-03-01-14-05.json
+++ b/common/changes/@bentley/presentation-components/ui-tree-updates_2021-03-01-14-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": " Handle partial hierarchy updates without loosing tree state.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-components/ui-tree-updates_2021-03-01-14-05.json
+++ b/common/changes/@bentley/ui-components/ui-tree-updates_2021-03-01-14-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/src/frontend/Update.test.tsx
+++ b/full-stack-tests/presentation/src/frontend/Update.test.tsx
@@ -35,7 +35,11 @@ describe("Update", () => {
     await terminate();
   });
 
-  describe("hierarchy", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("detection", () => {
     let hierarchyCompareSpy: SinonSpy<typeof Presentation.presentation.compareHierarchies>;
     let defaultProps: Omit<PresentationTreeNodeLoaderProps, "ruleset">;
 
@@ -46,10 +50,6 @@ describe("Update", () => {
         pagingSize: 100,
         enableHierarchyAutoUpdate: true,
       };
-    });
-
-    afterEach(() => {
-      sinon.restore();
     });
 
     describe("on ruleset modification", () => {
@@ -83,15 +83,11 @@ describe("Update", () => {
         await hierarchy.verifyChange(
           [{
             type: "Update",
-            node: { key: { type: "T_NODE" }, label: { displayValue: "test-2" } },
-            changes: [
-              { name: "Key" },
-              {
-                name: "LabelDefinition",
-                old: { displayValue: "test-1" },
-                new: { displayValue: "test-2" },
-              },
-            ],
+            target: { type: "T_NODE" },
+            changes: {
+              key: {},
+              label: { displayValue: "test-2" },
+            },
           }],
           ["test-2"],
         );
@@ -131,12 +127,12 @@ describe("Update", () => {
           [
             {
               type: "Delete",
-              node: { key: { instanceKeys: [{ className: "Generic:PhysicalObject", id: "0x74" }] } },
+              target: { instanceKeys: [{ className: "Generic:PhysicalObject", id: "0x74" }] },
             },
             {
               type: "Update",
-              node: { key: { instanceKeys: [{ className: "Generic:PhysicalObject", id: "0x75" }] } },
-              changes: [{ name: "Key" }],
+              target: { instanceKeys: [{ className: "Generic:PhysicalObject", id: "0x75" }] },
+              changes: { key: {} },
             }],
           ["Physical Object [0-39]"],
         );
@@ -181,7 +177,7 @@ describe("Update", () => {
           [
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECClassGroupingNode } },
+              target: { type: StandardNodeTypes.ECClassGroupingNode },
             },
             {
               type: "Insert",
@@ -253,7 +249,7 @@ describe("Update", () => {
         await hierarchy.verifyChange(
           [{
             type: "Delete",
-            node: { key: { type: "T_NODE_1" }, label: { displayValue: "test-1" } },
+            target: { type: "T_NODE_1" },
           }],
           ["test-2"],
         );
@@ -304,11 +300,11 @@ describe("Update", () => {
           [
             {
               type: "Delete",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] } },
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] },
             },
             {
               type: "Delete",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] } },
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] },
             },
           ],
           [],
@@ -345,21 +341,13 @@ describe("Update", () => {
           [
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] } },
-              changes: [{
-                name: "ForeColor",
-                old: "",
-                new: "Red",
-              }],
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] },
+              changes: { foreColor: "Red" },
             },
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] } },
-              changes: [{
-                name: "ForeColor",
-                old: "",
-                new: "Red",
-              }],
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] },
+              changes: { foreColor: "Red" },
             },
           ],
           [
@@ -399,21 +387,13 @@ describe("Update", () => {
           [
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] } },
-              changes: [{
-                name: "ForeColor",
-                old: "",
-                new: "Red",
-              }],
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] },
+              changes: { foreColor: "Red" },
             },
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] } },
-              changes: [{
-                name: "ForeColor",
-                old: "",
-                new: "Red",
-              }],
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] },
+              changes: { foreColor: "Red" },
             },
           ],
           [
@@ -427,21 +407,13 @@ describe("Update", () => {
           [
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] } },
-              changes: [{
-                name: "ForeColor",
-                old: "Red",
-                new: "Blue",
-              }],
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x74" }] },
+              changes: { foreColor: "Blue" },
             },
             {
               type: "Update",
-              node: { key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] } },
-              changes: [{
-                name: "ForeColor",
-                old: "Red",
-                new: "Blue",
-              }],
+              target: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [{ id: "0x75" }] },
+              changes: { foreColor: "Blue" },
             },
           ],
           [
@@ -507,29 +479,114 @@ describe("Update", () => {
           [
             {
               type: "Update",
-              node: { key: { type: "T_ROOT_1" } },
-              changes: [{
-                name: "HasChildren",
-                old: true,
-                new: false,
-              }],
+              target: { type: "T_ROOT_1" },
+              changes: { hasChildren: false },
             },
             {
               type: "Update",
-              node: { key: { type: "T_ROOT_2" } },
-              changes: [{
-                name: "HasChildren",
-                old: true,
-                new: false,
-              }],
+              target: { type: "T_ROOT_2" },
+              changes: { hasChildren: false },
             },
             {
               type: "Delete",
-              node: { key: { type: "T_CHILD_1" } },
+              target: { type: "T_CHILD_1" },
             },
           ],
           ["root-1", "root-2"],
         );
+      });
+    });
+
+    describe("partial update", () => {
+      it("handles node insertion", async () => {
+        const ruleset = await Presentation.presentation.rulesets().add({
+          id: faker.random.uuid(),
+          rules: [{
+            ruleType: RuleTypes.RootNodes,
+            specifications: [{ specType: ChildNodeSpecificationTypes.CustomNode, type: "T_NODE", label: "test-1" }],
+          }],
+        });
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, ["test-1"]);
+
+        await Presentation.presentation.rulesets().modify(
+          ruleset,
+          {
+            rules: [{
+              ruleType: RuleTypes.RootNodes,
+              specifications: [
+                { specType: ChildNodeSpecificationTypes.CustomNode, type: "T_NODE", label: "test-1" },
+                { specType: ChildNodeSpecificationTypes.CustomNode, type: "T_NODE", label: "test-2" },
+              ],
+            }],
+          },
+        );
+        await hierarchy.verifyChange(
+          [{
+            type: "Insert",
+            parent: undefined,
+            position: 1,
+            node: {
+              key: { type: "T_NODE" },
+              label: { displayValue: "test-2" },
+            },
+          }],
+          ["test-1", "test-2"],
+        );
+      });
+
+      it("handles node update", async () => {
+        const ruleset = await Presentation.presentation.rulesets().add({
+          id: faker.random.uuid(),
+          rules: [{
+            ruleType: RuleTypes.RootNodes,
+            specifications: [{ specType: ChildNodeSpecificationTypes.CustomNode, type: "T_NODE", label: "test-1" }],
+          }],
+        });
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, ["test-1"]);
+
+        await Presentation.presentation.rulesets().modify(
+          ruleset,
+          {
+            rules: [{
+              ruleType: RuleTypes.RootNodes,
+              specifications: [
+                { specType: ChildNodeSpecificationTypes.CustomNode, type: "T_NODE", label: "test-updated" },
+              ],
+            }],
+          },
+        );
+        await hierarchy.verifyChange(
+          [{
+            type: "Update",
+            target: { type: "T_NODE" },
+            changes: {
+              label: { displayValue: "test-updated" },
+            },
+          }],
+          ["test-updated"],
+        );
+      });
+
+      it("handles node removal", async () => {
+        const ruleset = await Presentation.presentation.rulesets().add({
+          id: faker.random.uuid(),
+          rules: [{
+            ruleType: RuleTypes.RootNodes,
+            specifications: [{ specType: ChildNodeSpecificationTypes.CustomNode, type: "T_NODE", label: "test-1" }],
+          }],
+        });
+        const hierarchy = await verifyHierarchy({ ...defaultProps, ruleset }, ["test-1"]);
+
+        await Presentation.presentation.rulesets().modify(
+          ruleset,
+          {
+            rules: [{
+              ruleType: RuleTypes.RootNodes,
+              specifications: [],
+            }],
+          },
+        );
+        await hierarchy.verifyChange([{ type: "Delete", target: { type: "T_NODE" } }], []);
       });
     });
 

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -1171,13 +1171,14 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const addonResponse: HierarchyCompareInfoJSON = setup({
+        const unprocessedResponse: HierarchyCompareInfoJSON = {
           changes: [{
             type: "Insert",
             position: 1,
             node: createRandomECInstancesNodeJSON(),
           }],
-        });
+        };
+        const addonResponse = setup(unprocessedResponse);
 
         // test
         const options: PresentationDataCompareOptions<IModelDb, NodeKey> = {
@@ -1212,13 +1213,14 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const addonResponse: HierarchyCompareInfoJSON = setup({
+        const unprocessedResponse: HierarchyCompareInfoJSON = {
           changes: [{
             type: "Insert",
             position: 1,
             node: createRandomECInstancesNodeJSON(),
           }],
-        });
+        };
+        const addonResponse = setup(unprocessedResponse);
 
         // test
         const options: WithClientRequestContext<PresentationDataCompareOptions<IModelDb, NodeKey>> = {
@@ -1250,12 +1252,13 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const addonResponse: HierarchyCompareInfoJSON = setup({
+        const addonResponse: HierarchyCompareInfoJSON = {
           changes: [{
             type: "Delete",
-            node: createRandomECInstancesNodeJSON(),
+            target: createRandomECInstancesNodeJSON().key,
           }],
-        });
+        };
+        setup(addonResponse);
 
         // test
         const options: WithClientRequestContext<PresentationDataCompareOptions<IModelDb, NodeKey>> = {
@@ -1287,13 +1290,14 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const addonResponse: HierarchyCompareInfoJSON = setup({
+        const addonResponse: HierarchyCompareInfoJSON = {
           changes: [{
             type: "Update",
-            node: createRandomECInstancesNodeJSON(),
-            changes: [],
+            target: createRandomECInstancesNodeJSON().key,
+            changes: {},
           }],
-        });
+        };
+        setup(addonResponse);
 
         // test
         const options: WithClientRequestContext<PresentationDataCompareOptions<IModelDb, NodeKey>> = {
@@ -1353,9 +1357,10 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const addonResponse: HierarchyCompareInfoJSON = setup({
+        const addonResponse: HierarchyCompareInfoJSON = {
           changes: [],
-        });
+        };
+        setup(addonResponse);
 
         // test
         const options: WithClientRequestContext<PresentationDataCompareOptions<IModelDb, NodeKey>> = {
@@ -1388,9 +1393,10 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const addonResponse: HierarchyCompareInfoJSON = setup({
+        const addonResponse: HierarchyCompareInfoJSON = {
           changes: [],
-        });
+        };
+        setup(addonResponse);
 
         // test
         const options: WithClientRequestContext<PresentationDataCompareOptions<IModelDb, NodeKey>> = {

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -1637,7 +1637,7 @@ describe("PresentationRpcImpl", () => {
         const result: HierarchyCompareInfo = {
           changes: [{
             type: "Delete",
-            node: createRandomECInstancesNode(),
+            target: createRandomECInstancesNode().key,
           }],
         };
         const rpcOptions: PresentationDataCompareRpcOptions = {
@@ -1665,7 +1665,7 @@ describe("PresentationRpcImpl", () => {
         const result: HierarchyCompareInfo = {
           changes: [{
             type: "Delete",
-            node: createRandomECInstancesNode(),
+            target: createRandomECInstancesNode().key,
           }],
         };
         const rpcOptions: PresentationDataCompareRpcOptions = {
@@ -1699,7 +1699,7 @@ describe("PresentationRpcImpl", () => {
         const result: HierarchyCompareInfo = {
           changes: [{
             type: "Delete",
-            node: createRandomECInstancesNode(),
+            target: createRandomECInstancesNode().key,
           }],
         };
         const rpcOptions: PresentationDataCompareRpcOptions = {
@@ -1729,7 +1729,7 @@ describe("PresentationRpcImpl", () => {
         const result: HierarchyCompareInfo = {
           changes: [{
             type: "Delete",
-            node: createRandomECInstancesNode(),
+            target: createRandomECInstancesNode().key,
           }],
         };
         const rpcOptions: PresentationDataCompareRpcOptions = {
@@ -1761,7 +1761,7 @@ describe("PresentationRpcImpl", () => {
         const result: HierarchyCompareInfo = {
           changes: [{
             type: "Delete",
-            node: createRandomECInstancesNode(),
+            target: createRandomECInstancesNode().key,
           }],
         };
         const rpcOptions: PresentationDataCompareRpcOptions = {

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -7,7 +7,7 @@
  */
 
 import { NodeKey, NodeKeyJSON } from "./hierarchy/Key";
-import { Node, NodeJSON, PartialNode, PartialNodeJson } from "./hierarchy/Node";
+import { Node, NodeJSON, PartialNode, PartialNodeJSON } from "./hierarchy/Node";
 
 /** @alpha */
 export const UPDATE_FULL = "FULL";
@@ -209,7 +209,7 @@ export interface NodeUpdateInfo {
 export interface NodeUpdateInfoJSON {
   type: "Update";
   target: NodeKeyJSON;
-  changes: PartialNodeJson;
+  changes: PartialNodeJSON;
 }
 
 /** @alpha */

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -132,7 +132,7 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
         return {
           type: "Update",
           target: NodeKey.toJSON(obj.target),
-          changes: Node.toPartialJson(obj.changes),
+          changes: Node.toPartialJSON(obj.changes),
         };
 
       case "Delete":
@@ -158,7 +158,7 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
         return {
           type: "Update",
           target: NodeKey.fromJSON(json.target),
-          changes: Node.fromPartialJson(json.changes),
+          changes: Node.fromPartialJSON(json.changes),
         };
 
       case "Delete":

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -6,7 +6,8 @@
  * @module Core
  */
 
-import { Node, NodeJSON } from "./hierarchy/Node";
+import { NodeKey, NodeKeyJSON } from "./hierarchy/Key";
+import { Node, NodeJSON, PartialNode, PartialNodeJson } from "./hierarchy/Node";
 
 /** @alpha */
 export const UPDATE_FULL = "FULL";
@@ -118,24 +119,61 @@ export type PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo 
 export namespace PartialHierarchyModification { // eslint-disable-line @typescript-eslint/no-redeclare
   /** Serialize given object to JSON. */
   export function toJSON(obj: PartialHierarchyModification): PartialHierarchyModificationJSON {
-    return {
-      ...obj,
-      node: Node.toJSON(obj.node),
-    };
+    switch (obj.type) {
+      case "Insert":
+        return {
+          type: "Insert",
+          node: Node.toJSON(obj.node),
+          position: obj.position,
+          parent: obj.parent,
+        };
+
+      case "Update":
+        return {
+          type: "Update",
+          target: NodeKey.toJSON(obj.target),
+          changes: Node.toPartialJson(obj.changes),
+        };
+
+      case "Delete":
+        return {
+          type: "Delete",
+          target: NodeKey.toJSON(obj.target),
+        };
+    }
   }
 
   /** Deserialize given object from JSON */
   export function fromJSON(json: PartialHierarchyModificationJSON): PartialHierarchyModification {
-    return {
-      ...json,
-      node: Node.fromJSON(json.node),
-    };
+    switch (json.type) {
+      case "Insert":
+        return {
+          type: "Insert",
+          node: Node.fromJSON(json.node),
+          position: json.position,
+          parent: json.parent,
+        };
+
+      case "Update":
+        return {
+          type: "Update",
+          target: NodeKey.fromJSON(json.target),
+          changes: Node.fromPartialJson(json.changes),
+        };
+
+      case "Delete":
+        return {
+          type: "Delete",
+          target: NodeKey.fromJSON(json.target),
+        };
+    }
   }
 }
 
 /** @alpha */
 export interface NodeInsertionInfo {
   type: "Insert";
+  parent?: string;
   position: number;
   node: Node;
 }
@@ -143,6 +181,7 @@ export interface NodeInsertionInfo {
 /** @alpha */
 export interface NodeInsertionInfoJSON {
   type: "Insert";
+  parent?: string;
   position: number;
   node: NodeJSON;
 }
@@ -150,35 +189,27 @@ export interface NodeInsertionInfoJSON {
 /** @alpha */
 export interface NodeDeletionInfo {
   type: "Delete";
-  node: Node;
+  target: NodeKey;
 }
 
 /** @alpha */
 export interface NodeDeletionInfoJSON {
   type: "Delete";
-  node: NodeJSON;
+  target: NodeKeyJSON;
 }
 
 /** @alpha */
 export interface NodeUpdateInfo {
   type: "Update";
-  node: Node;
-  changes: Array<{
-    name: string;
-    old: unknown;
-    new: unknown;
-  }>;
+  target: NodeKey;
+  changes: PartialNode;
 }
 
 /** @alpha */
 export interface NodeUpdateInfoJSON {
   type: "Update";
-  node: NodeJSON;
-  changes: Array<{
-    name: string;
-    old: unknown;
-    new: unknown;
-  }>;
+  target: NodeKeyJSON;
+  changes: PartialNodeJson;
 }
 
 /** @alpha */

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -123,9 +123,9 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
       case "Insert":
         return {
           type: "Insert",
-          node: Node.toJSON(obj.node),
+          parent: obj.parent === undefined ? undefined : NodeKey.toJSON(obj.parent),
           position: obj.position,
-          parent: obj.parent,
+          node: Node.toJSON(obj.node),
         };
 
       case "Update":
@@ -149,9 +149,9 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
       case "Insert":
         return {
           type: "Insert",
-          node: Node.fromJSON(json.node),
+          parent: json.parent === undefined ? undefined : NodeKey.fromJSON(json.parent),
           position: json.position,
-          parent: json.parent,
+          node: Node.fromJSON(json.node),
         };
 
       case "Update":
@@ -173,7 +173,7 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
 /** @alpha */
 export interface NodeInsertionInfo {
   type: "Insert";
-  parent?: string;
+  parent?: NodeKey;
   position: number;
   node: Node;
 }
@@ -181,7 +181,7 @@ export interface NodeInsertionInfo {
 /** @alpha */
 export interface NodeInsertionInfoJSON {
   type: "Insert";
-  parent?: string;
+  parent?: NodeKey;
   position: number;
   node: NodeJSON;
 }

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -181,7 +181,7 @@ export interface NodeInsertionInfo {
 /** @alpha */
 export interface NodeInsertionInfoJSON {
   type: "Insert";
-  parent?: NodeKey;
+  parent?: NodeKeyJSON;
   position: number;
   node: NodeJSON;
 }

--- a/presentation/common/src/presentation-common/hierarchy/Node.ts
+++ b/presentation/common/src/presentation-common/hierarchy/Node.ts
@@ -91,7 +91,7 @@ export namespace Node {
   }
 
   /** @internal */
-  export function toPartialJson(node: PartialNode): PartialNodeJson {
+  export function toPartialJSON(node: PartialNode): PartialNodeJson {
     if (node.key === undefined) {
       return node;
     }
@@ -117,7 +117,7 @@ export namespace Node {
   }
 
   /** @internal */
-  export function fromPartialJson(json: PartialNodeJson): PartialNode {
+  export function fromPartialJSON(json: PartialNodeJson): PartialNode {
     if (json.key === undefined) {
       return json;
     }

--- a/presentation/common/src/presentation-common/hierarchy/Node.ts
+++ b/presentation/common/src/presentation-common/hierarchy/Node.ts
@@ -43,7 +43,9 @@ export interface Node {
   /** Is this node's checkbox enabled */
   isCheckboxEnabled?: boolean;
   /** Extended data injected into this node */
-  extendedData?: { [key: string]: any };
+  extendedData?: {
+    [key: string]: any;
+  };
 }
 
 /**
@@ -65,17 +67,39 @@ export interface NodeJSON {
   isCheckboxVisible?: boolean;
   isChecked?: boolean;
   isCheckboxEnabled?: boolean;
-  extendedData?: { [key: string]: any };
+  extendedData?: {
+    [key: string]: any;
+  };
 }
+
+/** @alpha */
+export type PartialNode = AllOrNone<Partial<Node>, "key" | "label">;
+/** @alpha */
+export type PartialNodeJson = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
+type AllOrNone<T, P extends keyof T> = Omit<T, P> & ({ [K in P]?: never } | Required<Pick<T, P>>);
 
 /** @public */
 export namespace Node {
   /** Serialize given [[Node]] to JSON */
   export function toJSON(node: Node): NodeJSON {
-    const { label, ...baseNode } = node;
+    const { key, label, ...baseNode } = node;
     return {
       ...baseNode,
-      key: NodeKey.toJSON(node.key),
+      key: NodeKey.toJSON(key),
+      labelDefinition: LabelDefinition.toJSON(label),
+    };
+  }
+
+  /** @internal */
+  export function toPartialJson(node: PartialNode): PartialNodeJson {
+    if (node.key === undefined) {
+      return node;
+    }
+
+    const { key, label, ...baseNode } = node;
+    return {
+      ...baseNode,
+      key: NodeKey.toJSON(key),
       labelDefinition: LabelDefinition.toJSON(label),
     };
   }
@@ -88,6 +112,20 @@ export namespace Node {
     return {
       ...baseJson,
       key: NodeKey.fromJSON(json.key),
+      label: LabelDefinition.fromJSON(labelDefinition),
+    };
+  }
+
+  /** @internal */
+  export function fromPartialJson(json: PartialNodeJson): PartialNode {
+    if (json.key === undefined) {
+      return json;
+    }
+
+    const { key, labelDefinition, ...baseJson } = json;
+    return {
+      ...baseJson,
+      key: NodeKey.fromJSON(key),
       label: LabelDefinition.fromJSON(labelDefinition),
     };
   }

--- a/presentation/common/src/presentation-common/hierarchy/Node.ts
+++ b/presentation/common/src/presentation-common/hierarchy/Node.ts
@@ -75,7 +75,7 @@ export interface NodeJSON {
 /** @alpha */
 export type PartialNode = AllOrNone<Partial<Node>, "key" | "label">;
 /** @alpha */
-export type PartialNodeJson = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
+export type PartialNodeJSON = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
 type AllOrNone<T, P extends keyof T> = Omit<T, P> & ({ [K in P]?: never } | Required<Pick<T, P>>);
 
 /** @public */
@@ -91,7 +91,7 @@ export namespace Node {
   }
 
   /** @internal */
-  export function toPartialJSON(node: PartialNode): PartialNodeJson {
+  export function toPartialJSON(node: PartialNode): PartialNodeJSON {
     if (node.key === undefined) {
       return node;
     }
@@ -117,7 +117,7 @@ export namespace Node {
   }
 
   /** @internal */
-  export function fromPartialJSON(json: PartialNodeJson): PartialNode {
+  export function fromPartialJSON(json: PartialNodeJSON): PartialNode {
     if (json.key === undefined) {
       return json;
     }

--- a/presentation/common/src/test/Update.test.snap
+++ b/presentation/common/src/test/Update.test.snap
@@ -131,7 +131,31 @@ Object {
 }
 `;
 
-exports[`PartialHierarchyModification fromJSON deserializes \`NodeInsertionInfo\` from JSON 1`] = `
+exports[`PartialHierarchyModification fromJSON deserializes \`NodeInsertionInfo\` with parent from JSON 1`] = `
+Object {
+  "node": Object {
+    "key": Object {
+      "instanceKeys": Array [],
+      "pathFromRoot": Array [],
+      "type": "ECInstancesNode",
+    },
+    "label": Object {
+      "displayValue": "TestNode",
+      "rawValue": "test_node",
+      "typeName": "string",
+    },
+  },
+  "parent": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
+  },
+  "position": 123,
+  "type": "Insert",
+}
+`;
+
+exports[`PartialHierarchyModification fromJSON deserializes \`NodeInsertionInfo\` without parent from JSON 1`] = `
 Object {
   "node": Object {
     "key": Object {
@@ -176,7 +200,31 @@ Object {
 }
 `;
 
-exports[`PartialHierarchyModification toJSON serializes \`NodeInsertionInfo\` 1`] = `
+exports[`PartialHierarchyModification toJSON serializes \`NodeInsertionInfo\` with parent 1`] = `
+Object {
+  "node": Object {
+    "key": Object {
+      "instanceKeys": Array [],
+      "pathFromRoot": Array [],
+      "type": "ECInstancesNode",
+    },
+    "labelDefinition": Object {
+      "displayValue": "TestNode",
+      "rawValue": "test_node",
+      "typeName": "string",
+    },
+  },
+  "parent": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
+  },
+  "position": 123,
+  "type": "Insert",
+}
+`;
+
+exports[`PartialHierarchyModification toJSON serializes \`NodeInsertionInfo\` without parent 1`] = `
 Object {
   "node": Object {
     "key": Object {

--- a/presentation/common/src/test/Update.test.snap
+++ b/presentation/common/src/test/Update.test.snap
@@ -16,43 +16,26 @@ Object {
           "typeName": "string",
         },
       },
+      "parent": undefined,
       "position": 123,
       "type": "Insert",
     },
     Object {
-      "changes": Array [
-        Object {
-          "name": "test",
-          "new": "new value",
-          "old": "old value",
-        },
-      ],
-      "node": Object {
-        "key": Object {
-          "instanceKeys": Array [],
-          "pathFromRoot": Array [],
-          "type": "ECInstancesNode",
-        },
-        "label": Object {
-          "displayValue": "TestNode",
-          "rawValue": "test_node",
-          "typeName": "string",
-        },
+      "changes": Object {
+        "backColor": "new value",
+      },
+      "target": Object {
+        "instanceKeys": Array [],
+        "pathFromRoot": Array [],
+        "type": "ECInstancesNode",
       },
       "type": "Update",
     },
     Object {
-      "node": Object {
-        "key": Object {
-          "instanceKeys": Array [],
-          "pathFromRoot": Array [],
-          "type": "ECInstancesNode",
-        },
-        "label": Object {
-          "displayValue": "TestNode",
-          "rawValue": "test_node",
-          "typeName": "string",
-        },
+      "target": Object {
+        "instanceKeys": Array [],
+        "pathFromRoot": Array [],
+        "type": "ECInstancesNode",
       },
       "type": "Delete",
     },
@@ -80,43 +63,26 @@ Object {
           "typeName": "string",
         },
       },
+      "parent": undefined,
       "position": 123,
       "type": "Insert",
     },
     Object {
-      "changes": Array [
-        Object {
-          "name": "test",
-          "new": "new value",
-          "old": "old value",
-        },
-      ],
-      "node": Object {
-        "key": Object {
-          "instanceKeys": Array [],
-          "pathFromRoot": Array [],
-          "type": "ECInstancesNode",
-        },
-        "labelDefinition": Object {
-          "displayValue": "TestNode",
-          "rawValue": "test_node",
-          "typeName": "string",
-        },
+      "changes": Object {
+        "backColor": "new value",
+      },
+      "target": Object {
+        "instanceKeys": Array [],
+        "pathFromRoot": Array [],
+        "type": "ECInstancesNode",
       },
       "type": "Update",
     },
     Object {
-      "node": Object {
-        "key": Object {
-          "instanceKeys": Array [],
-          "pathFromRoot": Array [],
-          "type": "ECInstancesNode",
-        },
-        "labelDefinition": Object {
-          "displayValue": "TestNode",
-          "rawValue": "test_node",
-          "typeName": "string",
-        },
+      "target": Object {
+        "instanceKeys": Array [],
+        "pathFromRoot": Array [],
+        "type": "ECInstancesNode",
       },
       "type": "Delete",
     },
@@ -131,17 +97,10 @@ Object {
 exports[`HierarchyUpdateInfo fromJSON deserializes partial \`HierarchyUpdateInfo\` from JSON 1`] = `
 Array [
   Object {
-    "node": Object {
-      "key": Object {
-        "instanceKeys": Array [],
-        "pathFromRoot": Array [],
-        "type": "ECInstancesNode",
-      },
-      "label": Object {
-        "displayValue": "TestNode",
-        "rawValue": "test_node",
-        "typeName": "string",
-      },
+    "target": Object {
+      "instanceKeys": Array [],
+      "pathFromRoot": Array [],
+      "type": "ECInstancesNode",
     },
     "type": "Delete",
   },
@@ -151,17 +110,10 @@ Array [
 exports[`HierarchyUpdateInfo toJSON serializes partial \`HierarchyUpdateInfo\` to JSON 1`] = `
 Array [
   Object {
-    "node": Object {
-      "key": Object {
-        "instanceKeys": Array [],
-        "pathFromRoot": Array [],
-        "type": "ECInstancesNode",
-      },
-      "labelDefinition": Object {
-        "displayValue": "TestNode",
-        "rawValue": "test_node",
-        "typeName": "string",
-      },
+    "target": Object {
+      "instanceKeys": Array [],
+      "pathFromRoot": Array [],
+      "type": "ECInstancesNode",
     },
     "type": "Delete",
   },
@@ -170,17 +122,10 @@ Array [
 
 exports[`PartialHierarchyModification fromJSON deserializes \`NodeDeletionInfo\` from JSON 1`] = `
 Object {
-  "node": Object {
-    "key": Object {
-      "instanceKeys": Array [],
-      "pathFromRoot": Array [],
-      "type": "ECInstancesNode",
-    },
-    "label": Object {
-      "displayValue": "TestNode",
-      "rawValue": "test_node",
-      "typeName": "string",
-    },
+  "target": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
   },
   "type": "Delete",
 }
@@ -200,6 +145,7 @@ Object {
       "typeName": "string",
     },
   },
+  "parent": undefined,
   "position": 123,
   "type": "Insert",
 }
@@ -207,24 +153,13 @@ Object {
 
 exports[`PartialHierarchyModification fromJSON deserializes \`NodeUpdateInfo\` from JSON 1`] = `
 Object {
-  "changes": Array [
-    Object {
-      "name": "test",
-      "new": "new value",
-      "old": "old value",
-    },
-  ],
-  "node": Object {
-    "key": Object {
-      "instanceKeys": Array [],
-      "pathFromRoot": Array [],
-      "type": "ECInstancesNode",
-    },
-    "label": Object {
-      "displayValue": "TestNode",
-      "rawValue": "test_node",
-      "typeName": "string",
-    },
+  "changes": Object {
+    "backColor": "new value",
+  },
+  "target": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
   },
   "type": "Update",
 }
@@ -232,17 +167,10 @@ Object {
 
 exports[`PartialHierarchyModification toJSON serializes \`NodeDeletionInfo\` 1`] = `
 Object {
-  "node": Object {
-    "key": Object {
-      "instanceKeys": Array [],
-      "pathFromRoot": Array [],
-      "type": "ECInstancesNode",
-    },
-    "labelDefinition": Object {
-      "displayValue": "TestNode",
-      "rawValue": "test_node",
-      "typeName": "string",
-    },
+  "target": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
   },
   "type": "Delete",
 }
@@ -262,6 +190,7 @@ Object {
       "typeName": "string",
     },
   },
+  "parent": undefined,
   "position": 123,
   "type": "Insert",
 }
@@ -269,24 +198,13 @@ Object {
 
 exports[`PartialHierarchyModification toJSON serializes \`NodeUpdateInfo\` 1`] = `
 Object {
-  "changes": Array [
-    Object {
-      "name": "test",
-      "new": "new value",
-      "old": "old value",
-    },
-  ],
-  "node": Object {
-    "key": Object {
-      "instanceKeys": Array [],
-      "pathFromRoot": Array [],
-      "type": "ECInstancesNode",
-    },
-    "labelDefinition": Object {
-      "displayValue": "TestNode",
-      "rawValue": "test_node",
-      "typeName": "string",
-    },
+  "changes": Object {
+    "backColor": "new value",
+  },
+  "target": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
   },
   "type": "Update",
 }
@@ -309,17 +227,10 @@ Object {
       "content": undefined,
       "hierarchy": Array [
         Object {
-          "node": Object {
-            "key": Object {
-              "instanceKeys": Array [],
-              "pathFromRoot": Array [],
-              "type": "ECInstancesNode",
-            },
-            "label": Object {
-              "displayValue": "TestNode",
-              "rawValue": "test_node",
-              "typeName": "string",
-            },
+          "target": Object {
+            "instanceKeys": Array [],
+            "pathFromRoot": Array [],
+            "type": "ECInstancesNode",
           },
           "type": "Delete",
         },
@@ -346,17 +257,10 @@ Object {
       "content": undefined,
       "hierarchy": Array [
         Object {
-          "node": Object {
-            "key": Object {
-              "instanceKeys": Array [],
-              "pathFromRoot": Array [],
-              "type": "ECInstancesNode",
-            },
-            "labelDefinition": Object {
-              "displayValue": "TestNode",
-              "rawValue": "test_node",
-              "typeName": "string",
-            },
+          "target": Object {
+            "instanceKeys": Array [],
+            "pathFromRoot": Array [],
+            "type": "ECInstancesNode",
           },
           "type": "Delete",
         },

--- a/presentation/common/src/test/Update.test.ts
+++ b/presentation/common/src/test/Update.test.ts
@@ -51,7 +51,7 @@ describe("UpdateInfo", () => {
           ["test_ruleset_3"]: {
             hierarchy: [{
               type: "Delete",
-              node: testNode,
+              target: testNode.key,
             }],
           },
         },
@@ -75,7 +75,7 @@ describe("UpdateInfo", () => {
           ["test_ruleset_3"]: {
             hierarchy: [{
               type: "Delete",
-              node: testNodeJson,
+              target: testNodeJson.key,
             }],
           },
         },
@@ -95,7 +95,7 @@ describe("HierarchyUpdateInfo", () => {
     it("serializes partial `HierarchyUpdateInfo` to JSON", () => {
       const info: HierarchyUpdateInfo = [{
         type: "Delete",
-        node: testNode,
+        target: testNode.key,
       }];
       expect(HierarchyUpdateInfo.toJSON(info)).to.matchSnapshot();
     });
@@ -110,7 +110,7 @@ describe("HierarchyUpdateInfo", () => {
     it("deserializes partial `HierarchyUpdateInfo` from JSON", () => {
       const json: HierarchyUpdateInfoJSON = [{
         type: "Delete",
-        node: testNodeJson,
+        target: testNodeJson.key,
       }];
       expect(HierarchyUpdateInfo.fromJSON(json)).to.matchSnapshot();
     });
@@ -131,12 +131,10 @@ describe("PartialHierarchyModification", () => {
     it("serializes `NodeUpdateInfo`", () => {
       const info: NodeUpdateInfo = {
         type: "Update",
-        node: testNode,
-        changes: [{
-          name: "test",
-          old: "old value",
-          new: "new value",
-        }],
+        target: testNode.key,
+        changes: {
+          backColor: "new value",
+        },
       };
       expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
     });
@@ -144,7 +142,7 @@ describe("PartialHierarchyModification", () => {
     it("serializes `NodeDeletionInfo`", () => {
       const info: NodeDeletionInfo = {
         type: "Delete",
-        node: testNode,
+        target: testNode.key,
       };
       expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
     });
@@ -163,12 +161,10 @@ describe("PartialHierarchyModification", () => {
     it("deserializes `NodeUpdateInfo` from JSON", () => {
       const info: NodeUpdateInfoJSON = {
         type: "Update",
-        node: testNodeJson,
-        changes: [{
-          name: "test",
-          old: "old value",
-          new: "new value",
-        }],
+        target: testNode.key,
+        changes: {
+          backColor: "new value",
+        },
       };
       expect(PartialHierarchyModification.fromJSON(info)).to.matchSnapshot();
     });
@@ -176,7 +172,7 @@ describe("PartialHierarchyModification", () => {
     it("deserializes `NodeDeletionInfo` from JSON", () => {
       const info: NodeDeletionInfoJSON = {
         type: "Delete",
-        node: testNodeJson,
+        target: testNodeJson.key,
       };
       expect(PartialHierarchyModification.fromJSON(info)).to.matchSnapshot();
     });
@@ -195,16 +191,14 @@ describe("HierarchyCompareInfo", () => {
           },
           {
             type: "Update",
-            node: testNode,
-            changes: [{
-              name: "test",
-              old: "old value",
-              new: "new value",
-            }],
+            target: testNode.key,
+            changes: {
+              backColor: "new value",
+            },
           },
           {
             type: "Delete",
-            node: testNode,
+            target: testNode.key,
           },
         ],
         continuationToken: {
@@ -227,16 +221,14 @@ describe("HierarchyCompareInfo", () => {
           },
           {
             type: "Update",
-            node: testNodeJson,
-            changes: [{
-              name: "test",
-              old: "old value",
-              new: "new value",
-            }],
+            target: testNodeJson.key,
+            changes: {
+              backColor: "new value",
+            },
           },
           {
             type: "Delete",
-            node: testNodeJson,
+            target: testNodeJson.key,
           },
         ],
         continuationToken: {

--- a/presentation/common/src/test/Update.test.ts
+++ b/presentation/common/src/test/Update.test.ts
@@ -119,11 +119,21 @@ describe("HierarchyUpdateInfo", () => {
 
 describe("PartialHierarchyModification", () => {
   describe("toJSON", () => {
-    it("serializes `NodeInsertionInfo`", () => {
+    it("serializes `NodeInsertionInfo` without parent", () => {
       const info: NodeInsertionInfo = {
-        node: testNode,
-        position: 123,
         type: "Insert",
+        position: 123,
+        node: testNode,
+      };
+      expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
+    });
+
+    it("serializes `NodeInsertionInfo` with parent", () => {
+      const info: NodeInsertionInfo = {
+        type: "Insert",
+        parent: testNode.key,
+        position: 123,
+        node: testNode,
       };
       expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
     });
@@ -149,9 +159,19 @@ describe("PartialHierarchyModification", () => {
   });
 
   describe("fromJSON", () => {
-    it("deserializes `NodeInsertionInfo` from JSON", () => {
+    it("deserializes `NodeInsertionInfo` without parent from JSON", () => {
       const info: NodeInsertionInfoJSON = {
         type: "Insert",
+        position: 123,
+        node: testNodeJson,
+      };
+      expect(PartialHierarchyModification.fromJSON(info)).to.matchSnapshot();
+    });
+
+    it("deserializes `NodeInsertionInfo` with parent from JSON", () => {
+      const info: NodeInsertionInfoJSON = {
+        type: "Insert",
+        parent: testNodeJson.key,
         position: 123,
         node: testNodeJson,
       };

--- a/presentation/common/src/test/hierarchy/Node.test.ts
+++ b/presentation/common/src/test/hierarchy/Node.test.ts
@@ -26,7 +26,7 @@ describe("Node", () => {
     });
   });
 
-  describe("toPartialJson", () => {
+  describe("toPartialJSON", () => {
     it("serializes partial Node", () => {
       const json = Node.toPartialJSON(testNode);
       expect(json).to.deep.equal(testNodeJson);
@@ -45,7 +45,7 @@ describe("Node", () => {
     });
   });
 
-  describe("fromPartialJson", () => {
+  describe("fromPartialJSON", () => {
     it("creates partial Node from serialized partial JSON", () => {
       const node = Node.fromPartialJSON(testNodeJson);
       expect(node).to.deep.equal(testNode);

--- a/presentation/common/src/test/hierarchy/Node.test.ts
+++ b/presentation/common/src/test/hierarchy/Node.test.ts
@@ -28,7 +28,7 @@ describe("Node", () => {
 
   describe("toPartialJson", () => {
     it("serializes partial Node", () => {
-      const json = Node.toPartialJson(testNode);
+      const json = Node.toPartialJSON(testNode);
       expect(json).to.deep.equal(testNodeJson);
     });
   });
@@ -47,7 +47,7 @@ describe("Node", () => {
 
   describe("fromPartialJson", () => {
     it("creates partial Node from serialized partial JSON", () => {
-      const node = Node.fromPartialJson(testNodeJson);
+      const node = Node.fromPartialJSON(testNodeJson);
       expect(node).to.deep.equal(testNode);
     });
   });

--- a/presentation/common/src/test/hierarchy/Node.test.ts
+++ b/presentation/common/src/test/hierarchy/Node.test.ts
@@ -26,6 +26,13 @@ describe("Node", () => {
     });
   });
 
+  describe("toPartialJson", () => {
+    it("serializes partial Node", () => {
+      const json = Node.toPartialJson(testNode);
+      expect(json).to.deep.equal(testNodeJson);
+    });
+  });
+
   describe("fromJSON", () => {
     it("creates valid Node from JSON", () => {
       const node = Node.fromJSON(testNodeJson);
@@ -34,6 +41,13 @@ describe("Node", () => {
 
     it("creates valid Node from serialized JSON", () => {
       const node = Node.fromJSON(JSON.stringify(testNodeJson));
+      expect(node).to.deep.equal(testNode);
+    });
+  });
+
+  describe("fromPartialJson", () => {
+    it("creates partial Node from serialized partial JSON", () => {
+      const node = Node.fromPartialJson(testNodeJson);
       expect(node).to.deep.equal(testNode);
     });
   });

--- a/presentation/components/src/presentation-components/common/StyleHelper.ts
+++ b/presentation/components/src/presentation-components/common/StyleHelper.ts
@@ -195,8 +195,19 @@ export class StyleHelper {
     return color;
   }
 
-  public static isBold(node: Node): boolean { return node.fontStyle ? (node.fontStyle.indexOf("Bold") !== -1) : false; }
-  public static isItalic(node: Node): boolean { return node.fontStyle ? (node.fontStyle.indexOf("Italic") !== -1) : false; }
-  public static getForeColor(node: Node): number | undefined { return node.foreColor ? StyleHelper.getColor(node.foreColor) : undefined; }
-  public static getBackColor(node: Node): number | undefined { return node.backColor ? StyleHelper.getColor(node.backColor) : undefined; }
+  public static isBold(node: Partial<Node>): boolean {
+    return (node.fontStyle?.indexOf("Bold") ?? -1) !== -1;
+  }
+
+  public static isItalic(node: Partial<Node>): boolean {
+    return (node.fontStyle?.indexOf("Italic") ?? -1) !== -1;
+  }
+
+  public static getForeColor(node: Partial<Node>): number | undefined {
+    return node.foreColor ? StyleHelper.getColor(node.foreColor) : undefined;
+  }
+
+  public static getBackColor(node: Partial<Node>): number | undefined {
+    return node.backColor ? StyleHelper.getColor(node.backColor) : undefined;
+  }
 }

--- a/presentation/components/src/presentation-components/tree/Utils.ts
+++ b/presentation/components/src/presentation-components/tree/Utils.ts
@@ -6,7 +6,7 @@
  * @module Tree
  */
 
-import { LabelDefinition, Node, NodeKey, PageOptions as PresentationPageOptions } from "@bentley/presentation-common";
+import { LabelDefinition, Node, NodeKey, PartialNode, PageOptions as PresentationPageOptions } from "@bentley/presentation-common";
 import { PropertyRecord } from "@bentley/ui-abstract";
 import { DelayLoadedTreeNodeItem, ItemColorOverrides, ItemStyle, PageOptions as UiPageOptions } from "@bentley/ui-components";
 import { CheckBoxState } from "@bentley/ui-core";
@@ -47,7 +47,24 @@ export function createTreeNodeItem(
   return item;
 }
 
-function createTreeNodeId(key: NodeKey): string {
+/** @internal */
+export function createPartialTreeNodeItem(
+  node: PartialNode,
+  parentId: string | undefined,
+  props: CreateTreeNodeItemProps,
+): Partial<DelayLoadedTreeNodeItem> {
+  const item: Partial<DelayLoadedTreeNodeItem> = {};
+  if (node.key !== undefined) {
+    item.id = createTreeNodeId(node.key);
+    item.label = createNodeLabelRecord(node, !!props.appendChildrenCountForGroupingNodes);
+  }
+
+  assignOptionalTreeNodeItemFields(item, node, parentId);
+  return item;
+}
+
+/** @internal */
+export function createTreeNodeId(key: NodeKey): string {
   return [...key.pathFromRoot].reverse().join("/");
 }
 

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -86,6 +86,16 @@ export function usePresentationTreeNodeLoader(props: PresentationTreeNodeLoaderP
   useModelSourceUpdateOnRulesetVariablesChange(modelSourceUpdateProps);
 
   const nodeLoader = usePagedTreeNodeLoader(dataProvider, props.pagingSize, modelSource);
+  // When node loader is changed, all node loads automatically get cancelled; need to resume
+  useResumeNodeLoading(modelSource, nodeLoader);
+  return nodeLoader;
+}
+
+/** Starts loading children for nodes that are marked as loading, each time arguments change. */
+function useResumeNodeLoading(
+  modelSource: TreeModelSource,
+  nodeLoader: PagedTreeNodeLoader<IPresentationTreeDataProvider>,
+): void {
   useEffect(
     () => {
       let subscriptions: Subscription | undefined;
@@ -105,8 +115,6 @@ export function usePresentationTreeNodeLoader(props: PresentationTreeNodeLoaderP
     },
     [modelSource, nodeLoader],
   );
-
-  return nodeLoader;
 }
 
 interface ModelSourceUpdateProps {

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -138,13 +138,7 @@ function useModelSourceUpdateOnIModelHierarchyUpdate(props: ModelSourceUpdatePro
         }
       }
     },
-    [
-      dataProvider.rulesetId,
-      dataProvider.imodel.key,
-      rerenderWithTreeModel,
-      modelSource,
-      props.treeNodeItemCreationProps,
-    ],
+    [modelSource, dataProvider, rerenderWithTreeModel, props.treeNodeItemCreationProps],
   );
   useEffect(
     () => {
@@ -299,11 +293,12 @@ function createDataProvider(props: PresentationTreeNodeLoaderProps): IPresentati
   if (props.dataProvider) {
     dataProvider = props.dataProvider;
   } else {
-    const { preloadingEnabled: _preloadingEnabled, dataProvider: _dataProvider, ...providerProps } = props;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { preloadingEnabled, dataProvider: testDataProvider, ...providerProps } = props;
     dataProvider = new PresentationTreeDataProvider(providerProps);
   }
   if (props.preloadingEnabled && dataProvider.loadHierarchy) {
-    void dataProvider.loadHierarchy();
+    dataProvider.loadHierarchy(); // eslint-disable-line @typescript-eslint/no-floating-promises
   }
   return dataProvider;
 }

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -211,7 +211,8 @@ export function updateTreeModel(
       switch (modification.type) {
         case "Insert":
           const nodeInput = convertToTreeModelNodeInput(createTreeNodeItem(modification.node));
-          model.insertChild(modification.parent, nodeInput, modification.position);
+          const parentId = modification.parent === undefined ? undefined : createTreeNodeId(modification.parent);
+          model.insertChild(parentId, nodeInput, modification.position);
           break;
 
         case "Update":

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -6,17 +6,17 @@
  * @module Tree
  */
 
-import { useCallback, useEffect, useState } from "react";
-import {
-  PartialHierarchyModification, RegisteredRuleset, Ruleset, UPDATE_FULL, VariableValue,
-} from "@bentley/presentation-common";
+import * as immer from "immer";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { PartialHierarchyModification, RegisteredRuleset, Ruleset, UPDATE_FULL, VariableValue } from "@bentley/presentation-common";
 import { IModelHierarchyChangeEventArgs, Presentation } from "@bentley/presentation-frontend";
 import {
-  PagedTreeNodeLoader, TreeModelSource, usePagedTreeNodeLoader, useTreeModelSource,
+  MutableTreeModel, PagedTreeNodeLoader, Subscription, TreeModel, TreeModelNodeInput, TreeModelSource, TreeNodeItemData, usePagedTreeNodeLoader,
 } from "@bentley/ui-components";
 import { useDisposable } from "@bentley/ui-core";
 import { PresentationTreeDataProvider, PresentationTreeDataProviderProps } from "../DataProvider";
 import { IPresentationTreeDataProvider } from "../IPresentationTreeDataProvider";
+import { createPartialTreeNodeItem, createTreeNodeId, createTreeNodeItem, CreateTreeNodeItemProps } from "../Utils";
 import { getExpandedNodeItems, useExpandedNodesTracking } from "./UseExpandedNodesTracking";
 
 /**
@@ -60,45 +60,92 @@ export interface PresentationTreeNodeLoaderProps extends PresentationTreeDataPro
  * @beta
  */
 export function usePresentationTreeNodeLoader(props: PresentationTreeNodeLoaderProps): PagedTreeNodeLoader<IPresentationTreeDataProvider> {
-  const [resetCounter, setResetCounter] = useState(0);
-  const reset = useCallback(() => setResetCounter((value) => ++value), []);
+  interface Info {
+    treeModel: MutableTreeModel | undefined;
+  }
 
+  const [info, setInfo] = useState<Info>({ treeModel: undefined });
   const dataProvider = useDisposable(useCallback(
-    () => {
-      return createDataProvider(props);
-    },
-    [resetCounter, ...Object.values(props)], /* eslint-disable-line react-hooks/exhaustive-deps */ /* re-create the data-provider whenever any prop changes */
+    () => createDataProvider(props),
+    [info, ...Object.values(props)], /* eslint-disable-line react-hooks/exhaustive-deps */ /* re-create the data-provider whenever any prop changes */
   ));
-  const modelSource = useTreeModelSource(dataProvider);
 
-  useModelSourceUpdateOnIModelHierarchyUpdate({ modelSource, dataProvider, reset, enable: props.enableHierarchyAutoUpdate });
-  useModelSourceUpdateOnRulesetModification({ modelSource, dataProvider, reset, enable: props.enableHierarchyAutoUpdate });
-  useModelSourceUpdateOnRulesetVariablesChange({ modelSource, dataProvider, reset, enable: props.enableHierarchyAutoUpdate });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const modelSource = useMemo(() => new TreeModelSource(info.treeModel), [dataProvider, info]);
 
-  return usePagedTreeNodeLoader(dataProvider, props.pagingSize, modelSource);
+  const rerenderWithTreeModel = (treeModel?: MutableTreeModel) => setInfo({ treeModel });
+  const modelSourceUpdateProps: ModelSourceUpdateProps = {
+    enable: props.enableHierarchyAutoUpdate,
+    modelSource,
+    rerenderWithTreeModel,
+    dataProvider,
+    treeNodeItemCreationProps: { appendChildrenCountForGroupingNodes: props.appendChildrenCountForGroupingNodes },
+  };
+  useModelSourceUpdateOnIModelHierarchyUpdate(modelSourceUpdateProps);
+  useModelSourceUpdateOnRulesetModification(modelSourceUpdateProps);
+  useModelSourceUpdateOnRulesetVariablesChange(modelSourceUpdateProps);
+
+  const nodeLoader = usePagedTreeNodeLoader(dataProvider, props.pagingSize, modelSource);
+  useEffect(
+    () => {
+      let subscriptions: Subscription | undefined;
+      for (const node of modelSource.getModel().iterateTreeModelNodes()) {
+        if (!node.isLoading) {
+          continue;
+        }
+
+        if (subscriptions === undefined) {
+          subscriptions = nodeLoader.loadNode(node, 0).subscribe();
+        } else {
+          subscriptions.add(nodeLoader.loadNode(node, 0).subscribe());
+        }
+      }
+
+      return () => subscriptions?.unsubscribe();
+    },
+    [modelSource, nodeLoader],
+  );
+
+  return nodeLoader;
 }
 
 interface ModelSourceUpdateProps {
   enable?: boolean;
   modelSource: TreeModelSource;
+  rerenderWithTreeModel: (treeModel?: MutableTreeModel) => void;
   dataProvider: IPresentationTreeDataProvider;
-  reset: () => void;
+  treeNodeItemCreationProps: CreateTreeNodeItemProps;
 }
 
 function useModelSourceUpdateOnIModelHierarchyUpdate(props: ModelSourceUpdateProps) {
-  const { modelSource, dataProvider, reset } = props;
+  const { modelSource, dataProvider, rerenderWithTreeModel } = props;
   useExpandedNodesTracking({ modelSource, dataProvider, enableAutoUpdate: props.enable ?? false });
-  const onIModelHierarchyChanged = useCallback(async (args: IModelHierarchyChangeEventArgs) => {
-    if (args.rulesetId === dataProvider.rulesetId && args.imodelKey === dataProvider.imodel.key) {
-      if (args.updateInfo === UPDATE_FULL)
-        reset();
-      else
-        updateModelSource(modelSource, args.updateInfo, reset);
-    }
-  }, [modelSource, dataProvider, reset]);
-  useEffect(() => {
-    return props.enable ? Presentation.presentation.onIModelHierarchyChanged.addListener(onIModelHierarchyChanged) : undefined;
-  }, [onIModelHierarchyChanged, props.enable]);
+  const onIModelHierarchyChanged = useCallback(
+    async (args: IModelHierarchyChangeEventArgs) => {
+      if (args.rulesetId === dataProvider.rulesetId && args.imodelKey === dataProvider.imodel.key) {
+        if (args.updateInfo === UPDATE_FULL) {
+          rerenderWithTreeModel(undefined);
+        } else {
+          updateModelSource(modelSource, rerenderWithTreeModel, args.updateInfo, props.treeNodeItemCreationProps);
+        }
+      }
+    },
+    [
+      dataProvider.rulesetId,
+      dataProvider.imodel.key,
+      rerenderWithTreeModel,
+      modelSource,
+      props.treeNodeItemCreationProps,
+    ],
+  );
+  useEffect(
+    () => {
+      return props.enable
+        ? Presentation.presentation.onIModelHierarchyChanged.addListener(onIModelHierarchyChanged)
+        : undefined;
+    },
+    [onIModelHierarchyChanged, props.enable],
+  );
 }
 
 function useModelSourceUpdateOnRulesetModification(props: ModelSourceUpdateProps) {
@@ -112,9 +159,9 @@ function useModelSourceUpdateOnRulesetModification(props: ModelSourceUpdateProps
         rulesetOrId: curr.toJSON(),
         expandedNodeKeys: getExpandedNodeKeys(props.modelSource, props.dataProvider),
       });
-      updateModelSource(props.modelSource, compareResult, props.reset);
+      updateModelSource(props.modelSource, props.rerenderWithTreeModel, compareResult, props.treeNodeItemCreationProps);
     }
-  }, [props.modelSource, props.dataProvider, props.reset]);
+  }, [props.dataProvider, props.modelSource, props.rerenderWithTreeModel, props.treeNodeItemCreationProps]);
   useEffect(() => {
     return props.enable ? Presentation.presentation.rulesets().onRulesetModified.addListener(onRulesetModified) : undefined;
   }, [onRulesetModified, props.enable]);
@@ -133,17 +180,105 @@ function useModelSourceUpdateOnRulesetVariablesChange(props: ModelSourceUpdatePr
       rulesetOrId: props.dataProvider.rulesetId,
       expandedNodeKeys: getExpandedNodeKeys(props.modelSource, props.dataProvider),
     });
-    updateModelSource(props.modelSource, compareResult, props.reset);
-  }, [props.modelSource, props.dataProvider, props.reset]);
+    updateModelSource(props.modelSource, props.rerenderWithTreeModel, compareResult, props.treeNodeItemCreationProps);
+  }, [props.dataProvider, props.modelSource, props.rerenderWithTreeModel, props.treeNodeItemCreationProps]);
   useEffect(() => {
     return props.enable ? Presentation.presentation.vars(props.dataProvider.rulesetId).onVariableChanged.addListener(onRulesetVariableChanged) : undefined;
   }, [props.dataProvider.rulesetId, onRulesetVariableChanged, props.enable]);
 }
 
-function updateModelSource(_modelSource: TreeModelSource, _hierarchyModifications: PartialHierarchyModification[], reset: () => void) {
-  // WIP: this should smartly update model source based on hierarchy modifications, but for
-  // now we just call `reset` which completely re-creates the data provider and model source
-  reset();
+function updateModelSource(
+  modelSource: TreeModelSource,
+  rerenderWithTreeModel: (treeModel?: MutableTreeModel) => void,
+  hierarchyModifications: PartialHierarchyModification[],
+  treeNodeItemCreationProps: CreateTreeNodeItemProps,
+) {
+  const newModel = updateTreeModel(modelSource.getModel(), hierarchyModifications, treeNodeItemCreationProps);
+  if (newModel !== modelSource.getModel() || newModel === undefined) {
+    rerenderWithTreeModel(newModel);
+  }
+}
+
+/** @internal */
+export function updateTreeModel(
+  treeModel: TreeModel,
+  hierarchyModifications: PartialHierarchyModification[],
+  treeNodeItemCreationProps: CreateTreeNodeItemProps,
+): MutableTreeModel | undefined {
+  let encounteredAnError = false;
+  const updatedTreeModel = immer.produce(treeModel as MutableTreeModel, (model) => {
+    for (const modification of hierarchyModifications) {
+      switch (modification.type) {
+        case "Insert":
+          const nodeInput = convertToTreeModelNodeInput(createTreeNodeItem(modification.node));
+          model.insertChild(modification.parent, nodeInput, modification.position);
+          break;
+
+        case "Update":
+          const existingNode = model.getNode(createTreeNodeId(modification.target));
+          if (existingNode === undefined) {
+            break;
+          }
+
+          const updatedItem = {
+            ...existingNode.item,
+            ...createPartialTreeNodeItem(modification.changes, existingNode.parentId, treeNodeItemCreationProps),
+          };
+
+          delete existingNode.editingInfo;
+          existingNode.item = updatedItem;
+          existingNode.label = updatedItem.label;
+          existingNode.description = updatedItem.description ?? "";
+
+          if ("hasChildren" in modification.changes) {
+            model.setNumChildren(existingNode.id, modification.changes.hasChildren ? undefined : 0);
+            if (!modification.changes.hasChildren) {
+              existingNode.isExpanded = false;
+              existingNode.isLoading = false;
+            }
+          }
+
+          if ("key" in modification.changes && existingNode.id !== updatedItem.id) {
+            if (!model.changeNodeId(existingNode.id, updatedItem.id)) {
+              encounteredAnError = true;
+              return;
+            }
+
+            existingNode.isSelected = false;
+          }
+
+          break;
+
+        case "Delete":
+          const nodeToRemove = model.getNode(createTreeNodeId(modification.target));
+          if (nodeToRemove === undefined) {
+            return;
+          }
+
+          model.removeChild(nodeToRemove.parentId, nodeToRemove.id);
+          break;
+      }
+    }
+  });
+
+  if (encounteredAnError) {
+    return undefined;
+  }
+
+  return updatedTreeModel;
+}
+
+function convertToTreeModelNodeInput(item: TreeNodeItemData): TreeModelNodeInput {
+  return {
+    description: item.description,
+    isExpanded: !!item.autoExpand,
+    id: item.id,
+    item,
+    label: item.label,
+    isLoading: false,
+    numChildren: item.hasChildren ? undefined : 0,
+    isSelected: false,
+  };
 }
 
 function getExpandedNodeKeys(modelSource: TreeModelSource, dataProvider: IPresentationTreeDataProvider) {
@@ -155,12 +290,11 @@ function createDataProvider(props: PresentationTreeNodeLoaderProps): IPresentati
   if (props.dataProvider) {
     dataProvider = props.dataProvider;
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { preloadingEnabled, dataProvider: testDataProvider, ...providerProps } = props;
+    const { preloadingEnabled: _preloadingEnabled, dataProvider: _dataProvider, ...providerProps } = props;
     dataProvider = new PresentationTreeDataProvider(providerProps);
   }
   if (props.preloadingEnabled && dataProvider.loadHierarchy) {
-    dataProvider.loadHierarchy(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void dataProvider.loadHierarchy();
   }
   return dataProvider;
 }

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -2,26 +2,33 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
 import { expect } from "chai";
+import { it } from "mocha";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { BeEvent, IDisposable } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
-import { RegisteredRuleset, Ruleset, VariableValue, VariableValueTypes } from "@bentley/presentation-common";
-import { IModelHierarchyChangeEventArgs, Presentation, PresentationManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
-import { PropertyRecord } from "@bentley/ui-abstract";
-import { TreeDataChangesListener, TreeModelNodeInput, TreeNodeItem } from "@bentley/ui-components";
-import { cleanup, renderHook } from "@testing-library/react-hooks";
+import {
+  LabelDefinition, LabelGroupingNodeKey, Node, PartialHierarchyModification, RegisteredRuleset, StandardNodeTypes, VariableValueTypes,
+} from "@bentley/presentation-common";
+import { Presentation, PresentationManager, RulesetManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
+import { PrimitiveValue, PropertyRecord } from "@bentley/ui-abstract";
+import {
+  from, MutableTreeModel, PagedTreeNodeLoader, TreeDataChangesListener, TreeModel, TreeModelNode, TreeModelNodeEditingInfo, TreeModelNodeInput,
+  TreeNodeItem,
+} from "@bentley/ui-components";
+import { act, cleanup, renderHook } from "@testing-library/react-hooks";
 import { IPresentationTreeDataProvider } from "../../../presentation-components";
-import { PresentationTreeNodeLoaderProps, usePresentationTreeNodeLoader } from "../../../presentation-components/tree/controlled/TreeHooks";
+import {
+  PresentationTreeNodeLoaderProps, updateTreeModel, usePresentationTreeNodeLoader,
+} from "../../../presentation-components/tree/controlled/TreeHooks";
+import { createTreeNodeItem } from "../../../presentation-components/tree/Utils";
 import { createRandomTreeNodeItem, mockPresentationManager } from "../../_helpers/UiComponents";
 
 describe("usePresentationNodeLoader", () => {
-
-  let onIModelHierarchyChanged: BeEvent<(args: IModelHierarchyChangeEventArgs) => void>;
-  let onRulesetModified: BeEvent<(curr: RegisteredRuleset, prev: Ruleset) => void>;
-  let onRulesetVariableChanged: BeEvent<(variableId: string, prevValue: VariableValue, currValue: VariableValue) => void>;
+  let onIModelHierarchyChanged: PresentationManager["onIModelHierarchyChanged"];
+  let onRulesetModified: RulesetManager["onRulesetModified"];
+  let onRulesetVariableChanged: RulesetVariablesManager["onVariableChanged"];
   let presentationManagerMock: moq.IMock<PresentationManager>;
   let rulesetVariablesManagerMock: moq.IMock<RulesetVariablesManager>;
   const imodelMock = moq.Mock.ofType<IModelConnection>();
@@ -98,6 +105,11 @@ describe("usePresentationNodeLoader", () => {
   });
 
   describe("auto-updating model source", () => {
+    const hierarchyChange: PartialHierarchyModification = {
+      type: "Insert",
+      node: { key: { type: "", pathFromRoot: [] }, label: LabelDefinition.fromLabelString("") },
+      position: 0,
+    };
 
     beforeEach(() => {
       initialProps.enableHierarchyAutoUpdate = true;
@@ -146,7 +158,7 @@ describe("usePresentationNodeLoader", () => {
       );
       const oldNodeLoader = result.current;
 
-      onIModelHierarchyChanged.raiseEvent({ rulesetId, updateInfo: [], imodelKey });
+      onIModelHierarchyChanged.raiseEvent({ rulesetId, updateInfo: [hierarchyChange], imodelKey });
 
       expect(result.current).to.not.eq(oldNodeLoader);
     });
@@ -165,7 +177,7 @@ describe("usePresentationNodeLoader", () => {
     });
 
     it("creates a new nodeLoader when `RulesetsManager` raises a related `onRulesetModified` event", async () => {
-      const { result, waitForValueToChange } = renderHook(
+      const { result, waitForNextUpdate } = renderHook(
         (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
         { initialProps },
       );
@@ -181,18 +193,19 @@ describe("usePresentationNodeLoader", () => {
           rulesetOrId: currRuleset.toJSON(),
           expandedNodeKeys: [],
         }))
-        .returns(async () => [])
+        .returns(async () => [hierarchyChange])
         .verifiable();
-      onRulesetModified.raiseEvent(currRuleset, currRuleset.toJSON());
 
-      await waitForValueToChange(() => result.current !== oldNodeLoader);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      act(() => { onRulesetModified.raiseEvent(currRuleset, currRuleset.toJSON()); });
+      await waitForNextUpdate();
+
       expect(result.current).to.not.eq(oldNodeLoader);
-
       presentationManagerMock.verifyAll();
     });
 
     it("creates a new nodeLoader when `RulesetVariablesManager` raises an `onRulesetVariableChanged` event", async () => {
-      const { result, waitForValueToChange } = renderHook(
+      const { result, waitForNextUpdate } = renderHook(
         (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
         { initialProps },
       );
@@ -212,24 +225,35 @@ describe("usePresentationNodeLoader", () => {
           rulesetOrId: rulesetId,
           expandedNodeKeys: [],
         }))
-        .returns(async () => [])
+        .returns(async () => [hierarchyChange])
         .verifiable();
       rulesetVariablesManagerMock.setup(async (x) => x.getAllVariables()).returns(async () => variables);
 
-      onRulesetVariableChanged.raiseEvent("var-id", "prev", "curr");
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      act(() => { onRulesetVariableChanged.raiseEvent("var-id", "prev", "curr"); });
+      await waitForNextUpdate();
 
-      await waitForValueToChange(() => result.current !== oldNodeLoader);
       expect(result.current).to.not.eq(oldNodeLoader);
-
       presentationManagerMock.verifyAll();
     });
 
-    it("sends visible expanded nodes when comparing hierarchies due to ruleset modification", async () => {
-      const { result, waitForValueToChange } = renderHook(
+    it("does not create a new nodeLoader when there are no changes", () => {
+      const { result } = renderHook(
         (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
         { initialProps },
       );
       const oldNodeLoader = result.current;
+
+      onIModelHierarchyChanged.raiseEvent({ rulesetId, updateInfo: [], imodelKey });
+
+      expect(result.current).to.eq(oldNodeLoader);
+    });
+
+    it("sends visible expanded nodes when comparing hierarchies due to ruleset modification", async () => {
+      const { result, waitForNextUpdate } = renderHook(
+        (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
+        { initialProps },
+      );
 
       const createTreeModelNodeInput = (id: string, isExpanded: boolean): TreeModelNodeInput => ({
         id,
@@ -263,16 +287,15 @@ describe("usePresentationNodeLoader", () => {
             result.current.dataProvider.getNodeKey(b.item),
           ],
         }))
-        .returns(async () => [])
+        .returns(async () => [hierarchyChange])
         .verifiable();
-      onRulesetModified.raiseEvent(currRuleset, currRuleset.toJSON());
 
-      await waitForValueToChange(() => result.current !== oldNodeLoader);
-      expect(result.current).to.not.eq(oldNodeLoader);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      act(() => { onRulesetModified.raiseEvent(currRuleset, currRuleset.toJSON()); });
 
+      await waitForNextUpdate();
       presentationManagerMock.verifyAll();
     });
-
   });
 
   it("starts preloading hierarchy", () => {
@@ -327,4 +350,413 @@ describe("usePresentationNodeLoader", () => {
     expect(dataProvider.dispose).to.be.calledOnce;
   });
 
+  function createNode(label: string): Node {
+    return Node.fromJSON({
+      key: { type: StandardNodeTypes.ECInstancesNode, instanceKeys: [], pathFromRoot: [label] },
+      labelDefinition: { displayValue: label, rawValue: label, typeName: "string" },
+    });
+  }
+
+  function createNodeInput(label: string): TreeModelNodeInput {
+    const node = createNode(label);
+    const item = createTreeNodeItem(node, undefined);
+    return {
+      id: label,
+      item,
+      label: item.label,
+      isExpanded: false,
+      isLoading: false,
+      isSelected: false,
+    };
+  }
+
+  it("reinitiates node loading on hierarchy change", async () => {
+    const { result } = renderHook(
+      (props: PresentationTreeNodeLoaderProps) => usePresentationTreeNodeLoader(props),
+      { initialProps: { ...initialProps, enableHierarchyAutoUpdate: true } },
+    );
+    result.current.modelSource.modifyModel((model) => {
+      model.setChildren(undefined, [createNodeInput("loading_node1"), createNodeInput("loading_node2")], 0);
+      model.getNode("loading_node1")!.isLoading = true;
+      model.getNode("loading_node2")!.isLoading = true;
+    });
+
+    const spyLoadNode = sinon.stub(PagedTreeNodeLoader.prototype, "loadNode").returns(from([]));
+
+    void act(() => {
+      onIModelHierarchyChanged.raiseEvent({
+        imodelKey,
+        rulesetId,
+        updateInfo: [{ type: "Insert", parent: undefined, position: 2, node: createNode("inserted_node") }],
+      });
+    });
+
+    expect(spyLoadNode).to.have.been.called.calledTwice;
+  });
+
+  describe("updateTreeModel", () => {
+    type TreeHierarchy = string | {
+      [label: string]: TreeHierarchy[];
+    } | {
+      label: string;
+      selected?: true;
+      expanded?: true;
+      loading?: true;
+      editingInfo?: TreeModelNodeEditingInfo;
+      children?: TreeHierarchy[];
+    };
+
+    function expectTree(model: TreeModel, expectedHierarchy: TreeHierarchy[]): void {
+      const actualHierarchy = buildActualHierarchy(undefined);
+      expect(actualHierarchy).to.deep.equal(expectedHierarchy);
+
+      function buildActualHierarchy(parentId: string | undefined): TreeHierarchy[] {
+        const result: TreeHierarchy[] = [];
+        for (const childId of model.getChildren(parentId) ?? []) {
+          const node = model.getNode(childId) as TreeModelNode;
+          const label = (node.label.value as PrimitiveValue).displayValue!;
+          const children = buildActualHierarchy(childId);
+          const additionalProperties: Partial<TreeHierarchy> = {};
+          if (node.isSelected) {
+            additionalProperties.selected = true;
+          }
+
+          if (node.isExpanded) {
+            additionalProperties.expanded = true;
+          }
+
+          if (node.isLoading) {
+            additionalProperties.loading = true;
+          }
+
+          if (node.editingInfo) {
+            additionalProperties.editingInfo = node.editingInfo;
+          }
+
+          if (Object.keys(additionalProperties).length > 0) {
+            result.push({ label, ...additionalProperties, ...(children.length > 0 && { children }) });
+          } else if (children.length > 0) {
+            result.push({ [label]: children });
+          } else {
+            result.push(label);
+          }
+        }
+
+        return result;
+      }
+    }
+
+    function createTreeModel(hierarchy: TreeHierarchy[]): MutableTreeModel {
+      const treeModel = new MutableTreeModel();
+      insertNodes(undefined, hierarchy);
+      expectTree(treeModel, hierarchy);
+      return treeModel;
+
+      function insertNodes(parentId: string | undefined, childNodes: TreeHierarchy[]): void {
+        for (let i = 0; i < childNodes.length; ++i) {
+          const node = childNodes[i];
+          if (typeof node === "string") {
+            treeModel.insertChild(parentId, createNodeInput(node), i);
+          } else if (typeof node.label === "string") {
+            treeModel.insertChild(parentId, createNodeInput(node.label), i);
+            const insertedNode = treeModel.getNode(node.label)!;
+            if (node.selected) {
+              insertedNode.isSelected = true;
+            }
+
+            if (node.expanded) {
+              insertedNode.isExpanded = true;
+            }
+
+            if (node.loading) {
+              insertedNode.isLoading = true;
+            }
+
+            if (node.editingInfo) {
+              insertedNode.editingInfo = node.editingInfo as TreeModelNodeEditingInfo;
+            }
+
+            insertNodes(node.label, node.children ?? []);
+          } else {
+            const nodeLabel = Object.keys(node)[0];
+            treeModel.insertChild(parentId, createNodeInput(nodeLabel), i);
+            insertNodes(nodeLabel, (node as any)[nodeLabel] as TreeHierarchy[]);
+          }
+        }
+      }
+    }
+
+    it("returns `undefined` on failure", () => {
+      const initialTree = createTreeModel(["root1", "root2"]);
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{
+          type: "Update",
+          target: createNode("root1").key,
+          changes: { key: createNode("root2").key, label: LabelDefinition.fromLabelString("root2") },
+        }],
+        {},
+      );
+      expect(updatedTree).to.be.undefined;
+    });
+
+    it("keeps nodes selected", () => {
+      const initialTree = createTreeModel(
+        [{ label: "root1", selected: true }, { label: "root2", selected: true }, "root3"],
+      );
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{
+          type: "Update",
+          target: createNode("root1").key,
+          changes: { description: "updated description" },
+        }],
+        {}
+      );
+      expect(updatedTree).to.be.not.equal(initialTree);
+      expectTree(updatedTree!, [{ label: "root1", selected: true }, { label: "root2", selected: true }, "root3"]);
+    });
+
+    it("keeps nodes expanded", () => {
+      const initialTree = createTreeModel(
+        [{ label: "root1", expanded: true }, { label: "root2", expanded: true }, "root3"],
+      );
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{
+          type: "Update",
+          target: createNode("root1").key,
+          changes: { description: "updated description" },
+        }],
+        {}
+      );
+      expect(updatedTree).to.be.not.equal(initialTree);
+      expectTree(updatedTree!, [{ label: "root1", expanded: true }, { label: "root2", expanded: true }, "root3"]);
+    });
+
+    describe("node insertion", () => {
+      it("inserts root node", () => {
+        const initialTree = createTreeModel(["root1", "root2"]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{ type: "Insert", position: 1, node: createNode("inserted_node") }],
+          { appendChildrenCountForGroupingNodes: false },
+        );
+        expectTree(updatedTree!, ["root1", "inserted_node", "root2"]);
+      });
+
+      it("inserts child node wihout children", () => {
+        const initialTree = createTreeModel([{ ["root1"]: ["child1"] }]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{ type: "Insert", parent: "root1", position: 0, node: createNode("inserted_node") }],
+          {},
+        );
+        expectTree(updatedTree!, [{ ["root1"]: ["inserted_node", "child1"] }]);
+        expect(updatedTree!.getNode("root1")!.numChildren).to.be.equal(2);
+        expect(updatedTree!.getNode("inserted_node")!.numChildren).to.be.equal(0);
+      });
+
+      it("inserts child node with children", () => {
+        const initialTree = createTreeModel([{ ["root1"]: ["child1"] }]);
+        const node = createNode("inserted_node");
+        node.hasChildren = true;
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{ type: "Insert", parent: "root1", position: 0, node }],
+          {},
+        );
+        expectTree(updatedTree!, [{ ["root1"]: ["inserted_node", "child1"] }]);
+        expect(updatedTree!.getNode("root1")!.numChildren).to.be.equal(2);
+        expect(updatedTree!.getNode("inserted_node")!.numChildren).to.be.equal(undefined);
+      });
+
+      it("creates new hierarchy level", () => {
+        const initialTree = createTreeModel([{ ["root1"]: ["child1"] }]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{ type: "Insert", parent: "child1", position: 0, node: createNode("inserted_node") }],
+          {},
+        );
+        expectTree(updatedTree!, [{ ["root1"]: [{ ["child1"]: ["inserted_node"] }] }]);
+        expect(updatedTree!.getNode("child1")!.numChildren).to.be.equal(1);
+      });
+    });
+
+    describe("node update", () => {
+      it("ignores nodes that do not exist", () => {
+        const initialTree = createTreeModel(["root1", "root2"]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root3").key,
+            changes: { description: "new description" },
+          }],
+          {},
+        );
+        expect(initialTree).to.be.equal(updatedTree);
+      });
+
+      it("updates existing node", () => {
+        const initialTree = createTreeModel(["root1", "root2", "root3"]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root2").key,
+            changes: {
+              key: createNode("root2").key,
+              label: LabelDefinition.fromLabelString("updated_node"),
+              description: "updated description",
+            },
+          }],
+          {},
+        );
+        expectTree(updatedTree!, ["root1", "updated_node", "root3"]);
+        expect(updatedTree!.getNode("root2")?.description).to.be.equal("updated description");
+      });
+
+      it("removes children if node no longer has them", () => {
+        const initialTree = createTreeModel([{ ["root1"]: ["child1"] }, "root2"]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { hasChildren: false },
+          }],
+          {},
+        );
+        expectTree(updatedTree!, ["root1", "root2"]);
+        expect(updatedTree!.getNode("root1")!.numChildren).to.be.equal(0);
+      });
+
+      it("makes node expandable if it has children after update", () => {
+        const initialTree = createTreeModel(["root1", "root2"]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { hasChildren: true },
+          }],
+          {},
+        );
+        expectTree(updatedTree!, ["root1", "root2"]);
+        expect(updatedTree!.getNode("root1")!.numChildren).to.be.undefined;
+      });
+
+      it("updates node key", () => {
+        const initialTree = createTreeModel(["root1", "root2"]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { key: createNode("updated_node").key, label: LabelDefinition.fromLabelString("updated_node") },
+          }],
+          {},
+        );
+        expectTree(updatedTree!, ["updated_node", "root2"]);
+        expect(updatedTree!.getNode("updated_node")).not.to.be.undefined;
+      });
+
+      it("appends child count for grouping nodes", () => {
+        const initialTree = createTreeModel(["root1", "root2"]);
+        const updatedKey: LabelGroupingNodeKey = {
+          groupedInstancesCount: 10,
+          pathFromRoot: [],
+          type: StandardNodeTypes.DisplayLabelGroupingNode,
+          label: "",
+        };
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { key: updatedKey, label: LabelDefinition.fromLabelString("updated_node") },
+          }],
+          { appendChildrenCountForGroupingNodes: true },
+        );
+        expectTree(updatedTree!, ["updated_node (10)", "root2"]);
+      });
+
+      it("exits edit state on modified nodes", () => {
+        const editingInfo: TreeModelNodeEditingInfo = { onCommit: () => { }, onCancel: () => { } };
+        const initialTree = createTreeModel([{ label: "root1", editingInfo }, { label: "root2", editingInfo }]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { key: createNode("root1").key, label: LabelDefinition.fromLabelString("updated_node") },
+          }],
+          {}
+        );
+        expectTree(updatedTree!, ["updated_node", { label: "root2", editingInfo }]);
+      });
+
+      it("collapses nodes that no longer have children", () => {
+        const initialTree = createTreeModel([
+          { label: "root1", expanded: true, loading: true, children: ["child1"] },
+          { label: "root2", expanded: true, loading: true, children: ["child2"] },
+        ]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { hasChildren: false },
+          }],
+          {},
+        );
+        expectTree(
+          updatedTree!,
+          ["root1", { label: "root2", expanded: true, loading: true, children: ["child2"] }],
+        );
+      });
+
+      it("deselects nodes that have changed keys", () => {
+        const initialTree = createTreeModel([{ label: "root1", selected: true }, { label: "root2", selected: true }]);
+        const updatedTree = updateTreeModel(
+          initialTree,
+          [{
+            type: "Update",
+            target: createNode("root1").key,
+            changes: { key: createNode("updated_key").key, label: LabelDefinition.fromLabelString("updated_node") },
+          }],
+          {}
+        );
+        expectTree(updatedTree!, ["updated_node", { label: "root2", selected: true }]);
+      });
+    });
+
+    describe("node removal", () => {
+      it("removes root node", () => {
+        const initialTree = createTreeModel(["root1", "root2", "root3"]);
+        const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("root2").key }], {});
+        expectTree(updatedTree!, ["root1", "root3"]);
+      });
+
+      it("removes child node", () => {
+        const initialTree = createTreeModel([{ ["root1"]: ["child1", "child2"] }, "root2"]);
+        const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("child1").key }], {});
+        expectTree(updatedTree!, [{ ["root1"]: ["child2"] }, "root2"]);
+      });
+
+      it("removes children along with removed node", () => {
+        const initialTree = createTreeModel([{ ["root1"]: ["child1", "child2"] }, "root2"]);
+        const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("root1").key }], {});
+        expectTree(updatedTree!, ["root2"]);
+      });
+
+      it("ignores deletion of node that does not exist", () => {
+        const initialTree = createTreeModel(["root1", "root2"]);
+        const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("root3").key }], {});
+        expect(updatedTree).to.be.equal(initialTree);
+        expectTree(updatedTree!, ["root1", "root2"]);
+      });
+    });
+  });
 });

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -549,7 +549,7 @@ describe("usePresentationNodeLoader", () => {
         const initialTree = createTreeModel([{ ["root1"]: ["child1"] }]);
         const updatedTree = updateTreeModel(
           initialTree,
-          [{ type: "Insert", parent: "root1", position: 0, node: createNode("inserted_node") }],
+          [{ type: "Insert", parent: createNode("root1").key, position: 0, node: createNode("inserted_node") }],
           {},
         );
         expectTree(updatedTree!, [{ ["root1"]: ["inserted_node", "child1"] }]);
@@ -563,7 +563,7 @@ describe("usePresentationNodeLoader", () => {
         node.hasChildren = true;
         const updatedTree = updateTreeModel(
           initialTree,
-          [{ type: "Insert", parent: "root1", position: 0, node }],
+          [{ type: "Insert", parent: createNode("root1").key, position: 0, node }],
           {},
         );
         expectTree(updatedTree!, [{ ["root1"]: ["inserted_node", "child1"] }]);
@@ -575,7 +575,7 @@ describe("usePresentationNodeLoader", () => {
         const initialTree = createTreeModel([{ ["root1"]: ["child1"] }]);
         const updatedTree = updateTreeModel(
           initialTree,
-          [{ type: "Insert", parent: "child1", position: 0, node: createNode("inserted_node") }],
+          [{ type: "Insert", parent: createNode("child1").key, position: 0, node: createNode("inserted_node") }],
           {},
         );
         expectTree(updatedTree!, [{ ["root1"]: [{ ["child1"]: ["inserted_node"] }] }]);

--- a/ui/components/src/ui-components/tree/controlled/TreeModelSource.ts
+++ b/ui/components/src/ui-components/tree/controlled/TreeModelSource.ts
@@ -26,13 +26,12 @@ export interface TreeModelChanges {
  * @beta
  */
 export class TreeModelSource {
-  private _model = new MutableTreeModel();
   private _visibleNodes?: VisibleTreeNodes;
 
   /** Event that is emitted every time tree model is changed. */
   public onModelChanged = new BeUiEvent<[TreeModel, TreeModelChanges]>();
 
-  constructor() {
+  constructor(private _model: MutableTreeModel = new MutableTreeModel()) {
     this.onModelChanged.addListener(() => this._visibleNodes = undefined);
   }
 


### PR DESCRIPTION
Until now, we used to handle partial hierarchy updates the same way as full updates: by rebuilding the existing tree model from scratch. This PR aims to support updating existing trees without loosing the UI state such as node selection or expansion.

[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/146794)