### PR TITLE
Presentation: Modify TypeDefinitionElement properties display

### DIFF
--- a/common/changes/@bentley/presentation-backend/presentation-type-definition-properties-display-modifications_2021-04-28-05-19.json
+++ b/common/changes/@bentley/presentation-backend/presentation-type-definition-properties-display-modifications_2021-04-28-05-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Start showing more `TypeDefinitionElement` properties",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
+++ b/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
@@ -694,45 +694,35 @@
       "ruleType": "ContentModifier",
       "class": {
         "schemaName": "BisCore",
-        "className": "PhysicalType"
+        "className": "TypeDefinitionElement"
       },
       "propertyOverrides": [
         {
-          "name": "*",
+          "name": "IsPrivate",
           "isDisplayed": false
         },
         {
-          "name": "CodeValue",
-          "isDisplayed": true,
-          "doNotHideOtherPropertiesOnDisplayOverride": true
-        },
-        {
-          "name": "UserLabel",
-          "isDisplayed": true,
-          "doNotHideOtherPropertiesOnDisplayOverride": true
+          "name": "Recipe",
+          "isDisplayed": false
         }
       ]
     },
     {
       "ruleType": "ContentModifier",
+      "requiredSchemas": [
+        {
+          "name": "BisCore",
+          "minVersion": "1.0.11"
+        }
+      ],
       "class": {
         "schemaName": "BisCore",
-        "className": "SpatialLocationType"
+        "className": "PhysicalType"
       },
       "propertyOverrides": [
         {
-          "name": "*",
-          "isDisplayed": false
-        },
-        {
-          "name": "CodeValue",
-          "isDisplayed": true,
-          "doNotHideOtherPropertiesOnDisplayOverride": true
-        },
-        {
-          "name": "UserLabel",
-          "isDisplayed": true,
-          "doNotHideOtherPropertiesOnDisplayOverride": true
+          "name": "PhysicalMaterial",
+          "labelOverride": "Physical Material"
         }
       ]
     },


### PR DESCRIPTION
Instead of blacklisting all and whitelisting only `CodeValue` and `UserLabel`, we now blacklist only specific properties: `IsPrivate` and `Recipe` (they're going to be marked hidden at ECSchema level in upcoming release). Also, until a new BisCore version is released, re-label the `PhysicalMaterial` property.

![image](https://user-images.githubusercontent.com/35135765/116350453-a2cdf000-a7fa-11eb-8c12-31cb805f977b.png)

@diegoalexdiaz, can you confirm we want to see `Model` property?