### PR TITLE
Fix ios edge shader bugs

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-ios-edge-shader-bugs_2021-04-08-17-44.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-ios-edge-shader-bugs_2021-04-08-17-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix iOS shader bugs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/glsl/Viewport.ts
+++ b/core/frontend/src/render/webgl/glsl/Viewport.ts
@@ -8,7 +8,7 @@
 
 import { ShaderBuilder, VariableType, VertexShaderBuilder } from "../ShaderBuilder";
 import { addRenderPass } from "./RenderPass";
-import { addModelViewMatrix, addModelViewProjectionMatrix, addProjectionMatrix } from "./Vertex";
+import { addModelViewMatrix, addProjectionMatrix } from "./Vertex";
 
 /** @internal */
 export function addViewport(shader: ShaderBuilder) {

--- a/core/frontend/src/render/webgl/glsl/Viewport.ts
+++ b/core/frontend/src/render/webgl/glsl/Viewport.ts
@@ -8,7 +8,7 @@
 
 import { ShaderBuilder, VariableType, VertexShaderBuilder } from "../ShaderBuilder";
 import { addRenderPass } from "./RenderPass";
-import { addModelViewMatrix, addProjectionMatrix } from "./Vertex";
+import { addModelViewMatrix, addModelViewProjectionMatrix, addProjectionMatrix } from "./Vertex";
 
 /** @internal */
 export function addViewport(shader: ShaderBuilder) {
@@ -46,8 +46,11 @@ vec4 modelToWindowCoordinates(vec4 position, vec4 next, out vec4 clippedMvpPos, 
   vec4  n = MAT_MV * next;
 
   if (q.z > s_maxZ) {
-    if (n.z > s_maxZ)
+    if (n.z > s_maxZ) {
+      clippedMvPos = vec3(0.0, 0.0, 1.0);
+      clippedMvpPos = vec4(0.0, 0.0, 1.0, 0.0);
       return vec4(0.0, 0.0, 1.0, 0.0);    // Entire segment behind front clip plane.
+    }
 
     float t = (s_maxZ - q.z) / (n.z - q.z);
 


### PR DESCRIPTION
The shader function modelToWindowCoordinates() needs to initialize its output parameters for all code paths.
Not doing so caused the iOS shader compiler to trip up and take very long to compile certain shaders.  Lines could also drop out in certain situations.
This PR fixes this bug item: https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/589235