### PR TITLE
UI/modeless dialog fix

### DIFF
--- a/common/changes/@bentley/ui-core/ui-modeless-dialog-fix_2021-04-22-19-45.json
+++ b/common/changes/@bentley/ui-core/ui-modeless-dialog-fix_2021-04-22-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Removed unneeded CSS class for modeless dialogs that was setting width & height to 0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "51122937+DanEastBentley@users.noreply.github.com"
+}

--- a/ui/core/src/ui-core/dialog/Dialog.scss
+++ b/ui/core/src/ui-core/dialog/Dialog.scss
@@ -33,11 +33,6 @@
     display: block;
   }
 
-  &.core-dialog-hidden {
-    width: 0;
-    height: 0;
-  }
-
   .core-dialog-container {
     position: fixed;
 

--- a/ui/core/src/ui-core/dialog/Dialog.tsx
+++ b/ui/core/src/ui-core/dialog/Dialog.tsx
@@ -270,7 +270,6 @@ export class Dialog extends React.Component<DialogProps, DialogState> {
       <div
         className={classnames(
           "core-dialog",
-          !modal && "core-dialog-hidden",
           opened && "core-dialog-opened",
           className,
         )}


### PR DESCRIPTION
Removed unneeded CSS class for modeless dialogs that was setting width & height to 0