### PR TITLE
Presentation: External sources

### DIFF
--- a/common/changes/@bentley/presentation-backend/presentation-external-sources_2021-04-27-14-23.json
+++ b/common/changes/@bentley/presentation-backend/presentation-external-sources_2021-04-27-14-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Expose `ExternalSource -> RepositoryLink` related properties when showing `Element` content",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/src/frontend/Content.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Content.test.ts
@@ -191,7 +191,7 @@ describe("Content", () => {
       };
       const keys = KeySet.fromJSON({ instanceKeys: [["PCJ_TestSchema:TestClass", ["0x61", "0x70", "0x6a", "0x3c", "0x71"]]], nodeKeys: [] });
       const descriptor = (await Presentation.presentation.getContentDescriptor({ imodel, rulesetOrId: ruleset }, "", keys, undefined))!;
-      const field = findFieldByLabel(descriptor.fields, "$óúrçè Fílê Ñâmé")!;
+      const field = findFieldByLabel(descriptor.fields, "Ñámê")!;
       await validatePagedDistinctValuesResponse(ruleset, keys, descriptor, field.getFieldDescriptor(), [{
         displayValue: "Properties_60InstancesWithUrl2.dgn",
         groupedRawValues: ["Properties_60InstancesWithUrl2.dgn"],

--- a/full-stack-tests/presentation/src/frontend/FavoriteProperties.test.ts
+++ b/full-stack-tests/presentation/src/frontend/FavoriteProperties.test.ts
@@ -131,8 +131,8 @@ describe("Favorite properties", () => {
       expect(propertyData.categories.some((category) => category.name === FAVORITES_CATEGORY_NAME)).to.be.false;
 
       // find the property record to make the property favorite
-      const sourceFileInfoCategory = propertyData.categories.find((c) => c.name.endsWith("source_file_information"))!;
-      const sourceFileNameRecord = propertyData.records[sourceFileInfoCategory.name][0];
+      const sourceInfoModelSourceCategory = propertyData.categories.find((c) => c.name.endsWith("model_source"))!;
+      const sourceFileNameRecord = propertyData.records[sourceInfoModelSourceCategory.name][0];
       const field = await propertiesDataProvider.getFieldByPropertyRecord(sourceFileNameRecord);
       await Presentation.favoriteProperties.add(field!, imodel, FavoritePropertiesScope.Global);
 

--- a/full-stack-tests/presentation/src/frontend/providers/PropertyPaneDataProvider.test.snap
+++ b/full-stack-tests/presentation/src/frontend/providers/PropertyPaneDataProvider.test.snap
@@ -268,9 +268,9 @@ Object {
       "name": "/selected-item/",
     },
     Object {
-      "expand": false,
-      "label": "$óúrçè Fílê Ïñfõrmätïòñ",
-      "name": "/selected-item/-source_file_information",
+      "expand": true,
+      "label": "Mòdél $õürçê",
+      "name": "/selected-item/-source_information-model_source",
     },
   ],
   "description": "Physical Object",
@@ -1534,12 +1534,12 @@ Object {
         },
       },
     ],
-    "/selected-item/-source_file_information": Array [
+    "/selected-item/-source_information-model_source": Array [
       PropertyRecord {
         "autoExpand": true,
         "description": "Properties_60InstancesWithUrl2.dgn",
         "property": Object {
-          "displayLabel": "$óúrçè Fílê Ñâmé",
+          "displayLabel": "Ñámê",
           "name": "rc_generic_PhysicalObject_bis_Model_bis_InformationContentElement_ncc_bis_RepositoryLink$pc_bis_Element_UserLabel_2",
           "typename": "string",
         },
@@ -1553,7 +1553,7 @@ Object {
         "autoExpand": true,
         "description": "file:///d|/temp/properties_60instanceswithurl2.dgn",
         "property": Object {
-          "displayLabel": "$óúrçè Fílê Páth",
+          "displayLabel": "Pàth",
           "name": "rc_generic_PhysicalObject_bis_Model_bis_InformationContentElement_ncc_bis_RepositoryLink$pc_bis_UrlLink_Url",
           "typename": "string",
         },
@@ -2090,10 +2090,18 @@ Object {
           "renderer": undefined,
         },
         Object {
-          "childCategories": Array [],
+          "childCategories": Array [
+            Object {
+              "childCategories": Array [],
+              "expand": true,
+              "label": "Mòdél $õürçê",
+              "name": "/selected-item/-source_information-model_source",
+              "renderer": undefined,
+            },
+          ],
           "expand": false,
-          "label": "$óúrçè Fílê Ïñfõrmätïòñ",
-          "name": "/selected-item/-source_file_information",
+          "label": "$óúrçè Íñfórmâtíöñ",
+          "name": "/selected-item/-source_information",
           "renderer": undefined,
         },
       ],
@@ -3364,12 +3372,12 @@ Object {
         },
       },
     ],
-    "/selected-item/-source_file_information": Array [
+    "/selected-item/-source_information-model_source": Array [
       PropertyRecord {
         "autoExpand": true,
         "description": "Properties_60InstancesWithUrl2.dgn",
         "property": Object {
-          "displayLabel": "$óúrçè Fílê Ñâmé",
+          "displayLabel": "Ñámê",
           "name": "rc_generic_PhysicalObject_bis_Model_bis_InformationContentElement_ncc_bis_RepositoryLink$pc_bis_Element_UserLabel_2",
           "typename": "string",
         },
@@ -3383,7 +3391,7 @@ Object {
         "autoExpand": true,
         "description": "file:///d|/temp/properties_60instanceswithurl2.dgn",
         "property": Object {
-          "displayLabel": "$óúrçè Fílê Páth",
+          "displayLabel": "Pàth",
           "name": "rc_generic_PhysicalObject_bis_Model_bis_InformationContentElement_ncc_bis_RepositoryLink$pc_bis_UrlLink_Url",
           "typename": "string",
         },

--- a/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
+++ b/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
@@ -215,8 +215,14 @@
       },
       "propertyCategories": [
         {
-          "id": "source_file_information",
-          "label": "@BisCore:Categories.SourceFileInformation@"
+          "id": "source_information",
+          "label": "@BisCore:Categories.SourceInformation@"
+        },
+        {
+          "id": "model_source",
+          "label": "@BisCore:Categories.SourceInformationModelSource@",
+          "parentId": "source_information",
+          "autoExpand": true
         }
       ],
       "relatedProperties": [
@@ -361,20 +367,19 @@
                     {
                       "name": "Url",
                       "overridesPriority": 1001,
-                      "labelOverride": "@BisCore:Properties.SourceFilePath@",
-                      "categoryId": "source_file_information",
+                      "labelOverride": "@BisCore:Properties.SourceInformation.Path@",
+                      "categoryId": "model_source",
                       "isDisplayed": true
                     },
                     {
                       "name": "UserLabel",
                       "overridesPriority": 1001,
-                      "labelOverride": "@BisCore:Properties.SourceFileName@",
-                      "categoryId": "source_file_information",
+                      "labelOverride": "@BisCore:Properties.SourceInformation.Name@",
+                      "categoryId": "model_source",
                       "isDisplayed": true
                     }
                   ],
-                  "relationshipMeaning": "SameInstance",
-                  "autoExpand": true
+                  "relationshipMeaning": "SameInstance"
                 }
               ]
             }
@@ -396,8 +401,8 @@
       },
       "propertyCategories": [
         {
-          "id": "source_file_information",
-          "label": "@BisCore:Categories.SourceFileInformation@"
+          "id": "source_information",
+          "label": "@BisCore:Categories.SourceInformation@"
         }
       ],
       "relatedProperties": [
@@ -420,9 +425,134 @@
             {
               "name": "Identifier",
               "overridesPriority": 1001,
-              "labelOverride": "@BisCore:Properties.SourceElementId@",
-              "categoryId": "source_file_information",
+              "categoryId": "source_information",
+              "labelOverride": "@BisCore:Properties.SourceInformation.ElementId@",
               "isDisplayed": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "ruleType": "ContentModifier",
+      "requiredSchemas": [
+        {
+          "name": "BisCore",
+          "minVersion": "1.0.13"
+        }
+      ],
+      "class": {
+        "schemaName": "BisCore",
+        "className": "Element"
+      },
+      "propertyCategories": [
+        {
+          "id": "source_information",
+          "label": "@BisCore:Categories.SourceInformation@",
+          "autoExpand": true
+        },
+        {
+          "id": "secondary_sources",
+          "label": "@BisCore:Categories.SourceInformationSecondarySources@",
+          "parentId": "source_information",
+          "autoExpand": true
+        }
+      ],
+      "relatedProperties": [
+        {
+          "relationshipMeaning": "SameInstance",
+          "propertiesSource": [
+            {
+              "relationship": {
+                "schemaName": "BisCore",
+                "className": "ElementOwnsMultiAspects"
+              },
+              "direction": "Forward",
+              "targetClass": {
+                "schemaName": "BisCore",
+                "className": "ExternalSourceAspect"
+              }
+            }
+          ],
+          "properties": "_none_",
+          "autoExpand": true,
+          "nestedRelatedProperties": [
+            {
+              "relationshipMeaning": "SameInstance",
+              "autoExpand": true,
+              "propertiesSource": [
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ElementIsFromSource"
+                  },
+                  "direction": "Forward"
+                },
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ExternalSourceIsInRepository"
+                  },
+                  "direction": "Forward"
+                }
+              ],
+              "properties": [
+                {
+                  "name": "UserLabel",
+                  "categoryId": "source_information",
+                  "labelOverride": "@BisCore:Properties.SourceInformation.Name@",
+                  "isDisplayed": true
+                },
+                {
+                  "name": "Url",
+                  "categoryId": "source_information",
+                  "labelOverride": "@BisCore:Properties.SourceInformation.Path@"
+                }
+              ]
+            },
+            {
+              "relationshipMeaning": "SameInstance",
+              "autoExpand": true,
+              "propertiesSource": [
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ElementIsFromSource"
+                  },
+                  "direction": "Forward",
+                  "targetClass": {
+                    "schemaName": "BisCore",
+                    "className": "ExternalSourceGroup"
+                  }
+                },
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ExternalSourceGroupGroupsSources"
+                  },
+                  "direction": "Forward"
+                },
+                {
+                  "relationship": {
+                    "schemaName": "BisCore",
+                    "className": "ExternalSourceIsInRepository"
+                  },
+                  "direction": "Forward"
+                }
+              ],
+              "properties": [
+                {
+                  "name": "UserLabel",
+                  "categoryId": "secondary_sources",
+                  "labelOverride": "@BisCore:Properties.SourceInformation.Name@",
+                  "isDisplayed": true
+                },
+                {
+                  "name": "Url",
+                  "categoryId": "secondary_sources",
+                  "labelOverride": "@BisCore:Properties.SourceInformation.Path@"
+                }
+              ]
             }
           ]
         }

--- a/presentation/common/assets/locales/en/BisCore.json
+++ b/presentation/common/assets/locales/en/BisCore.json
@@ -1,10 +1,18 @@
 {
   "Categories": {
-    "SourceFileInformation": "Source File Information"
+    "SourceFileInformation": "Source File Information",
+    "SourceInformation": "Source Information",
+    "SourceInformationModelSource": "Model Source",
+    "SourceInformationSecondarySources": "Secondary Sources"
   },
   "Properties": {
     "SourceElementId": "Source Element ID",
     "SourceFileName": "Source File Name",
-    "SourceFilePath": "Source File Path"
+    "SourceFilePath": "Source File Path",
+    "SourceInformation": {
+      "ElementId": "Element ID",
+      "Name": "Name",
+      "Path": "Path"
+    }
   }
 }


### PR DESCRIPTION
For iModels using BisCore 1.0.13 or above, loading additional related properties using the new `ExternalSource` class.