### PR TITLE
Export the ElectronIpc class

### DIFF
--- a/common/changes/@bentley/electron-manager/feat-export-electron-ipc_2021-03-31-23-28.json
+++ b/common/changes/@bentley/electron-manager/feat-export-electron-ipc_2021-03-31-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "Export the ElectronIpc class",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/core/electron-manager/src/frontend/ElectronApp.ts
+++ b/core/electron-manager/src/frontend/ElectronApp.ts
@@ -10,8 +10,9 @@ import { ElectronRpcManager } from "../common/ElectronRpcManager";
 
 /**
  * Frontend Ipc support for Electron apps.
+ * @beta
  */
-class ElectronIpc implements IpcSocketFrontend {
+export class ElectronIpc implements IpcSocketFrontend {
   private _api: ITwinElectronApi;
   public addListener(channelName: string, listener: IpcListener) {
     this._api.addListener(channelName, listener);


### PR DESCRIPTION
This class could be useful outside of the context of ElectronApp. For example, for desktop applications using the iTwinViewer, the iTwinViewer will handle startup and initialization based on configuration that is passed to the Viewer. This would allow applications to more easily use ipc's to obtain that configuration from the backend (auth config, etc.) prior to the initialization of ElectronApp. 