### PR TITLE
fix codeowners sanity check job

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.5.0
         with:
-          checks: "files,duppatterns,syntax"
+          checks: "duppatterns,syntax"
           experimental_checks: "notowned"
           # GitHub access token is required only if the `owners` check is enabled
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"


### PR DESCRIPTION
With the new way we're handling the `common/changes` folder, the "files" check will no longer work properly all the time.  It validates that all patterns in the codeowners file actually match files, which in the case of `common/changes` is no longer true.