### PR TITLE
UI: Add ability to move nodes within MutableTreeModel

### DIFF
--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -2948,6 +2948,7 @@ export class MutableTreeModel implements TreeModel {
     getRootNode(): TreeModelRootNode;
     insertChild(parentId: string | undefined, childNodeInput: TreeModelNodeInput, offset: number): void;
     iterateTreeModelNodes(parentId?: string): IterableIterator<MutableTreeModelNode>;
+    moveNode(sourceNodeId: string, targetParentId: string | undefined, targetIndex: number): boolean;
     removeChild(parentId: string | undefined, childId: string): void;
     setChildren(parentId: string | undefined, nodeInputs: TreeModelNodeInput[], offset: number): void;
     setNumChildren(parentId: string | undefined, numChildren: number | undefined): void;
@@ -4155,6 +4156,8 @@ export class SparseTree<T extends Node> {
     getNode(nodeId: string): T | undefined;
     // (undocumented)
     insertChild(parentId: string | undefined, child: T, offset: number): void;
+    // (undocumented)
+    moveNode(sourceParentId: string | undefined, sourceNodeId: string, targetParentId: string | undefined, targetIndex: number): void;
     // (undocumented)
     removeChild(parentId: string | undefined, childId: string): void;
     // (undocumented)

--- a/common/changes/@bentley/ui-components/ui-components-treemodel-movenode_2021-03-15-12-19.json
+++ b/common/changes/@bentley/ui-components/ui-components-treemodel-movenode_2021-03-15-12-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "`MutableTreeModel`: Add `moveNode` method.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/ui/components/src/test/tree/controlled/TreeModel.test.ts
+++ b/ui/components/src/test/tree/controlled/TreeModel.test.ts
@@ -287,6 +287,90 @@ describe("MutableTreeModel", () => {
     });
   });
 
+  describe("moveNode", () => {
+    beforeEach(() => {
+      treeModel = new MutableTreeModel();
+      treeModel.setChildren(undefined, [createTreeModelNodeInput("root1"), createTreeModelNodeInput("root2")], 0);
+      treeModel.setChildren("root1", [createTreeModelNodeInput("child1"), createTreeModelNodeInput("child2")], 0);
+      treeModel.setChildren("root2", [], 0);
+    });
+
+    it("does nothing when source node does not exist and returns `false`", () => {
+      const resultStatus = treeModel.moveNode("not_existing_node_id", "root1", 1);
+      expect(resultStatus).to.be.false;
+      expect([...treeModel.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+    });
+
+    it("does nothing when target parent node does not exist and returs `false`", () => {
+      const resultStatus = treeModel.moveNode("child1", "not_existing_node_id", 0);
+      expect(resultStatus).to.be.false;
+      expect([...treeModel.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+    });
+
+    it("does nothing when target parent node has `undefined` child count and returns `false`", () => {
+      treeModel.setNumChildren("root2", undefined);
+
+      const resultStatus = treeModel.moveNode("root1", "root2", 0);
+
+      expect(resultStatus).to.be.false;
+      expect([...treeModel.getChildren(undefined)!]).to.be.deep.equal(["root1", "root2"]);
+      expect([...treeModel.getChildren("root2")!]).to.be.deep.equal([]);
+    });
+
+    it("does nothing when attempting to creata a cycle and returns `false`", () => {
+      // Make hierarchy deeper so that ancestry is not direct and thus requires more work to detect
+      treeModel.insertChild("child2", createTreeModelNodeInput("grandchild1"), 0);
+      treeModel.setChildren("grandchild1", [], 0);
+
+      const resultStatus = treeModel.moveNode("root1", "grandchild1", 0);
+
+      expect(resultStatus).to.be.false;
+      expect([...treeModel.getChildren(undefined)!]).to.be.deep.equal(["root1", "root2"]);
+      expect([...treeModel.getChildren("grandchild1")!]).to.be.deep.equal([]);
+    });
+
+    it("moves to hierarchy root", () => {
+      const resultStatus = treeModel.moveNode("child1", undefined, 0);
+
+      expect(resultStatus).to.be.true;
+
+      expect(treeModel.getRootNode().numChildren).to.be.equal(3);
+      expect([...treeModel.getChildren(undefined)!]).to.be.deep.equal(["child1", "root1", "root2"]);
+
+      expect(treeModel.getNode("root1")!.numChildren).to.be.equal(1);
+      expect([...treeModel.getChildren("root1")!]).to.be.deep.equal(["child2"]);
+
+      expect(treeModel.getNode("child1")!.depth).to.be.equal(0);
+      expect(treeModel.getNode("child1")!.parentId).to.be.undefined;
+    });
+
+    it("moves to non-hierarchy root", () => {
+      const resultStatus = treeModel.moveNode("root1", "root2", 0);
+
+      expect(resultStatus).to.be.true;
+      expect(treeModel.getRootNode().numChildren).to.be.equal(1);
+      expect([...treeModel.getChildren(undefined)!]).to.be.deep.equal(["root2"]);
+
+      expect(treeModel.getNode("root2")!.numChildren).to.be.equal(1);
+      expect([...treeModel.getChildren("root2")!]).to.be.deep.equal(["root1"]);
+
+      expect(treeModel.getNode("root1")!.depth).to.be.equal(1);
+      expect(treeModel.getNode("root1")!.parentId).to.be.equal("root2");
+      expect([...treeModel.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+
+      expect(treeModel.getNode("child1")!.depth).to.be.equal(2);
+      expect(treeModel.getNode("child2")!.depth).to.be.equal(2);
+    });
+
+    it("moves to position beyond last one", () => {
+      const resultStatus = treeModel.moveNode("child1", "root1", 3);
+
+      expect(resultStatus).to.be.true;
+      expect(treeModel.getNode("root1")!.numChildren).to.be.equal(3);
+      expect([...treeModel.getChildren("root1")!]).to.be.deep.equal(["child2", undefined, "child1"]);
+    });
+  });
+
   describe("setNumChildren", () => {
     beforeEach(() => {
       treeModel = new MutableTreeModel();

--- a/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
+++ b/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
@@ -184,6 +184,64 @@ describe("SparseTree", () => {
     });
   });
 
+  describe("moveNode", () => {
+    beforeEach(() => {
+      sparseTree.setChildren(undefined, [{ id: "root1" }, { id: "root2" }], 0);
+      sparseTree.setChildren("root1", [{ id: "child1" }, { id: "child2" }], 0);
+    });
+
+    describe("when moving node inside another", () => {
+      it("moves root node", () => {
+        sparseTree.moveNode(undefined, "root1", "root2", 0);
+        expect([...sparseTree.getChildren(undefined)!]).to.be.deep.equal(["root2"]);
+        expect([...sparseTree.getChildren("root2")!]).to.be.deep.equal(["root1"]);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+      });
+
+      it("moves non-root node", () => {
+        sparseTree.moveNode("root1", "child1", "child2", 0);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child2"]);
+        expect([...sparseTree.getChildren("child2")!]).to.be.deep.equal(["child1"]);
+      });
+    });
+
+    describe("when moving node into hierarchy root", () => {
+      it("moves root node", () => {
+        sparseTree.moveNode(undefined, "root1", undefined, 2);
+        expect([...sparseTree.getChildren(undefined)!]).to.be.deep.equal(["root2", "root1"]);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+      });
+
+      it("moves non-root node", () => {
+        sparseTree.moveNode("root1", "child1", undefined, 1);
+        expect([...sparseTree.getChildren(undefined)!]).to.be.deep.equal(["root1", "child1", "root2"]);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child2"]);
+      });
+    });
+
+    describe("when moving node among siblings", () => {
+      it("does nothing when target position is same as source", () => {
+        sparseTree.moveNode("root1", "child1", "root1", 0);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+      });
+
+      it("does nothing when target position is just past source node", () => {
+        sparseTree.moveNode("root1", "child1", "root1", 1);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child1", "child2"]);
+      });
+
+      it("moves node into correct position towards beginning", () => {
+        sparseTree.moveNode("root1", "child2", "root1", 0);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child2", "child1"]);
+      });
+
+      it("moves node into correct position towards ending", () => {
+        sparseTree.moveNode("root1", "child1", "root1", 2);
+        expect([...sparseTree.getChildren("root1")!]).to.be.deep.equal(["child2", "child1"]);
+      });
+    });
+  });
+
   describe("setNumChildren", () => {
     it("sets count for root nodes", () => {
       sparseTree.setNumChildren(undefined, 10);

--- a/ui/components/src/ui-components/tree/controlled/TreeModel.ts
+++ b/ui/components/src/ui-components/tree/controlled/TreeModel.ts
@@ -311,6 +311,61 @@ export class MutableTreeModel implements TreeModel {
   }
 
   /**
+   * Transfers node along with its children to a new location. Fails if destination has undefined child count.
+   * @param sourceNodeId Node that is being moved.
+   * @param targetParentId Node that will receive a new child.
+   * @param targetIndex Insertion location among target's *current* children.
+   * @returns `true` on success, `false` otherwise.
+   */
+  public moveNode(sourceNodeId: string, targetParentId: string | undefined, targetIndex: number): boolean {
+    const sourceNode = this.getNode(sourceNodeId);
+    if (sourceNode === undefined) {
+      return false;
+    }
+
+    const targetParent = targetParentId === undefined ? this._rootNode : this.getNode(targetParentId);
+    if (targetParent === undefined || targetParent.numChildren === undefined) {
+      return false;
+    }
+
+    if (targetParentId !== undefined && this.areNodesRelated(sourceNodeId, targetParentId)) {
+      return false;
+    }
+
+    this._tree.moveNode(sourceNode.parentId, sourceNodeId, targetParentId, targetIndex);
+
+    const sourceParent = sourceNode.parentId === undefined ? this._rootNode : this.getNode(sourceNode.parentId);
+    assert(sourceParent !== undefined);
+    MutableTreeModel.setNumChildrenForNode(sourceParent, this._tree.getChildren(sourceNode.parentId));
+    MutableTreeModel.setNumChildrenForNode(targetParent, this._tree.getChildren(targetParentId));
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    (sourceNode.parentId as string | undefined) = targetParentId;
+
+    const updateDepths = (parentId: string, depth: number) => {
+      const node = this.getNode(parentId);
+      assert(node !== undefined);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      (node.depth as number) = depth;
+      for (const [nodeId] of this.getChildren(parentId)?.iterateValues() ?? []) {
+        updateDepths(nodeId, depth + 1);
+      }
+    };
+
+    updateDepths(sourceNodeId, targetParent.depth + 1);
+    return true;
+  }
+
+  private areNodesRelated(ancestorNodeId: string, descendantNodeId: string): boolean {
+    const node = this.getNode(descendantNodeId);
+    if (node === undefined || node.parentId === undefined) {
+      return false;
+    }
+
+    return node.parentId === ancestorNodeId ? true : this.areNodesRelated(ancestorNodeId, node.parentId);
+  }
+
+  /**
    * Sets the number of child nodes a parent is expected to contain. All child nodes of this parent will be subsequently
    * removed.
    */

--- a/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
+++ b/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
@@ -7,7 +7,7 @@
  */
 
 import { immerable } from "immer";
-import { compareNumbers, lowerBound } from "@bentley/bentleyjs-core";
+import { assert, compareNumbers, lowerBound } from "@bentley/bentleyjs-core";
 
 /** @internal */
 export interface Node {
@@ -97,6 +97,28 @@ export class SparseTree<T extends Node> {
     }
 
     return true;
+  }
+
+  public moveNode(
+    sourceParentId: string | undefined,
+    sourceNodeId: string,
+    targetParentId: string | undefined,
+    targetIndex: number,
+  ): void {
+    const sourceNodeSiblings = this.getChildren(sourceParentId);
+    assert(sourceNodeSiblings !== undefined);
+
+    const sourceIndex = this.getChildOffset(sourceParentId, sourceNodeId);
+    assert(sourceIndex !== undefined);
+
+    sourceNodeSiblings.remove(sourceIndex);
+    if (targetParentId === sourceParentId && targetIndex > sourceIndex) {
+      targetIndex -= 1;
+    }
+
+    const targetNodeSiblings = this.getChildren(targetParentId, true);
+    assert(targetNodeSiblings !== undefined);
+    targetNodeSiblings.insert(targetIndex, sourceNodeId);
   }
 
   public setNumChildren(parentId: string | undefined, numChildren: number) {


### PR DESCRIPTION
Adds `moveNode` method to `MutableTreeModel`.

Moving a node inside a parent that has `undefined` children count is restricted to avoid creating issues where tree node loader is involved.