### PR TITLE
Presentation: Add missing related properties specifications for core element types

### DIFF
--- a/common/changes/@bentley/presentation-backend/presentation-generalize-related-properties-rules-for-type-definitions_2021-04-27-07-36.json
+++ b/common/changes/@bentley/presentation-backend/presentation-generalize-related-properties-rules-for-type-definitions_2021-04-27-07-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Add missing related properties specifications for core element types",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
+++ b/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
@@ -396,36 +396,40 @@
       "ruleType": "ContentModifier",
       "class": {
         "schemaName": "BisCore",
-        "className": "PhysicalElement"
+        "className": "GeometricElement3d"
       },
       "relatedProperties": [
         {
-          "relationships": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "PhysicalElementIsOfType"
-            ]
+          "propertiesSource": {
+            "relationship": {
+              "schemaName": "BisCore",
+              "className": "GeometricElement3dHasTypeDefinition"
+            },
+            "direction": "Forward"
           },
-          "relatedClasses": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "PhysicalType"
-            ]
-          },
-          "requiredDirection": "Forward",
-          "isPolymorphic": true,
+          "handleTargetClassPolymorphically": true,
           "relationshipMeaning": "RelatedInstance",
           "nestedRelatedProperties": [
             {
-              "relationships": {
-                "schemaName": "BisCore",
-                "classNames": [
-                  "ElementOwnsMultiAspects",
-                  "ElementOwnsUniqueAspect"
-                ]
+              "propertiesSource": {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsUniqueAspect"
+                },
+                "direction": "Forward"
               },
-              "requiredDirection": "Forward",
-              "isPolymorphic": true,
+              "handleTargetClassPolymorphically": true,
+              "relationshipMeaning": "SameInstance"
+            },
+            {
+              "propertiesSource": {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsMultiAspects"
+                },
+                "direction": "Forward"
+              },
+              "handleTargetClassPolymorphically": true,
               "relationshipMeaning": "SameInstance"
             }
           ]
@@ -436,36 +440,40 @@
       "ruleType": "ContentModifier",
       "class": {
         "schemaName": "BisCore",
-        "className": "SpatialLocationElement"
+        "className": "GeometricElement2d"
       },
       "relatedProperties": [
         {
-          "relationships": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "SpatialLocationIsOfType"
-            ]
+          "propertiesSource": {
+            "relationship": {
+              "schemaName": "BisCore",
+              "className": "GeometricElement2dHasTypeDefinition"
+            },
+            "direction": "Forward"
           },
-          "relatedClasses": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "SpatialLocationType"
-            ]
-          },
-          "requiredDirection": "Forward",
-          "isPolymorphic": true,
+          "handleTargetClassPolymorphically": true,
           "relationshipMeaning": "RelatedInstance",
           "nestedRelatedProperties": [
             {
-              "relationships": {
-                "schemaName": "BisCore",
-                "classNames": [
-                  "ElementOwnsMultiAspects",
-                  "ElementOwnsUniqueAspect"
-                ]
+              "propertiesSource": {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsUniqueAspect"
+                },
+                "direction": "Forward"
               },
-              "requiredDirection": "Forward",
-              "isPolymorphic": true,
+              "handleTargetClassPolymorphically": true,
+              "relationshipMeaning": "SameInstance"
+            },
+            {
+              "propertiesSource": {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsMultiAspects"
+                },
+                "direction": "Forward"
+              },
+              "handleTargetClassPolymorphically": true,
               "relationshipMeaning": "SameInstance"
             }
           ]

--- a/presentation/backend/assets/supplemental-presentation-rules/Functional.PresentationRuleSet.json
+++ b/presentation/backend/assets/supplemental-presentation-rules/Functional.PresentationRuleSet.json
@@ -12,6 +12,50 @@
   },
   "rules": [
     {
+      "ruleType": "ContentModifier",
+      "class": {
+        "schemaName": "Functional",
+        "className": "FunctionalElement"
+      },
+      "relatedProperties": [
+        {
+          "propertiesSource": {
+            "relationship": {
+              "schemaName": "Functional",
+              "className": "FunctionalElementIsOfType"
+            },
+            "direction": "Forward"
+          },
+          "handleTargetClassPolymorphically": true,
+          "relationshipMeaning": "RelatedInstance",
+          "nestedRelatedProperties": [
+            {
+              "propertiesSource": {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsUniqueAspect"
+                },
+                "direction": "Forward"
+              },
+              "handleTargetClassPolymorphically": true,
+              "relationshipMeaning": "SameInstance"
+            },
+            {
+              "propertiesSource": {
+                "relationship": {
+                  "schemaName": "BisCore",
+                  "className": "ElementOwnsMultiAspects"
+                },
+                "direction": "Forward"
+              },
+              "handleTargetClassPolymorphically": true,
+              "relationshipMeaning": "SameInstance"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "ruleType": "Content",
       "condition": "ContentDisplayType = \"Graphics\" ANDALSO SelectedNode.IsOfClass(\"FunctionalElement\", \"Functional\")",
       "onlyIfNotHandled": true,


### PR DESCRIPTION
We were only loading related `TypeDefinition` properties for `PhysicalElement` and `SpatialLocationElement` instances. Now we're loading them for all core types that have a related type definition: `GeometricElement3d`, `GeometricElement2d` and `FunctionalElement`.

Note: `AnalyticalElement` is covered by the rule for `GeometricElement3d`.