### PR TITLE
Add saveChanges to ensure the updated DbGuid is persisted

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/fix-checkpoint-dbguid_2021-03-24-20-51.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-checkpoint-dbguid_2021-03-24-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -290,6 +290,7 @@ export class V1CheckpointManager {
           requestContext.enter();
         }
       } finally {
+        db.saveChanges();
         db.close();
       }
 


### PR DESCRIPTION
The requirement to call saveChanges was missed when we needed to update the DbGuid. This caused a regression in 2.14.x that was caught during testing.

Writing tests now but I'll open separate PR tomorrow as it will take a bit of time to finish them up and I'd like to continue testing 2.14 without the blocker.