### PR TITLE
Presentation: Fix hilite rules for functional elements

### DIFF
--- a/common/changes/@bentley/presentation-frontend/presentation-fix-hilite-rules-for-functional-elements_2021-03-23-14-50.json
+++ b/common/changes/@bentley/presentation-frontend/presentation-fix-hilite-rules-for-functional-elements_2021-03-23-14-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "Fix hilite rules for functional elements",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/presentation/frontend/src/presentation-frontend/selection/HiliteRules.json
+++ b/presentation/frontend/src/presentation-frontend/selection/HiliteRules.json
@@ -149,6 +149,7 @@
     {
       "ruleType": "Content",
       "condition": "ContentDisplayType = \"Graphics\" ANDALSO SelectedNode.IsOfClass(\"Element\", \"BisCore\")",
+      "priority": 0,
       "onlyIfNotHandled": true,
       "specifications": [
         {


### PR DESCRIPTION
Hilite rules for `BisCore:Element` took precedence over `Functional:FunctionalElement` which broke getting hilite list for the latter.