### PR TITLE
#588248 - fixed silhouettes for WebGL1 instancing

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-webgl1-silhouettes_2021-04-02-16-54.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-webgl1-silhouettes_2021-04-02-16-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fixed silhouettes for instanced geometry when running with WebGL1",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "36053767+MarcNeely@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/glsl/Edge.ts
+++ b/core/frontend/src/render/webgl/glsl/Edge.ts
@@ -130,7 +130,7 @@ function createBase(isSilhouette: boolean, instanced: IsInstanced, isAnimated: I
   addLineWeight(vert);
 
   if (isSilhouette) {
-    addNormalMatrix(vert);
+    addNormalMatrix(vert, instanced);
     addModelViewProjectionMatrix(vert);
     vert.set(VertexShaderComponent.CheckForEarlyDiscard, checkForSilhouetteDiscard);
     vert.addFunction(octDecodeNormal);

--- a/core/frontend/src/render/webgl/glsl/RealityMesh.ts
+++ b/core/frontend/src/render/webgl/glsl/RealityMesh.ts
@@ -12,7 +12,7 @@ import { AttributeMap } from "../AttributeMap";
 import { TextureUnit } from "../RenderFlags";
 import { FragmentShaderBuilder, FragmentShaderComponent, ProgramBuilder, VariableType, VertexShaderComponent } from "../ShaderBuilder";
 import { System } from "../System";
-import { FeatureMode, IsShadowable, IsThematic, TechniqueFlags } from "../TechniqueFlags";
+import { FeatureMode, IsInstanced, IsShadowable, IsThematic, TechniqueFlags } from "../TechniqueFlags";
 import { TechniqueId } from "../TechniqueId";
 import { Texture } from "../Texture";
 import { addVaryingColor } from "./Color";
@@ -138,7 +138,7 @@ const mixFeatureColor = `
   `;
 
 function addThematicToRealityMesh(builder: ProgramBuilder, gradientTextureUnit: TextureUnit) {
-  addNormalMatrix(builder.vert);
+  addNormalMatrix(builder.vert, IsInstanced.No);
   builder.vert.addFunction(octDecodeNormal);
   builder.vert.addGlobal("g_hillshadeIndex", VariableType.Float);
   builder.addFunctionComputedVarying("v_n", VariableType.Vec3, "computeLightingNormal", computeNormal);

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -430,8 +430,8 @@ export function addSurfaceFlags(builder: ProgramBuilder, withFeatureOverrides: b
   });
 }
 
-function addNormal(builder: ProgramBuilder, animated: IsAnimated) {
-  addNormalMatrix(builder.vert);
+function addNormal(builder: ProgramBuilder, instanced: IsInstanced, animated: IsAnimated) {
+  addNormalMatrix(builder.vert, instanced);
 
   builder.vert.addFunction(octDecodeNormal);
   addChooseWithBitFlagFunctions(builder.vert);
@@ -510,7 +510,7 @@ export function createSurfaceBuilder(flags: TechniqueFlags): ProgramBuilder {
   addFeatureSymbology(builder, feat, opts);
   addSurfaceFlags(builder, FeatureMode.Overrides === feat, true);
   addSurfaceDiscard(builder, flags);
-  addNormal(builder, flags.isAnimated);
+  addNormal(builder, flags.isInstanced, flags.isAnimated);
 
   // In HiddenLine mode, we must compute the base color (plus feature overrides etc) in order to get the alpha, then replace with background color (preserving alpha for the transparency threshold test).
   addChooseWithBitFlagFunctions(builder.frag);


### PR DESCRIPTION
This fixes silhouettes (and also lighting) for instanced geometry when displayed using WebGL1.  When instancing is used, the matrix for transforming normals to view space is now just extracted from the modelView matrix like it used to be.  For models which use a scaled ModelDisplayTransformProvider there was no problem since instancing is turned off in that case.