### PR TITLE
Handle bad views in display-test-app.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fallback-on-bad-view_2021-04-20-17-00.json
+++ b/common/changes/@bentley/imodeljs-frontend/fallback-on-bad-view_2021-04-20-17-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "IModelConnection.View.load throws if the input is not a valid Id.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -963,6 +963,9 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
 
     /** Load a [[ViewState]] object from the specified [[ViewDefinition]] id. */
     public async load(viewDefinitionId: Id64String): Promise<ViewState> {
+      if (!Id64.isValidId64(viewDefinitionId))
+        throw new IModelError(IModelStatus.InvalidId, "Invalid view definition Id for IModelConnection.Views.load", Logger.logError, loggerCategory, () => { return { viewDefinitionId }; });
+
       const options: ViewStateLoadProps = {
         displayStyle: {
           omitScheduleScriptElementIds: true,

--- a/test-apps/display-test-app/src/frontend/ViewPicker.ts
+++ b/test-apps/display-test-app/src/frontend/ViewPicker.ts
@@ -17,6 +17,7 @@ export class ViewList extends SortedArray<ViewSpec> {
 
   private constructor() {
     super((lhs, rhs) => {
+      // Every entry has a unique Id, but we want to sort in the UI based on other criteria first.
       let cmp = compareBooleans(lhs.isPrivate, rhs.isPrivate);
       if (0 === cmp) {
         cmp = compareStrings(lhs.name, rhs.name);
@@ -33,7 +34,18 @@ export class ViewList extends SortedArray<ViewSpec> {
   public async getView(id: Id64String, iModel: IModelConnection): Promise<ViewState> {
     let view = this._views.get(id);
     if (undefined === view) {
-      view = await iModel.views.load(id);
+      if (Id64.isInvalid(id)) {
+        view = this.manufactureSpatialView(iModel);
+      } else {
+        try {
+          view = await iModel.views.load(id);
+        } catch (_) {
+          // The view probably references a nonexistent display style or model/category selector. Replace with a default spatial view.
+          // The viewport's title bar will display "UNNAMED" instead of the bad view's name.
+          view = this.manufactureSpatialView(iModel);
+        }
+      }
+
       this._views.set(id, view);
     }
 
@@ -101,8 +113,8 @@ export class ViewList extends SortedArray<ViewSpec> {
     if (Id64.isInvalid(this._defaultViewId))
       this.insert({ id: Id64.invalid, name: "Spatial View", class: SpatialViewState.classFullName, isPrivate: false });
 
-    const selectedView = Id64.isInvalid(this._defaultViewId) ? this.manufactureSpatialView(iModel) : await iModel.views.load(this._defaultViewId);
-    this._views.set(this._defaultViewId, selectedView);
+    // Ensure default view is selected and loaded.
+    await this.getView(this._defaultViewId, iModel);
   }
 
   // create a new spatial view initialized to show the project extents from top view. Model and

--- a/test-apps/display-test-app/src/frontend/ViewPicker.ts
+++ b/test-apps/display-test-app/src/frontend/ViewPicker.ts
@@ -34,16 +34,13 @@ export class ViewList extends SortedArray<ViewSpec> {
   public async getView(id: Id64String, iModel: IModelConnection): Promise<ViewState> {
     let view = this._views.get(id);
     if (undefined === view) {
-      if (Id64.isInvalid(id)) {
+      try {
+        view = await iModel.views.load(id);
+      } catch (_) {
+        // The view probably references a nonexistent display style or model/category selector. Replace with a default spatial view.
+        // Or, we've opened a blank connection and `id` is intentionally invalid.
+        // The viewport's title bar will display "UNNAMED" instead of the bad view's name.
         view = this.manufactureSpatialView(iModel);
-      } else {
-        try {
-          view = await iModel.views.load(id);
-        } catch (_) {
-          // The view probably references a nonexistent display style or model/category selector. Replace with a default spatial view.
-          // The viewport's title bar will display "UNNAMED" instead of the bad view's name.
-          view = this.manufactureSpatialView(iModel);
-        }
       }
 
       this._views.set(id, view);

--- a/test-apps/display-test-app/src/frontend/ViewPicker.ts
+++ b/test-apps/display-test-app/src/frontend/ViewPicker.ts
@@ -37,7 +37,7 @@ export class ViewList extends SortedArray<ViewSpec> {
       try {
         view = await iModel.views.load(id);
       } catch (_) {
-        // The view probably references a nonexistent display style or model/category selector. Replace with a default spatial view.
+        // The view probably refers to a nonexistent display style or model/category selector. Replace with a default spatial view.
         // Or, we've opened a blank connection and `id` is intentionally invalid.
         // The viewport's title bar will display "UNNAMED" instead of the bad view's name.
         view = this.manufactureSpatialView(iModel);


### PR DESCRIPTION
If `ViewState.load` throws, it's probably because of nonexistent display style or model/category selector. In this case, just display a generated spatial view instead of terminating.