### PR TITLE
Dynamic graphics

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -60,6 +60,7 @@ import { ElementAlignedBox3d } from '@bentley/imodeljs-common';
 import { ElementAspectProps } from '@bentley/imodeljs-common';
 import { ElementGeometryRequest } from '@bentley/imodeljs-common';
 import { ElementGeometryUpdate } from '@bentley/imodeljs-common';
+import { ElementGraphicsRequestProps } from '@bentley/imodeljs-common';
 import { ElementLoadProps } from '@bentley/imodeljs-common';
 import { ElementProps } from '@bentley/imodeljs-common';
 import { EntityMetaData } from '@bentley/imodeljs-common';
@@ -2186,6 +2187,9 @@ export abstract class FunctionalType extends TypeDefinitionElement {
     static get className(): string;
 }
 
+// @internal
+export function generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise<Uint8Array | undefined>;
+
 // @public
 export class GenericDocument extends Document {
     constructor(props: ElementProps, iModel: IModelDb);
@@ -2530,6 +2534,8 @@ export abstract class IModelDb extends IModel {
     // (undocumented)
     protected _fontMap?: FontMap;
     static forEachMetaData(iModel: IModelDb, classFullName: string, wantSuper: boolean, func: PropertyCallback, includeCustom?: boolean): void;
+    // @beta
+    generateElementGraphics(request: ElementGraphicsRequestProps): Promise<Uint8Array | undefined>;
     getBriefcaseId(): BriefcaseId;
     getGeoCoordinatesFromIModelCoordinates(requestContext: ClientRequestContext, props: string): Promise<GeoCoordinatesResponseProps>;
     // @beta

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -1487,7 +1487,7 @@ export function computeChildTileRanges(tile: TileMetadata, root: TileTreeMetadat
 // @internal
 export function computeTileChordTolerance(tile: TileMetadata, is3d: boolean): number;
 
-// @internal
+// @alpha
 export enum ContentFlags {
     // (undocumented)
     AllowInstancing = 1,
@@ -1936,6 +1936,13 @@ export enum DownloadBriefcaseStatus {
 export type DPoint2dProps = number[];
 
 // @beta
+export interface DynamicGraphicsRequestProps extends GraphicsRequestProps {
+    readonly elementId?: Id64String;
+    readonly geometry: GeometryStreamProps;
+    readonly placement: PlacementProps;
+}
+
+// @beta
 export const Easing: {
     Linear: {
         None: (k: number) => number;
@@ -2264,18 +2271,8 @@ export interface ElementGeometryUpdate {
     viewIndependent?: boolean;
 }
 
-// @internal
-export interface ElementGraphicsRequestProps {
-    readonly clipToProjectExtents?: boolean;
-    readonly contentFlags?: ContentFlags;
-    readonly elementId: Id64String;
-    readonly formatVersion: number;
-    readonly id: string;
-    readonly location?: TransformProps;
-    readonly omitEdges?: boolean;
-    readonly toleranceLog10: number;
-    readonly treeFlags?: TreeFlags;
-}
+// @beta
+export type ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequestProps;
 
 // @alpha
 export interface ElementIdsAndRangesProps {
@@ -3356,6 +3353,20 @@ export class GraphicParams {
     rasterWidth: number;
     setFillTransparency(transparency: number): void;
     setLineTransparency(transparency: number): void;
+}
+
+// @beta
+export interface GraphicsRequestProps {
+    readonly clipToProjectExtents?: boolean;
+    // @alpha
+    readonly contentFlags?: ContentFlags;
+    readonly formatVersion: number;
+    readonly id: string;
+    readonly location?: TransformProps;
+    readonly omitEdges?: boolean;
+    readonly toleranceLog10: number;
+    // @alpha
+    readonly treeFlags?: TreeFlags;
 }
 
 // @public
@@ -5117,6 +5128,11 @@ export interface PartReference {
     };
     // (undocumented)
     type: "partReference";
+}
+
+// @beta
+export interface PersistentGraphicsRequestProps extends GraphicsRequestProps {
+    readonly elementId: Id64String;
 }
 
 // @public
@@ -7611,7 +7627,7 @@ export interface TileVersionInfo {
     formatVersion: number;
 }
 
-// @internal
+// @alpha
 export enum TreeFlags {
     // (undocumented)
     EnforceDisplayPriority = 2,

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -1936,10 +1936,27 @@ export enum DownloadBriefcaseStatus {
 export type DPoint2dProps = number[];
 
 // @beta
+export interface DynamicGraphicsRequest2dProps extends DynamicGraphicsRequestProps {
+    // (undocumented)
+    readonly placement: Omit<Placement2dProps, "bbox">;
+    // (undocumented)
+    readonly type: "2d";
+}
+
+// @beta
+export interface DynamicGraphicsRequest3dProps extends DynamicGraphicsRequestProps {
+    // (undocumented)
+    readonly placement: Omit<Placement3dProps, "bbox">;
+    // (undocumented)
+    readonly type: "3d";
+}
+
+// @beta
 export interface DynamicGraphicsRequestProps extends GraphicsRequestProps {
+    readonly categoryId: Id64String;
     readonly elementId?: Id64String;
     readonly geometry: GeometryStreamProps;
-    readonly placement: PlacementProps;
+    readonly modelId?: Id64String;
 }
 
 // @beta
@@ -2272,7 +2289,7 @@ export interface ElementGeometryUpdate {
 }
 
 // @beta
-export type ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequestProps;
+export type ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequest2dProps | DynamicGraphicsRequest3dProps;
 
 // @alpha
 export interface ElementIdsAndRangesProps {
@@ -3360,7 +3377,8 @@ export interface GraphicsRequestProps {
     readonly clipToProjectExtents?: boolean;
     // @alpha
     readonly contentFlags?: ContentFlags;
-    readonly formatVersion: number;
+    // @alpha
+    readonly formatVersion?: number;
     readonly id: string;
     readonly location?: TransformProps;
     readonly omitEdges?: boolean;

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -7280,6 +7280,9 @@ export function queryTerrainElevationOffset(viewport: ScreenViewport, carto: Car
 // @internal
 export function rangeToCartographicArea(view3d: ViewState3d, range: Range3d): GlobalLocationArea | undefined;
 
+// @beta
+export function readElementGraphics(bytes: Uint8Array, iModel: IModelConnection, modelId: Id64String, is3d: boolean): Promise<RenderGraphic | undefined>;
+
 // @internal
 export function readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, range: ElementAlignedBox3d, system: RenderSystem): RenderGraphic | undefined;
 
@@ -10014,7 +10017,6 @@ export class TileAdmin {
     registerViewport(vp: Viewport): void;
     // @internal (undocumented)
     requestCachedTileContent(tile: IModelTile): Promise<Uint8Array | undefined>;
-    // @internal (undocumented)
     requestElementGraphics(iModel: IModelConnection, requestProps: ElementGraphicsRequestProps): Promise<Uint8Array | undefined>;
     // @internal
     requestTiles(vp: Viewport, tiles: Set<Tile>): void;

--- a/common/api/summary/imodeljs-backend.exports.csv
+++ b/common/api/summary/imodeljs-backend.exports.csv
@@ -155,6 +155,7 @@ public;FunctionalModel
 public;FunctionalPartition 
 public;FunctionalSchema 
 public;class FunctionalType 
+internal;generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise
 public;GenericDocument 
 public;GenericGraphicalModel3d 
 public;GenericGraphicalType2d 

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -123,6 +123,8 @@ public;DisplayStyleSubCategoryProps
 beta;DomainOptions
 internal;DownloadBriefcaseStatus
 beta;DPoint2dProps = number[]
+beta;DynamicGraphicsRequest2dProps 
+beta;DynamicGraphicsRequest3dProps 
 beta;DynamicGraphicsRequestProps 
 beta;Easing:
 beta;EasingFunction = (k: number) => number
@@ -145,7 +147,7 @@ alpha;ElementGeometryInfo
 alpha;ElementGeometryOpcode
 alpha;ElementGeometryRequest
 alpha;ElementGeometryUpdate
-beta;ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequestProps
+beta;ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequest2dProps | DynamicGraphicsRequest3dProps
 alpha;ElementIdsAndRangesProps
 public;ElementLoadProps
 public;ElementProps 

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -89,7 +89,7 @@ internal;compareIModelTileTreeIds(lhs: IModelTileTreeId, rhs: IModelTileTreeId):
 internal;CompositeTileHeader 
 internal;computeChildTileProps(parent: TileMetadata, idProvider: ContentIdProvider, root: TileTreeMetadata):
 internal;computeTileChordTolerance(tile: TileMetadata, is3d: boolean): number
-internal;ContentFlags
+alpha;ContentFlags
 internal;class ContentIdProvider
 public;ContextRealityModelProps
 public;CreateEmptySnapshotIModelProps = CreateIModelProps & CreateSnapshotIModelProps
@@ -123,6 +123,7 @@ public;DisplayStyleSubCategoryProps
 beta;DomainOptions
 internal;DownloadBriefcaseStatus
 beta;DPoint2dProps = number[]
+beta;DynamicGraphicsRequestProps 
 beta;Easing:
 beta;EasingFunction = (k: number) => number
 public;EcefLocation 
@@ -144,7 +145,7 @@ alpha;ElementGeometryInfo
 alpha;ElementGeometryOpcode
 alpha;ElementGeometryRequest
 alpha;ElementGeometryUpdate
-internal;ElementGraphicsRequestProps
+beta;ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequestProps
 alpha;ElementIdsAndRangesProps
 public;ElementLoadProps
 public;ElementProps 
@@ -224,6 +225,7 @@ internal;GltfV2ChunkTypes
 internal;GltfVersions
 public;Gradient
 public;GraphicParams
+beta;GraphicsRequestProps
 public;GridOrientationType
 public;GroundPlane
 public;GroundPlaneProps
@@ -369,6 +371,7 @@ beta;OverriddenBy
 internal;PackedFeature
 internal;PackedFeatureTable
 public;PartReference
+beta;PersistentGraphicsRequestProps 
 public;PhysicalElementProps 
 public;PhysicalTypeProps 
 public;Placement2d 
@@ -568,7 +571,7 @@ internal;TileTreeContentIds
 internal;TileTreeMetadata
 internal;TileTreeProps
 alpha;TileVersionInfo
-internal;TreeFlags
+alpha;TreeFlags
 beta;Tween
 beta;TweenCallback = (obj: any) => void
 beta;Tweens

--- a/common/api/summary/imodeljs-frontend.exports.csv
+++ b/common/api/summary/imodeljs-frontend.exports.csv
@@ -398,6 +398,7 @@ beta;QuantityTypeDefinition
 beta;QuantityTypeKey = string
 internal;queryTerrainElevationOffset(viewport: ScreenViewport, carto: Cartographic): Promise
 internal;rangeToCartographicArea(view3d: ViewState3d, range: Range3d): GlobalLocationArea | undefined
+beta;readElementGraphics(bytes: Uint8Array, iModel: IModelConnection, modelId: Id64String, is3d: boolean): Promise
 internal;readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, range: ElementAlignedBox3d, system: RenderSystem): RenderGraphic | undefined
 internal;RealityModelSource = ViewState | DisplayStyleState
 internal;RealityModelTileClient

--- a/common/changes/@bentley/imodeljs-backend/dynamic-graphics_2021-03-31-16-42.json
+++ b/common/changes/@bentley/imodeljs-backend/dynamic-graphics_2021-03-31-16-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "IModelDb.generateElementGraphics can generate graphics for a non-persistent geometry stream.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/dynamic-graphics_2021-03-31-16-42.json
+++ b/common/changes/@bentley/imodeljs-common/dynamic-graphics_2021-03-31-16-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "An ElementGraphicsRequest can supply a non-persistent geometry stream.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/dynamic-graphics_2021-03-31-16-42.json
+++ b/common/changes/@bentley/imodeljs-frontend/dynamic-graphics_2021-03-31-16-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "TileAdmin.requestElementGraphics can obtain graphics for a non-persistent geometry stream.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/backend/src/ElementGraphics.ts
+++ b/core/backend/src/ElementGraphics.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Tiles
+ */
+
+import { assert, ClientRequestContext, IModelStatus } from "@bentley/bentleyjs-core";
+import { ElementGraphicsRequestProps, IModelError } from "@bentley/imodeljs-common";
+import { ElementGraphicsStatus } from "@bentley/imodeljs-native";
+import { IModelDb } from "./IModelDb";
+
+/** See [[IModelDb.generateElementGraphics]] and IModelTileRpcImpl.requestElementGraphics.
+ * @internal
+ */
+export async function generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise<Uint8Array | undefined> {
+  const requestContext = ClientRequestContext.current;
+  const result = await iModel.nativeDb.generateElementGraphics(request);
+
+  requestContext.enter();
+  let error: string | undefined;
+  switch (result.status) {
+    case ElementGraphicsStatus.NoGeometry:
+    case ElementGraphicsStatus.Canceled:
+      return undefined;
+    case ElementGraphicsStatus.Success:
+      return result.content;
+    case ElementGraphicsStatus.InvalidJson:
+      error = "Invalid JSON";
+      break;
+    case ElementGraphicsStatus.UnknownMajorFormatVersion:
+      error = "Unknown major format version";
+      break;
+    case ElementGraphicsStatus.ElementNotFound:
+      error = `Element Id ${request.elementId} not found`;
+      break;
+    case ElementGraphicsStatus.DuplicateRequestId:
+      error = `Duplicate request Id "${request.id}"`;
+      break;
+  }
+
+  assert(undefined !== error);
+  throw new IModelError(IModelStatus.BadRequest, error);
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -18,7 +18,7 @@ import { ChangesType, Lock, LockLevel, LockType } from "@bentley/imodelhub-clien
 import {
   AxisAlignedBox3d, Base64EncodedString, BRepGeometryCreate, BriefcaseIdValue, CategorySelectorProps, Code, CodeSpec, CreateEmptySnapshotIModelProps, CreateEmptyStandaloneIModelProps,
   CreateSnapshotIModelProps, DisplayStyleProps, DomainOptions, EcefLocation, ElementAspectProps, ElementGeometryRequest, ElementGeometryUpdate,
-  ElementLoadProps, ElementProps, EntityMetaData, EntityProps, EntityQueryParams, FilePropertyProps, FontMap, FontMapProps, FontProps,
+  ElementGraphicsRequestProps, ElementLoadProps, ElementProps, EntityMetaData, EntityProps, EntityQueryParams, FilePropertyProps, FontMap, FontMapProps, FontProps,
   GeoCoordinatesResponseProps, GeometryContainmentRequestProps, GeometryContainmentResponseProps, IModel, IModelCoordinatesResponseProps, IModelError,
   IModelNotFoundResponse, IModelProps, IModelRpcProps, IModelTileTreeProps, IModelVersion, LocalBriefcaseProps,
   MassPropertiesRequestProps, MassPropertiesResponseProps, ModelLoadProps, ModelProps, ModelSelectorProps, OpenBriefcaseProps, ProfileOptions,
@@ -46,6 +46,7 @@ import { Relationships } from "./Relationship";
 import { CachedSqliteStatement, SqliteStatement, SqliteStatementCache } from "./SqliteStatement";
 import { TxnManager } from "./TxnManager";
 import { DrawingViewDefinition, SheetViewDefinition, ViewDefinition } from "./ViewDefinition";
+import { generateElementGraphics } from "./ElementGraphics";
 
 const loggerCategory: string = BackendLoggerCategory.IModelDb;
 
@@ -1248,6 +1249,14 @@ export abstract class IModelDb extends IModel {
    */
   public createBRepGeometry(createProps: BRepGeometryCreate): DbResult {
     return this.nativeDb.createBRepGeometry(createProps);
+  }
+
+  /** Generate graphics for an element or geometry stream.
+   * @see [readElementGraphics]($frontend) to convert the result to a [RenderGraphic]($frontend) for display.
+   * @beta
+   */
+  public async generateElementGraphics(request: ElementGraphicsRequestProps): Promise<Uint8Array | undefined> {
+    return generateElementGraphics(request, this);
   }
 }
 

--- a/core/backend/src/imodeljs-backend.ts
+++ b/core/backend/src/imodeljs-backend.ts
@@ -52,6 +52,7 @@ export * from "./AliCloudStorageService";
 export * from "./DevTools";
 export * from "./usage-logging/UsageLoggingUtilities";
 export * from "./LocalhostIpcHost";
+export * from "./ElementGraphics";
 export * from "./IModelDb"; // must be last
 
 /** @docs-package-description
@@ -150,4 +151,7 @@ export * from "./IModelDb"; // must be last
  * @docs-group-description Authentication
  * Classes for working with Authentication.
  */
-
+/**
+ * @docs-group-description Tiles
+ * APIs for working with tile graphics.
+ */

--- a/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
@@ -8,11 +8,10 @@
 
 import { assert, BeDuration, ClientRequestContext, Id64Array, Logger } from "@bentley/bentleyjs-core";
 import {
-  CloudStorageContainerDescriptor, CloudStorageContainerUrl, CloudStorageTileCache, ElementGraphicsRequestProps, IModelError, IModelRpcProps,
-  IModelStatus, IModelTileRpcInterface, IModelTileTreeProps, RpcInterface, RpcInvocation, RpcManager, RpcPendingResponse,
+  CloudStorageContainerDescriptor, CloudStorageContainerUrl, CloudStorageTileCache, ElementGraphicsRequestProps, IModelRpcProps,
+  IModelTileRpcInterface, IModelTileTreeProps, RpcInterface, RpcInvocation, RpcManager, RpcPendingResponse,
   TileTreeContentIds, TileVersionInfo,
 } from "@bentley/imodeljs-common";
-import { ElementGraphicsStatus } from "@bentley/imodeljs-native";
 import { BackendLoggerCategory } from "../BackendLoggerCategory";
 import { IModelDb } from "../IModelDb";
 import { IModelHost } from "../IModelHost";
@@ -230,34 +229,8 @@ export class IModelTileRpcImpl extends RpcInterface implements IModelTileRpcInte
 
   /** @internal */
   public async requestElementGraphics(rpcProps: IModelRpcProps, request: ElementGraphicsRequestProps): Promise<Uint8Array | undefined> {
-    const requestContext = ClientRequestContext.current;
     const iModel = IModelDb.findByKey(rpcProps.key);
-    const result = await iModel.nativeDb.generateElementGraphics(request);
-
-    requestContext.enter();
-    let error: string | undefined;
-    switch (result.status) {
-      case ElementGraphicsStatus.NoGeometry:
-      case ElementGraphicsStatus.Canceled:
-        return undefined;
-      case ElementGraphicsStatus.Success:
-        return result.content;
-      case ElementGraphicsStatus.InvalidJson:
-        error = "Invalid JSON";
-        break;
-      case ElementGraphicsStatus.UnknownMajorFormatVersion:
-        error = "Unknown major format version";
-        break;
-      case ElementGraphicsStatus.ElementNotFound:
-        error = `Element Id ${request.elementId} not found`;
-        break;
-      case ElementGraphicsStatus.DuplicateRequestId:
-        error = `Duplicate request Id "${request.id}"`;
-        break;
-    }
-
-    assert(undefined !== error);
-    throw new IModelError(IModelStatus.BadRequest, error);
+    return iModel.generateElementGraphics(request);
   }
 }
 

--- a/core/backend/src/test/standalone/ElementGraphics.test.ts
+++ b/core/backend/src/test/standalone/ElementGraphics.test.ts
@@ -44,4 +44,38 @@ describe("ElementGraphics", () => {
     expect(content instanceof Uint8Array).to.be.true;
     expect(content.length).least(40);
   });
+
+  it("produces expected errors", async () => {
+    type TestCase = [ ElementGraphicsStatus, Partial<ElementGraphicsRequestProps> ];
+    const testCases: TestCase[] = [
+      [ ElementGraphicsStatus.ElementNotFound, { elementId: "0" } ],
+      [ ElementGraphicsStatus.ElementNotFound, { elementId: "0x12345678" } ],
+      [ ElementGraphicsStatus.ElementNotFound, { elementId: undefined } ],
+
+      [ ElementGraphicsStatus.InvalidJson, { id: undefined } ],
+      [ ElementGraphicsStatus.InvalidJson, { toleranceLog10: undefined } ],
+
+      [ ElementGraphicsStatus.InvalidJson, { toleranceLog10: 12.5 } ],
+      [ ElementGraphicsStatus.InvalidJson, { toleranceLog10: "tol" as any } ],
+
+      [ ElementGraphicsStatus.Success, { formatVersion: undefined } ],
+      [ ElementGraphicsStatus.UnknownMajorFormatVersion, { formatVersion: CurrentImdlVersion.Major + 1 } ],
+      [ ElementGraphicsStatus.UnknownMajorFormatVersion, { formatVersion: "latest" as any } ],
+    ];
+
+    for (const testCase of testCases) {
+      const request: ElementGraphicsRequestProps = {
+        id: "test",
+        elementId: "0x29",
+        toleranceLog10: -2,
+        formatVersion: CurrentImdlVersion.Major,
+        ...testCase[1],
+      };
+
+      const result = await imodel.nativeDb.generateElementGraphics(request);
+      expect(result.status).to.equal(testCase[0]);
+      if (result.status === ElementGraphicsStatus.Success)
+        expect(result.content).not.to.be.undefined;
+    }
+  });
 });

--- a/core/common/src/imodeljs-common.ts
+++ b/core/common/src/imodeljs-common.ts
@@ -124,6 +124,7 @@ export * from "./rpc/web/WebAppRpcProtocol";
 export * from "./rpc/web/WebAppRpcRequest";
 export * from "./tile/B3dmTileIO";
 export * from "./tile/CompositeTileIO";
+export * from "./tile/ElementGraphics";
 export * from "./tile/GltfTileIO";
 export * from "./tile/I3dmTileIO";
 export * from "./tile/IModelTileIO";

--- a/core/common/src/rpc/IModelTileRpcInterface.ts
+++ b/core/common/src/rpc/IModelTileRpcInterface.ts
@@ -6,39 +6,14 @@
  * @module RpcInterface
  */
 
-import { AbandonedError, Id64Array, Id64String } from "@bentley/bentleyjs-core";
-import { TransformProps } from "@bentley/geometry-core";
+import { AbandonedError, Id64Array } from "@bentley/bentleyjs-core";
 import { CloudStorageContainerDescriptor, CloudStorageContainerUrl } from "../CloudStorage";
 import { CloudStorageTileCache } from "../CloudStorageTileCache";
 import { IModelRpcProps } from "../IModel";
 import { RpcInterface } from "../RpcInterface";
 import { RpcManager } from "../RpcManager";
 import { IModelTileTreeProps, TileVersionInfo } from "../TileProps";
-import { ContentFlags, TreeFlags } from "../tile/TileMetadata";
-
-/** Wire format describing a request to produce graphics in [[TileFormat.IModelGraphics]] format for a single element.
- * @internal
- */
-export interface ElementGraphicsRequestProps {
-  /** Uniquely identifies this request among all requests for a given [[IModel]]. */
-  readonly id: string;
-  /** The element for which graphics are requested. */
-  readonly elementId: Id64String;
-  /** Log10 of the chord tolerance with which to stroke the element's geometry. e.g., for a chord tolerance of 0.01 (10^-2) meters, supply -2. */
-  readonly toleranceLog10: number;
-  /** The major version of the [[TileFormat.IModelGraphics]] format to use when producing the iMdl representation of the element's geometry. */
-  readonly formatVersion: number;
-  /** Optional flags. [[TreeFlags.UseProjectExtents]] has no effect. [[TreeFlags.EnforceDisplayPriority]] is not yet implemented. */
-  readonly treeFlags?: TreeFlags;
-  /** Optional flags. [[ContentFlags.ImprovedElision]] has no effect. */
-  readonly contentFlags?: ContentFlags;
-  /** Transform from element graphics to world coordinates. Defaults to identity. */
-  readonly location?: TransformProps;
-  /** If true, surface edges will be omitted from the graphics. */
-  readonly omitEdges?: boolean;
-  /** If true, the element's graphics will be clipped against the iModel's project extents. */
-  readonly clipToProjectExtents?: boolean;
-}
+import { ElementGraphicsRequestProps } from "../tile/ElementGraphics";
 
 /** @public */
 export abstract class IModelTileRpcInterface extends RpcInterface {
@@ -106,7 +81,7 @@ export abstract class IModelTileRpcInterface extends RpcInterface {
     return CloudStorageTileCache.getCache().retrieve({ tokenProps, treeId, contentId, guid });
   }
 
-  /** Requests graphics for a single element in [[TileFormat.IModel]] format.
+  /** Requests graphics for a single element in "iMdl" format.
    * @returns graphics in iMdl format, or `undefined` if the element's geometry produced no graphics or the request was canceled before completion.
    * @throws IModelError on bad request (nonexistent element, duplicate request Id, etc).
    * @internal

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -8,7 +8,7 @@
 
 import { Id64String } from "@bentley/bentleyjs-core";
 import { TransformProps } from "@bentley/geometry-core";
-import { PlacementProps } from "../ElementProps";
+import { Placement2dProps, Placement3dProps } from "../ElementProps";
 import { GeometryStreamProps } from "../geometry/GeometryStream";
 import { ContentFlags, TreeFlags } from "../tile/TileMetadata";
 
@@ -48,16 +48,13 @@ export interface PersistentGraphicsRequestProps extends GraphicsRequestProps {
 }
 
 /** Wire format describing a request to produce graphics in "iMdl" format for a single geometry stream.
+ * @see [[DynamicGraphicsRequest2dProps]] and [[DynamicGraphicsRequest3dProps]].
  * @see [[ElementGraphicsRequestProps]] for more details.
  * @beta
  */
 export interface DynamicGraphicsRequestProps extends GraphicsRequestProps {
   /** The geometry from which to generate the graphics. */
   readonly geometry: GeometryStreamProps;
-  /** The location and orientation of the geometry. The bounding box will be computed from the supplied [[geometry]].
-   * Supply a 2d placement for 2d geometry or 3d placement for 3d geometry.
-   */
-  readonly placement: Omit<PlacementProps, "bbox">;
   /** The category to which the geometry belongs. This is required to identify a persistent [SpatialCategory]($backend) for 3d geometry or
    * [DrawingCategory]($backend) for 2d geometry.
    */
@@ -71,10 +68,28 @@ export interface DynamicGraphicsRequestProps extends GraphicsRequestProps {
   readonly modelId?: Id64String;
 }
 
+/** Wire format describing a request to produce graphics in "iMdl" format for a 2d geometry stream.
+ * @see [[ElementGraphicsRequestProps]] for more details.
+ * @beta
+ */
+export interface DynamicGraphicsRequest2dProps extends DynamicGraphicsRequestProps {
+  readonly type: "2d";
+  readonly placement: Omit<Placement2dProps, "bbox">;
+}
+
+/** Wire format describing a request to produce graphics in "iMdl" format for a 3d geometry stream.
+ * @see [[ElementGraphicsRequestProps]] for more details.
+ * @beta
+ */
+export interface DynamicGraphicsRequest3dProps extends DynamicGraphicsRequestProps {
+  readonly type: "3d";
+  readonly placement: Omit<Placement3dProps, "bbox">;
+}
+
 /** Wire format describing a request to produce graphics in "iMdl" format for a single element or geometry stream.
  * @note Every request must have an `id` that is unique amongst all extant requests for a given [[IModel]].
  * @see [TileAdmin.requestElementGraphics]($frontend) and [IModelDb.generateElementGraphics]($backend) to fulfill such a request.
  * @see [readElementGraphics]($frontend) to convert the result of a request to a [RenderGraphic]($frontend) for display.
  * @beta
  */
-export type ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequestProps;
+export type ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequest2dProps | DynamicGraphicsRequest3dProps;

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -52,12 +52,23 @@ export interface PersistentGraphicsRequestProps extends GraphicsRequestProps {
  * @beta
  */
 export interface DynamicGraphicsRequestProps extends GraphicsRequestProps {
-  /** If specified, tools will recognize the generated graphics as being associated with this element. */
-  readonly elementId?: Id64String;
   /** The geometry from which to generate the graphics. */
   readonly geometry: GeometryStreamProps;
-  /** The location, orientation, and bounding box of the geometry. The bounding box must fully enclose the [[geometry]]. */
-  readonly placement: PlacementProps;
+  /** The location and orientation of the geometry. The bounding box will be computed from the supplied [[geometry]].
+   * Supply a 2d placement for 2d geometry or 3d placement for 3d geometry.
+   */
+  readonly placement: Omit<PlacementProps, "bbox">;
+  /** The category to which the geometry belongs. This is required to identify a persistent [SpatialCategory]($backend) for 3d geometry or
+   * [DrawingCategory]($backend) for 2d geometry.
+   */
+  readonly categoryId: Id64String;
+  /** If specified, tools will recognize the generated graphics as being associated with this element. */
+  readonly elementId?: Id64String;
+  /** If specified, tools will recognize the generated graphics as being associated with this model.
+   * It should identify a 3d model for 3d geometry or a 2d model for 2d geometry.
+   * It needn't identify a persistent model - it can be a transient Id.
+   */
+  readonly modelId?: Id64String;
 }
 
 /** Wire format describing a request to produce graphics in "iMdl" format for a single element or geometry stream.

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Tile
+ */
+
+import { Id64String } from "@bentley/bentleyjs-core";
+import { TransformProps } from "@bentley/geometry-core";
+import { PlacementProps } from "../ElementProps";
+import { GeometryStreamProps } from "../geometry/GeometryStream";
+import { ContentFlags, TreeFlags } from "../tile/TileMetadata";
+
+/** Wire format describing properties common to [[PersistentGraphicsRequestProps]] and [[DynamicGraphicsRequestProps]].
+ * @see [[ElementGraphicsRequestProps]].
+ * @beta
+ */
+export interface GraphicsRequestProps {
+  /** Uniquely identifies this request among all [[ElementGraphicsRequestProps]] for a given [[IModel]]. */
+  readonly id: string;
+  /** Log10 of the chord tolerance with which to stroke the element's geometry. e.g., for a chord tolerance of 0.01 (10^-2) meters, supply -2. */
+  readonly toleranceLog10: number;
+  /** The major version of the "iMdl" format to use when producing the iMdl representation of the element's geometry. */
+  readonly formatVersion: number;
+  /** Optional flags. [[TreeFlags.UseProjectExtents]] has no effect. [[TreeFlags.EnforceDisplayPriority]] is not yet implemented. @alpha */
+  readonly treeFlags?: TreeFlags;
+  /** Optional flags. [[ContentFlags.ImprovedElision]] has no effect. @alpha */
+  readonly contentFlags?: ContentFlags;
+  /** Transform from element graphics to world coordinates. Defaults to identity. */
+  readonly location?: TransformProps;
+  /** If true, surface edges will be omitted from the graphics. */
+  readonly omitEdges?: boolean;
+  /** If true, the element's graphics will be clipped against the iModel's project extents. */
+  readonly clipToProjectExtents?: boolean;
+}
+
+/** Wire format describing a request to produce graphics in "iMdl" format for a single element.
+ * @see [[ElementGraphicsRequestProps]] for more details.
+ * @beta
+ */
+export interface PersistentGraphicsRequestProps extends GraphicsRequestProps {
+  /** The element whose geometry is to be used to generate the graphics. */
+  readonly elementId: Id64String;
+}
+
+/** Wire format describing a request to produce graphics in "iMdl" format for a single geometry stream.
+ * @see [[ElementGraphicsRequestProps]] for more details.
+ * @beta
+ */
+export interface DynamicGraphicsRequestProps extends GraphicsRequestProps {
+  /** If specified, tools will recognize the generated graphics as being associated with this element. */
+  readonly elementId?: Id64String;
+  /** The geometry from which to generate the graphics. */
+  readonly geometry: GeometryStreamProps;
+  /** The location, orientation, and bounding box of the geometry. The bounding box must fully enclose the [[geometry]]. */
+  readonly placement: PlacementProps;
+}
+
+/** Wire format describing a request to produce graphics in "iMdl" format for a single element or geometry stream.
+ * @note Every request must have an `id` that is unique amongst all extant requests for a given [[IModel]].
+ * @see [TileAdmin.requestElementGraphics]($frontend) and [IModelDb.generateElementGraphics]($backend) to fulfill such a request.
+ * @see [readElementGraphics]($frontend) to convert the result of a request to a [RenderGraphic]($frontend) for display.
+ * @beta
+ */
+export type ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGraphicsRequestProps;

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -21,8 +21,11 @@ export interface GraphicsRequestProps {
   readonly id: string;
   /** Log10 of the chord tolerance with which to stroke the element's geometry. e.g., for a chord tolerance of 0.01 (10^-2) meters, supply -2. */
   readonly toleranceLog10: number;
-  /** The major version of the "iMdl" format to use when producing the iMdl representation of the element's geometry. */
-  readonly formatVersion: number;
+  /** The major version of the "iMdl" format to use when producing the iMdl representation of the element's geometry.
+   * If omitted, the most recent version known to the backend will be used.
+   * @alpha
+   */
+  readonly formatVersion?: number;
   /** Optional flags. [[TreeFlags.UseProjectExtents]] has no effect. [[TreeFlags.EnforceDisplayPriority]] is not yet implemented. @alpha */
   readonly treeFlags?: TreeFlags;
   /** Optional flags. [[ContentFlags.ImprovedElision]] has no effect. @alpha */

--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -96,7 +96,7 @@ export function getMaximumMajorTileFormatVersion(maxMajorVersion: number, format
 }
 
 /** Flags controlling the structure of a tile tree. The flags are part of the tile tree's Id.
- * @internal
+ * @alpha
  */
 export enum TreeFlags {
   None = 0,
@@ -216,7 +216,7 @@ export function compareIModelTileTreeIds(lhs: IModelTileTreeId, rhs: IModelTileT
 }
 
 /** Flags controlling how tile content is produced. The flags are part of the ContentId.
- * @internal
+ * @alpha
  */
 export enum ContentFlags {
   None = 0,

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -35,6 +35,19 @@ export interface ImdlReaderResult extends IModelTileContent {
   readStatus: TileReadStatus;
 }
 
+/** Convert the byte array returned by [[TileAdmin.requestElementGraphics]] into a [[RenderGraphic]].
+ * @beta
+ */
+export async function readElementGraphics(bytes: Uint8Array, iModel: IModelConnection, modelId: Id64String, is3d: boolean): Promise<RenderGraphic | undefined> {
+  const stream = new ByteStream(bytes.buffer);
+  const reader = ImdlReader.create(stream, iModel, modelId, is3d, IModelApp.renderSystem);
+  if (!reader)
+    return undefined;
+
+  const result = await reader.read();
+  return result.graphic;
+}
+
 /** Deserializes tile content in iMdl format. These tiles contain element geometry encoded into a format optimized for the imodeljs webgl renderer.
  * @internal
  */

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -619,7 +619,10 @@ export class TileAdmin {
     return { tokenProps, treeId, contentId, guid };
   }
 
-  /** @internal */
+  /** Request graphics for a single element or geometry stream.
+   * @see [[readElementGraphics]] to convert the result into a [[RenderGraphic]] for display.
+   * @beta
+   */
   public async requestElementGraphics(iModel: IModelConnection, requestProps: ElementGraphicsRequestProps): Promise<Uint8Array | undefined> {
     this.initializeRpc();
     const intfc = IModelTileRpcInterface.getClient();


### PR DESCRIPTION
`IModelTileRpcInterface.requestElementGraphics()` and `IModelDb.generateElementGraphics()` can now accept a non-persistent geometry stream from which to generate graphics, instead of a persistent element Id.

[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/154670)