### PR TITLE
Improve ortho silhouettes

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/improve-ortho-silhouettes_2021-04-19-19-59.json
+++ b/common/changes/@bentley/imodeljs-frontend/improve-ortho-silhouettes_2021-04-19-19-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "improved silhouettes for non-perspective views",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "36053767+MarcNeely@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/glsl/Edge.ts
+++ b/core/frontend/src/render/webgl/glsl/Edge.ts
@@ -12,11 +12,11 @@ import { IsAnimated, IsInstanced, IsThematic } from "../TechniqueFlags";
 import { TechniqueId } from "../TechniqueId";
 import { addAnimation } from "./Animation";
 import { addColor } from "./Color";
-import { addShaderFlags } from "./Common";
+import { addFrustum, addShaderFlags } from "./Common";
 import { addWhiteOnWhiteReversal } from "./Fragment";
 import { addAdjustWidth, addLineCode } from "./Polyline";
 import { octDecodeNormal } from "./Surface";
-import { addLineWeight, addModelViewMatrix, addModelViewProjectionMatrix, addNormalMatrix, addProjectionMatrix } from "./Vertex";
+import { addLineWeight, addModelViewMatrix, addNormalMatrix, addProjectionMatrix } from "./Vertex";
 import { addModelToWindowCoordinates, addViewport } from "./Viewport";
 
 const decodeEndPointAndQuadIndices = `
@@ -35,10 +35,11 @@ const checkForSilhouetteDiscard = `
   vec3 n0 = MAT_NORM * octDecodeNormal(a_normals.xy);
   vec3 n1 = MAT_NORM * octDecodeNormal(a_normals.zw);
 
-  float perpTol = 2.5e-4;
-  if (0.0 == MAT_MVP[0].w) {
-    return n0.z * n1.z > perpTol;        // orthographic.
+  if (kFrustumType_Perspective != u_frustum.z) {
+    float perpTol = 4.75e-6;
+    return (n0.z * n1.z > perpTol); // || (abs(n0.z) < 0.02 && abs(n1.z) < 0.02 && (abs(n0.z) > 0.01 || abs(n1.z) > 0.01)));        // orthographic.
   } else {
+    float perpTol = 2.5e-4;
     vec4  viewPos = MAT_MV * rawPos;     // perspective
     vec3  toEye = normalize(viewPos.xyz);
     float dot0 = dot(n0, toEye);
@@ -132,7 +133,7 @@ function createBase(isSilhouette: boolean, instanced: IsInstanced, isAnimated: I
 
   if (isSilhouette) {
     addNormalMatrix(vert, instanced);
-    addModelViewProjectionMatrix(vert);
+    addFrustum(builder);
     vert.set(VertexShaderComponent.CheckForEarlyDiscard, checkForSilhouetteDiscard);
     vert.addFunction(octDecodeNormal);
   }


### PR DESCRIPTION
This improves silhouettes that are generated for non-perspective views.  It also fixes some rare perspective views which were being processed as non-perspective views by modifying the test for whether the view is perspective or not (which also had a nice side effect of no longer requiring the mvp matrix to be sent into silhouette shaders).