### PR TITLE
Fix clipping shaders for WebGL 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,7 +120,9 @@ rush.json       @calebmshafer @scsewall
 /core/express-server            @calebmshafer @wgoehrig @ramanujam-raman
 /core/frontend                  @imodeljs/admins
 /core/frontend/src/render       @imodeljs/display
+/core/frontend/src/test/render  @imodeljs/display
 /core/frontend/src/tile         @imodeljs/display
+/core/frontend/src/test/tile    @imodeljs/display
 /core/frontend-devtools         @imodeljs/display
 /core/geometry                  @bbastings @EarlinLutz @mgooding @RBBentley
 /core/hypermodeling             @bbastings @pmconne

--- a/common/changes/@bentley/imodeljs-frontend/fix-webgl1-clipping_2021-04-14-19-55.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-webgl1-clipping_2021-04-14-19-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix WebGL1 clipping shaders.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/glsl/Clipping.ts
+++ b/core/frontend/src/render/webgl/glsl/Clipping.ts
@@ -65,8 +65,10 @@ const applyClipPlanesPrelude = `
 `;
 
 const applyClipPlanesLoopWebGL1 = `
-  for (int i = u_clipParams[0]; i < MAX_CLIPPING_PLANES; i++) {
-    if (i >= u_clipParams[1])
+  for (int i = 0; i < MAX_CLIPPING_PLANES; i++) {
+    if (i < u_clipParams[0])
+      continue;
+    else if (i >= u_clipParams[1])
       break;
 `;
 

--- a/core/frontend/src/test/render/webgl/Technique.test.ts
+++ b/core/frontend/src/test/render/webgl/Technique.test.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { assert, expect } from "chai";
+import { WebGLExtensionName } from "@bentley/webgl-compatibility";
 import { IModelApp } from "../../../IModelApp";
 import { RenderSystem } from "../../../render/RenderSystem";
 import { AttributeMap } from "../../../render/webgl/AttributeMap";
@@ -48,133 +49,141 @@ function createTarget(): Target | undefined {
 }
 
 describe("Techniques", () => {
-  before(async () => IModelApp.startup());
-  after(async () => IModelApp.shutdown());
+  const canvas = document.createElement("canvas");
+  const maxWebGLVersion = null !== canvas.getContext("webgl2") ? 2 : 1;
+  for (let webGLVersion = 1; webGLVersion <= maxWebGLVersion; webGLVersion++) {
+    const useWebGL2 = webGLVersion === 2;
+    describe(`WebGL ${webGLVersion}`, () => {
+      before(async () => {
+        await IModelApp.startup({ renderSys: { useWebGL2 } });
+      });
 
-  it("should produce a simple dynamic rendering technique", () => {
-    const target = createTarget();
-    assert(undefined !== target);
+      after(async () => {
+        await IModelApp.shutdown();
+      });
 
-    const techId = createPurpleQuadTechnique();
-    expect(techId).to.equal(TechniqueId.NumBuiltIn);
-  });
+      it("should produce a simple dynamic rendering technique", () => {
+        const target = createTarget();
+        assert(undefined !== target);
 
-  it("should render a purple quad", () => {
-    const target = createTarget();
-    assert(undefined !== target);
-    if (undefined === target) {
-      return;
-    }
+        const techId = createPurpleQuadTechnique();
+        expect(techId).to.equal(TechniqueId.NumBuiltIn);
+      });
 
-    const techId = createPurpleQuadTechnique();
-    const geom = ViewportQuadGeometry.create(techId);
-    assert.isDefined(geom);
+      it("should render a purple quad", () => {
+        const target = createTarget();
+        assert(undefined !== target);
+        if (undefined === target) {
+          return;
+        }
 
-    const progParams = new ShaderProgramParams();
-    progParams.init(target);
-    const drawParams = new DrawParams();
-    drawParams.init(progParams, geom!);
-    target.techniques.draw(drawParams);
-  });
+        const techId = createPurpleQuadTechnique();
+        const geom = ViewportQuadGeometry.create(techId);
+        assert.isDefined(geom);
 
-  // NB: compiling all shaders can potentially take a long time, especially on our mac build machines.
-  const compileTimeout = "95000";
-  async function compileAllShaders(opts?: RenderSystem.Options): Promise<void> {
-    if (undefined !== opts) {
-      // Replace current render system with customized one
-      await IModelApp.shutdown();
-      await IModelApp.startup({ renderSys: opts });
-    }
+        const progParams = new ShaderProgramParams();
+        progParams.init(target);
+        const drawParams = new DrawParams();
+        drawParams.init(progParams, geom!);
+        target.techniques.draw(drawParams);
+      });
 
-    expect(System.instance.techniques.compileShaders()).to.be.true;
+      // NB: compiling all shaders can potentially take a long time, especially on our mac build machines.
+      const compileTimeout = "95000";
+      async function compileAllShaders(disabledExtension?: WebGLExtensionName): Promise<void> {
+        if (disabledExtension) {
+          // The extensions we're disabling are core in WebGL 2.
+          expect(useWebGL2).to.be.false;
 
-    if (undefined !== opts) {
-      // Reset render system to default state
-      await IModelApp.shutdown();
-      await IModelApp.startup();
-    }
-  }
+          // Restart with extension disabled.
+          await IModelApp.shutdown();
+          await IModelApp.startup({
+            renderSys: {
+              useWebGL2: false,
+              disabledExtensions: [disabledExtension],
+            },
+          });
+        }
 
-  let haveWebGL2 = false; // currently we only use webgl 2 if explicitly enabled at startup
-  it("should compile all shader programs with WebGL 1", async () => {
-    haveWebGL2 = System.instance.capabilities.isWebGL2;
-    if (!haveWebGL2) {
-      const canvas = document.createElement("canvas");
-      haveWebGL2 = null !== canvas.getContext("webgl2");
-    }
+        expect(System.instance.techniques.compileShaders()).to.be.true;
 
-    await compileAllShaders({ useWebGL2: false });
-  }).timeout(compileTimeout);
+        if (disabledExtension) {
+          // Reset render system to previous state
+          await IModelApp.shutdown();
+          await IModelApp.startup({ renderSys: { useWebGL2: false } });
+        }
+      }
 
-  it("should successfully compile all shader programs with WebGL 2", async () => {
-    if (haveWebGL2)
-      await compileAllShaders({ useWebGL2: true });
-  }).timeout(compileTimeout);
+      it("should compile all shader programs", async () => {
+        await compileAllShaders();
+      }).timeout(compileTimeout);
 
-  it("should compile all shader programs without MRT", async () => {
-    if (System.instance.capabilities.supportsDrawBuffers) {
-      // WebGL 2 always supports MRT - must use WebGL 1 context to test.
-      await compileAllShaders({ disabledExtensions: ["WEBGL_draw_buffers"], useWebGL2: false });
-    }
-  }).timeout(compileTimeout);
+      if (!useWebGL2) {
+        it("should compile all shader programs without MRT", async () => {
+          if (System.instance.capabilities.supportsDrawBuffers)
+            await compileAllShaders("WEBGL_draw_buffers");
+        }).timeout(compileTimeout);
 
-  it("should compile all shader programs without logarithmic depth", async () => {
-    if (System.instance.supportsLogZBuffer)
-      await compileAllShaders({ logarithmicDepthBuffer: false, useWebGL2: false });
-  }).timeout(compileTimeout);
+        it("should compile all shader programs without logarithmic depth", async () => {
+          if (System.instance.capabilities.supportsFragDepth)
+            await compileAllShaders("EXT_frag_depth");
+        }).timeout(compileTimeout);
+      }
 
-  it("should successfully compile surface shader with clipping planes", () => {
-    const flags = new TechniqueFlags(true);
-    flags.numClipPlanes = 6;
-    flags.featureMode = FeatureMode.Overrides;
+      it("should successfully compile surface shader with clipping planes", () => {
+        const flags = new TechniqueFlags(true);
+        flags.numClipPlanes = 6;
+        flags.featureMode = FeatureMode.Overrides;
 
-    const tech = System.instance.techniques.getTechnique(TechniqueId.Surface);
-    const prog = tech.getShader(flags);
-    expect(prog.compile() === CompileStatus.Success).to.be.true;
-  });
+        const tech = System.instance.techniques.getTechnique(TechniqueId.Surface);
+        const prog = tech.getShader(flags);
+        expect(prog.compile() === CompileStatus.Success).to.be.true;
+      });
 
-  it("should produce exception on syntax error", () => {
-    const builder = createPurpleQuadBuilder();
-    builder.vert.headerComment = "// My Naughty Program";
-    builder.frag.set(FragmentShaderComponent.ComputeBaseColor, "blah blah blah");
-    const prog = builder.buildProgram(System.instance.context);
-    let compiled = false;
-    let ex: Error | undefined;
-    try {
-      compiled = prog.compile() === CompileStatus.Success;
-    } catch (err) {
-      ex = err;
-    }
+      it("should produce exception on syntax error", () => {
+        const builder = createPurpleQuadBuilder();
+        builder.vert.headerComment = "// My Naughty Program";
+        builder.frag.set(FragmentShaderComponent.ComputeBaseColor, "blah blah blah");
+        const prog = builder.buildProgram(System.instance.context);
+        let compiled = false;
+        let ex: Error | undefined;
+        try {
+          compiled = prog.compile() === CompileStatus.Success;
+        } catch (err) {
+          ex = err;
+        }
 
-    expect(compiled).to.be.false;
-    expect(ex).not.to.be.undefined;
-    const msg = ex!.toString();
-    expect(msg.includes("blah")).to.be.true;
-    expect(msg.includes("Fragment shader failed to compile")).to.be.true;
-    expect(msg.includes("Program description: // My Naughty Program")).to.be.true;
-  });
+        expect(compiled).to.be.false;
+        expect(ex).not.to.be.undefined;
+        const msg = ex!.toString();
+        expect(msg.includes("blah")).to.be.true;
+        expect(msg.includes("Fragment shader failed to compile")).to.be.true;
+        expect(msg.includes("Program description: // My Naughty Program")).to.be.true;
+      });
 
-  // NB: We may run across some extremely poor webgl implementation that fails to remove clearly-unused uniforms, which would cause this test to fail.
-  // If such an implementation exists, we'd like to know about it.
-  it("should produce exception on unused uniform", () => {
-    const builder = createPurpleQuadBuilder();
-    builder.frag.addUniform("u_unused", VariableType.Float, (prog) => {
-      prog.addProgramUniform("u_unused", (uniform, _params) => {
-        uniform.setUniform1f(123.45);
+      // NB: We may run across some extremely poor webgl implementation that fails to remove clearly-unused uniforms, which would cause this test to fail.
+      // If such an implementation exists, we'd like to know about it.
+      it("should produce exception on unused uniform", () => {
+        const builder = createPurpleQuadBuilder();
+        builder.frag.addUniform("u_unused", VariableType.Float, (prog) => {
+          prog.addProgramUniform("u_unused", (uniform, _params) => {
+            uniform.setUniform1f(123.45);
+          });
+        });
+
+        const program = builder.buildProgram(System.instance.context);
+        let compiled = false;
+        let ex: Error | undefined;
+        try {
+          compiled = program.compile() === CompileStatus.Success;
+        } catch (err) {
+          ex = err;
+        }
+
+        expect(compiled).to.be.false;
+        expect(ex).not.to.be.undefined;
+        expect(ex!.toString().includes("uniform u_unused not found.")).to.be.true;
       });
     });
-
-    const program = builder.buildProgram(System.instance.context);
-    let compiled = false;
-    let ex: Error | undefined;
-    try {
-      compiled = program.compile() === CompileStatus.Success;
-    } catch (err) {
-      ex = err;
-    }
-
-    expect(compiled).to.be.false;
-    expect(ex).not.to.be.undefined;
-    expect(ex!.toString().includes("uniform u_unused not found.")).to.be.true;
-  });
+  }
 });

--- a/core/frontend/src/test/render/webgl/Technique.test.ts
+++ b/core/frontend/src/test/render/webgl/Technique.test.ts
@@ -5,7 +5,6 @@
 import { assert, expect } from "chai";
 import { WebGLExtensionName } from "@bentley/webgl-compatibility";
 import { IModelApp } from "../../../IModelApp";
-import { RenderSystem } from "../../../render/RenderSystem";
 import { AttributeMap } from "../../../render/webgl/AttributeMap";
 import { CompileStatus } from "../../../render/webgl/ShaderProgram";
 import { DrawParams, ShaderProgramParams } from "../../../render/webgl/DrawCommand";


### PR DESCRIPTION
`Loop index cannot be initialized with non-constant expression`.
Make all shader compilation tests execute using both WebGL 1 and (if available) WebGL 2 such that they would have caught this.