### PR TITLE
Keyin palette history fix

### DIFF
--- a/common/changes/@bentley/ui-framework/keyinPaletteHistoryFix_2021-03-02-20-52.json
+++ b/common/changes/@bentley/ui-framework/keyinPaletteHistoryFix_2021-03-02-20-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Filter out history key-in that are no longer available in key-in palette.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/framework/src/ui-framework/popup/KeyinPalettePanel.tsx
+++ b/ui/framework/src/ui-framework/popup/KeyinPalettePanel.tsx
@@ -53,7 +53,11 @@ export function KeyinPalettePanel({ keyins, onKeyinExecuted, historyLength: allo
       const settingsResult = await uiSettings.getSetting(KEYIN_PALETTE_NAMESPACE, KEYIN_HISTORY_KEY);
       // istanbul ignore else
       if (UiSettingsStatus.Success === settingsResult.status) {
-        setHistoryKeyins(settingsResult.setting);
+        const filteredHistory = (settingsResult.setting as string[]).filter((keyin)=>{
+          const result = IModelApp.tools.parseKeyin(keyin);
+          return result.ok;
+        });
+        setHistoryKeyins(filteredHistory);
       } else {
         setHistoryKeyins([]);
       }


### PR DESCRIPTION
Ensure any key-ins that are stored in history are still available before displaying in key-in palette.