### PR TITLE
Output graphics for raster attachment as soon as they are ready.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-view-attachment-delay_2021-04-02-16-36.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-view-attachment-delay_2021-04-02-16-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix delay before raster view attachments appear in a sheet view.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -899,6 +899,8 @@ class RasterAttachment {
     this._viewport.setTileSizeModifier(context.viewport.tileSizeModifier);
 
     this._viewport.renderFrame();
+    if (this._graphics)
+      context.outputGraphic(this._graphics);
   }
 
   public discloseTileTrees(trees: DisclosedTileTreeSet) {


### PR DESCRIPTION
As described in [this bug](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/588816), when the graphics for a 3d view attachment with camera enabled become ready, they are not displayed on the sheet until the sheet viewport's scene is invalidated, e.g. by zooming or panning.
Add them to the sheet viewport's scene as soon as they are ready.