### PR TITLE
Do not precompile shaders by default

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -8157,7 +8157,6 @@ export namespace RenderSystem {
         // @internal
         disabledExtensions?: WebGLExtensionName[];
         displaySolarShadows?: boolean;
-        // @public
         doIdleWork?: boolean;
         dpiAwareLOD?: boolean;
         dpiAwareViewports?: boolean;

--- a/common/changes/@bentley/imodeljs-frontend/do-not-precompile-shaders-by-default_2021-04-01-16-32.json
+++ b/common/changes/@bentley/imodeljs-frontend/do-not-precompile-shaders-by-default_2021-04-01-16-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Revert the change which defaulted shader precompiling on. It resulted in noticeable UI sluggishness before any viewports were added, while shaders precompiled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -116,7 +116,7 @@ export class ViewManager {
     this.cursor = "default";
 
     const options = IModelApp.renderSystem.options;
-    this._doIdleWork = false !== options.doIdleWork;
+    this._doIdleWork = true === options.doIdleWork;
     if (this._doIdleWork)
       this._beginIdleWork();
   }

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -600,12 +600,13 @@ export namespace RenderSystem { // eslint-disable-line no-redeclare
      */
     planProjections?: boolean;
 
-    /** To help prevent delays when a user interacts with a [[Viewport]], the WebGL render system precompiles shader programs before any Viewport is opened.
+    /** To help prevent delays when a user interacts with a [[Viewport]], the WebGL render system can precompile shader programs before any Viewport is opened.
      * This particularly helps applications when they do not open a Viewport immediately upon startup - for example, if the user is first expected to select an iModel and a view through the user interface.
      * Shader precompilation will cease once all shader programs have been compiled, or when a Viewport is opened (registered with the [[ViewManager]]).
-     * To disable this feature, set this to `false`.
+     * @note Enabling this feature can slow UI interactions before a [[Viewport]] is opened.
+     * To enable this feature, set this to `true`.
      *
-     * Default value: true
+     * Default value: false
      *
      * @public
      */

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -608,7 +608,7 @@ export namespace RenderSystem { // eslint-disable-line no-redeclare
      *
      * Default value: false
      *
-     * @public
+     * @beta
      */
     doIdleWork?: boolean;
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -52,14 +52,6 @@ The `QuantityFormatSettingsPage` is marked as alpha in this release and is subje
 
 The alpha classes, interfaces, and definitions in the package `@bentley/imodeljs-quantity` have been updated to beta.
 
-## Incremental precompilation of shaders enabled by default
-
-To help prevent delays when a user interacts with a [Viewport]($frontend), the WebGL render system now by default precompiles shader programs used by the [RenderSystem]($frontend) before any Viewport is opened.
-
-Shader precompilation will cease once all shader programs have been compiled, or when a [Viewport]($frontend) is opened (registered with the [ViewManager]($frontend)).  As such, applications which do not open a [Viewport]($frontend) immediately upon startup stand to benefit - for example, if the user is first expected to select an iModel and/or a view through the user interface.
-
-To disable this functionality, set the `doIdleWork` property of the `RenderSystem.Options` object passed to `IModelApp.startup` to false.
-
 ## Added NativeHost.settingsStore for storing user-level settings for native applications
 
 The @beta class `NativeHost` now has a member [NativeHost.settingsStore]($backend) that may be used by native applications to store user-level data in a file in the [[NativeHost.appSettingsCacheDir]($backend) directory. It uses the [NativeAppStorage]($backend) api to store and load key/value pairs. Note that these settings are stored in a local file that may be deleted by the user, so it should only be used for a local cache of values that may be restored elsewhere.


### PR DESCRIPTION
Revert the change which defaulted shader precompiling on. It resulted in noticeable UI sluggishness before any viewports were added, while shaders precompiled.