### PR TITLE
Presentation: presentation-test-app enhancements

### DIFF
--- a/test-apps/presentation-test-app/src/frontend/components/app/App.css
+++ b/test-apps/presentation-test-app/src/frontend/components/app/App.css
@@ -5,7 +5,7 @@
 
 .app {
   display: grid;
-  grid-template-rows: 80px 30px 30px 30px calc(100vh - 80px - 30px - 30px - 30px);
+  grid-template-rows: 30px 40px calc(100vh - 30px - 40px);
   height: 100vh;
   position: relative;
   overflow: hidden;
@@ -15,6 +15,25 @@
   background-color: #222;
   color: white;
   padding-left: 20px;
+}
+
+.app-header h2 {
+  margin: 0;
+}
+
+.app-pickers {
+  display: grid;
+  grid-template-columns: auto 20% 10% 10%;
+  padding: 5px;
+  column-gap: 5px;
+}
+
+.app-pickers > div {
+  width: 100%;
+}
+
+.app-pickers > div > select {
+  width: 100%;
 }
 
 .app-content {

--- a/test-apps/presentation-test-app/src/frontend/components/diagnostics-selector/DiagnosticsSelector.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/diagnostics-selector/DiagnosticsSelector.tsx
@@ -31,6 +31,10 @@ export function DiagnosticsSelector(props: DiagnosticsSelectorProps) {
     },
   }), [shouldMeasurePerformance, editorSeverity, devSeverity]);
 
+  React.useEffect(() => {
+    onDiagnosticsOptionsChanged(result);
+  });
+
   const [position, setPosition] = React.useState<PointProps>();
   const onClose = React.useCallback(() => {
     setPosition(undefined);

--- a/test-apps/presentation-test-app/src/frontend/components/grid-widget/GridWidget.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/grid-widget/GridWidget.tsx
@@ -14,31 +14,36 @@ import { DiagnosticsSelector } from "../diagnostics-selector/DiagnosticsSelector
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const SampleTable = tableWithUnifiedSelection(Table);
 
-export interface Props {
+export interface GridWidgetProps {
   imodel: IModelConnection;
-  rulesetId: string;
+  rulesetId?: string;
 }
-
-export interface State {
-  dataProvider: PresentationTableDataProvider;
-}
-
-export default function GridWidget(props: Props) {
-  const { imodel, rulesetId } = props;
+export function GridWidget(props: GridWidgetProps) {
   const [diagnosticsOptions, setDiagnosticsOptions] = React.useState<DiagnosticsProps>({ ruleDiagnostics: undefined, devDiagnostics: undefined });
-
-  const dataProvider = useDisposable(React.useCallback(
-    () => new PresentationTableDataProvider({ imodel, ruleset: rulesetId, ...diagnosticsOptions }),
-    [imodel, rulesetId, diagnosticsOptions],
-  ));
-
   return (
     <div className="gridwidget">
       <h3>{IModelApp.i18n.translate("Sample:controls.grid")}</h3>
       <DiagnosticsSelector onDiagnosticsOptionsChanged={setDiagnosticsOptions} />
       <div className="gridwidget-content">
-        <SampleTable dataProvider={dataProvider} />
+        {props.rulesetId
+          ? <Grid imodel={props.imodel} rulesetId={props.rulesetId} diagnostics={diagnosticsOptions} />
+          : null
+        }
       </div>
     </div>
   );
+}
+
+interface GridProps {
+  imodel: IModelConnection;
+  rulesetId: string;
+  diagnostics: DiagnosticsProps;
+}
+function Grid(props: GridProps) {
+  const { imodel, rulesetId, diagnostics } = props;
+  const dataProvider = useDisposable(React.useCallback(
+    () => new PresentationTableDataProvider({ imodel, ruleset: rulesetId, ...diagnostics }),
+    [imodel, rulesetId, diagnostics],
+  ));
+  return (<SampleTable dataProvider={dataProvider} />);
 }

--- a/test-apps/presentation-test-app/src/frontend/components/imodel-selector/IModelSelector.css
+++ b/test-apps/presentation-test-app/src/frontend/components/imodel-selector/IModelSelector.css
@@ -3,11 +3,6 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-.IModelSelector {
-  padding: 10px 0px 0px 10px;
-}
-
 .IModelSelector .Error {
-  margin-top: 10px;
   color: red;
 }

--- a/test-apps/presentation-test-app/src/frontend/components/imodel-selector/IModelSelector.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/imodel-selector/IModelSelector.tsx
@@ -6,50 +6,60 @@
 import "./IModelSelector.css";
 import * as React from "react";
 import { IModelApp, IModelConnection } from "@bentley/imodeljs-frontend";
+import { Select, SelectOption } from "@bentley/ui-core";
 import { MyAppFrontend } from "../../api/MyAppFrontend";
 
 export interface Props {
-  onIModelSelected: (imodel?: IModelConnection) => void;
+  onIModelSelected: (imodel?: IModelConnection, path?: string) => void;
+  activeIModelPath?: string;
 }
 
 export interface State {
-  availableImodels: string[];
-  activeImodel?: string;
+  availableImodels: SelectOption[];
   error?: any;
 }
 
-export default class IModelSelector extends React.Component<Props, State> {
+export class IModelSelector extends React.Component<Props, State> {
 
-  constructor(props?: any, context?: any) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
     this.state = { availableImodels: [] };
   }
 
-  public async componentWillMount() { // eslint-disable-line react/no-deprecated
+  public async componentDidMount() {
     const imodels = await MyAppFrontend.getSampleImodels();
     imodels.splice(0, 0, "");
-    this.setState({ availableImodels: imodels });
+    this.setState({
+      availableImodels: imodels.map((path: string) => ({
+        label: path.split(/[\\/]/).pop() ?? "",
+        value: path,
+      })),
+    });
+    if (this.props.activeIModelPath && imodels.includes(this.props.activeIModelPath)) {
+      await this.doOpenIModel(this.props.activeIModelPath);
+    }
   }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private onImodelSelected = async (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const imodelPath = e.currentTarget.value;
+  private async doOpenIModel(imodelPath: string) {
     if (MyAppFrontend.iModel) {
       await MyAppFrontend.iModel.close();
     }
 
     let imodel: IModelConnection | undefined;
-    if (!imodelPath || "" === imodelPath) {
-      this.setState((prev: State) => ({ ...prev, imodel: undefined, error: undefined }));
-    } else {
+    if (imodelPath) {
       try {
         imodel = await MyAppFrontend.openIModel(imodelPath);
-        this.setState((prev: State) => ({ ...prev, activeImodel: imodelPath, error: undefined }));
+        this.setState({ error: undefined });
       } catch (err) {
-        this.setState((prev: State) => ({ ...prev, activeImodel: undefined, error: err }));
+        this.setState({ error: err });
       }
     }
-    this.props.onIModelSelected(imodel);
+    this.props.onIModelSelected(imodel, imodelPath);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private onImodelSelected = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    await this.doOpenIModel(e.currentTarget.value);
   };
 
   public render() {
@@ -59,13 +69,12 @@ export default class IModelSelector extends React.Component<Props, State> {
 
     return (
       <div className="IModelSelector">
-        {IModelApp.i18n.translate("Sample:controls.notifications.select-imodel")}:
-        {/* eslint-disable-next-line jsx-a11y/no-onchange */}
-        <select onChange={this.onImodelSelected}>
-          {this.state.availableImodels.map((path: string) => (
-            <option key={path} value={path}>{path.split(/[\\/]/).pop()}</option>
-          ))}
-        </select>
+        <Select
+          options={this.state.availableImodels}
+          defaultValue={this.props.activeIModelPath}
+          placeholder={IModelApp.i18n.translate("Sample:controls.notifications.select-imodel")}
+          onChange={this.onImodelSelected}
+        />
         {error}
       </div>
     );

--- a/test-apps/presentation-test-app/src/frontend/components/ruleset-selector/RulesetSelector.css
+++ b/test-apps/presentation-test-app/src/frontend/components/ruleset-selector/RulesetSelector.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
-
-.RulesetSelector {
-  padding: 10px 0px 0px 10px;
-}

--- a/test-apps/presentation-test-app/src/frontend/components/ruleset-selector/RulesetSelector.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/ruleset-selector/RulesetSelector.tsx
@@ -2,20 +2,19 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
-import "./RulesetSelector.css";
 import * as React from "react";
 import { IModelApp } from "@bentley/imodeljs-frontend";
+import { Select } from "@bentley/ui-core";
 import { MyAppFrontend } from "../../api/MyAppFrontend";
 
 export interface RulesetSelectorProps {
-  onRulesetSelected?: (rulesetId?: string) => void;
+  onRulesetSelected: (rulesetId?: string) => void;
+  activeRulesetId?: string;
 }
 export interface RulesetSelectorState {
   availableRulesets?: string[];
-  activeRulesetId?: string;
 }
-export default class RulesetSelector extends React.Component<RulesetSelectorProps, RulesetSelectorState> {
+export class RulesetSelector extends React.Component<RulesetSelectorProps, RulesetSelectorState> {
   constructor(props: RulesetSelectorProps) {
     super(props);
     this.state = {};
@@ -26,16 +25,11 @@ export default class RulesetSelector extends React.Component<RulesetSelectorProp
   }
   private async initAvailableRulesets() {
     const rulesetIds = await MyAppFrontend.getAvailableRulesets();
-    const activeRulesetId = rulesetIds.length > 0 ? rulesetIds[0] : undefined;
-    this.setState({ availableRulesets: rulesetIds, activeRulesetId });
-  }
-  public componentDidUpdate(_prevProps: RulesetSelectorProps, prevState: RulesetSelectorState) {
-    if (this.props.onRulesetSelected && this.state.activeRulesetId !== prevState.activeRulesetId)
-      this.props.onRulesetSelected(this.state.activeRulesetId);
+    this.setState({ availableRulesets: rulesetIds });
   }
   // eslint-disable-next-line @typescript-eslint/naming-convention
   private onSelectedRulesetIdChanged = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    this.setState({ activeRulesetId: e.target.value });
+    this.props.onRulesetSelected(e.target.value);
   };
   public render() {
     if (!this.state.availableRulesets)
@@ -44,13 +38,12 @@ export default class RulesetSelector extends React.Component<RulesetSelectorProp
       return (<div className="RulesetSelector">{IModelApp.i18n.translate("Sample:controls.notifications.no-available-rulesets")}</div>);
     return (
       <div className="RulesetSelector">
-        {IModelApp.i18n.translate("Sample:controls.notifications.select-ruleset")}:
-        {/* eslint-disable-next-line jsx-a11y/no-onchange */}
-        <select onChange={this.onSelectedRulesetIdChanged}>
-          {this.state.availableRulesets.map((rulesetId: string) => (
-            <option value={rulesetId} key={rulesetId}>{rulesetId}</option>
-          ))}
-        </select>
+        <Select
+          options={this.state.availableRulesets}
+          defaultValue={this.props.activeRulesetId}
+          placeholder={IModelApp.i18n.translate("Sample:controls.notifications.select-ruleset")}
+          onChange={this.onSelectedRulesetIdChanged}
+        />
       </div>
     );
   }

--- a/test-apps/presentation-test-app/src/frontend/components/tree-widget/TreeWidget.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/tree-widget/TreeWidget.tsx
@@ -3,15 +3,56 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
-import { IModelConnection } from "@bentley/imodeljs-frontend";
+import { IModelApp, IModelConnection } from "@bentley/imodeljs-frontend";
+import { DiagnosticsProps } from "@bentley/presentation-components";
+import { FilteringInput } from "@bentley/ui-components";
+import { DiagnosticsSelector } from "../diagnostics-selector/DiagnosticsSelector";
 import { Tree } from "./Tree";
 
 interface Props {
   imodel: IModelConnection;
-  rulesetId: string;
+  rulesetId?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const TreeWidget: React.FC<Props> = (props: Props) => {
-  return <Tree imodel={props.imodel} rulesetId={props.rulesetId} />;
-};
+export function TreeWidget(props: Props) {
+  const [diagnosticsOptions, setDiagnosticsOptions] = React.useState<DiagnosticsProps>({ ruleDiagnostics: undefined, devDiagnostics: undefined });
+
+  const [filter, setFilter] = React.useState("");
+  const [isFiltering, setIsFiltering] = React.useState(false);
+  const [matchesCount, setMatchesCount] = React.useState<number>();
+  const [activeMatchIndex, setActiveMatchIndex] = React.useState(0);
+
+  const onFilteringStateChange = React.useCallback((newIsFiltering: boolean, newMatchesCount: number | undefined) => {
+    setIsFiltering(newIsFiltering);
+    setMatchesCount(newMatchesCount);
+  }, []);
+
+  return (
+    <div className="treewidget">
+      <div className="treewidget-header">
+        <h3>{IModelApp.i18n.translate("Sample:controls.tree")}</h3>
+        <DiagnosticsSelector onDiagnosticsOptionsChanged={setDiagnosticsOptions} />
+        {props.rulesetId ? <FilteringInput
+          filteringInProgress={isFiltering}
+          onFilterCancel={() => { setFilter(""); }}
+          onFilterClear={() => { setFilter(""); }}
+          onFilterStart={(newFilter) => { setFilter(newFilter); }}
+          resultSelectorProps={{
+            onSelectedChanged: (index) => setActiveMatchIndex(index),
+            resultCount: matchesCount || 0,
+          }} /> : null}
+      </div>
+      <div className="filteredTree">
+        {props.rulesetId ? <>
+          <Tree
+            imodel={props.imodel}
+            rulesetId={props.rulesetId}
+            diagnostics={diagnosticsOptions}
+            filtering={{ filter, activeMatchIndex, onFilteringStateChange }}
+          />
+          {isFiltering ? <div className="filteredTreeOverlay" /> : null}
+        </> : null}
+      </div>
+    </div>
+  );
+}

--- a/test-apps/presentation-test-app/src/frontend/components/unit-system-selector/UnitSystemSelector.css
+++ b/test-apps/presentation-test-app/src/frontend/components/unit-system-selector/UnitSystemSelector.css
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
-
-.UnitSystemSelector {
-  padding: 10px 0px 0px 10px;
-}

--- a/test-apps/presentation-test-app/src/frontend/components/unit-system-selector/UnitSystemSelector.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/unit-system-selector/UnitSystemSelector.tsx
@@ -2,49 +2,45 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
-import "./UnitSystemSelector.css";
 import * as React from "react";
 import { IModelApp } from "@bentley/imodeljs-frontend";
 import { PresentationUnitSystem } from "@bentley/presentation-common";
+import { Select } from "@bentley/ui-core";
 
 export interface UnitSystemSelectorProps {
   selectedUnitSystem: PresentationUnitSystem | undefined;
   onUnitSystemSelected: (unitSystem: PresentationUnitSystem | undefined) => void;
 }
 
-export default function UnitSystemSelector(props: UnitSystemSelectorProps) { // eslint-disable-line @typescript-eslint/naming-convention
-  const { selectedUnitSystem, onUnitSystemSelected } = props;
-  const memoizedOnUnitSystemSelected = React.useCallback((evt: React.ChangeEvent<HTMLSelectElement>) => {
-    if (!onUnitSystemSelected)
-      return;
+export function UnitSystemSelector(props: UnitSystemSelectorProps) {
+  const { selectedUnitSystem, onUnitSystemSelected: onUnitSystemSelectedProp } = props;
+  const onUnitSystemSelected = React.useCallback((evt: React.ChangeEvent<HTMLSelectElement>) => {
     switch (evt.target.value) {
       case PresentationUnitSystem.BritishImperial:
-        onUnitSystemSelected(PresentationUnitSystem.BritishImperial);
+        onUnitSystemSelectedProp(PresentationUnitSystem.BritishImperial);
         break;
       case PresentationUnitSystem.Metric:
-        onUnitSystemSelected(PresentationUnitSystem.Metric);
+        onUnitSystemSelectedProp(PresentationUnitSystem.Metric);
         break;
       case PresentationUnitSystem.UsCustomary:
-        onUnitSystemSelected(PresentationUnitSystem.UsCustomary);
+        onUnitSystemSelectedProp(PresentationUnitSystem.UsCustomary);
         break;
       case PresentationUnitSystem.UsSurvey:
-        onUnitSystemSelected(PresentationUnitSystem.UsSurvey);
+        onUnitSystemSelectedProp(PresentationUnitSystem.UsSurvey);
         break;
       default:
-        onUnitSystemSelected(undefined);
+        onUnitSystemSelectedProp(undefined);
     }
-  }, [onUnitSystemSelected]);
+  }, [onUnitSystemSelectedProp]);
 
   return (
     <div className="UnitSystemSelector">
-      {IModelApp.i18n.translate("Sample:controls.notifications.select-unit-system")}:
-      {/* eslint-disable-next-line jsx-a11y/no-onchange */}
-      <select onChange={memoizedOnUnitSystemSelected} value={selectedUnitSystem}>
-        {availableUnitSystems.map(({ label, value }: { label: string, value: string }) => (
-          <option value={value} key={value}>{label}</option>
-        ))}
-      </select>
+      <Select
+        options={availableUnitSystems}
+        defaultValue={selectedUnitSystem}
+        placeholder={IModelApp.i18n.translate("Sample:controls.notifications.select-unit-system")}
+        onChange={onUnitSystemSelected}
+      />
     </div>
   );
 }


### PR DESCRIPTION
- Fix the app not being able to re-open another iModel when one was already opened.
- Fix components not getting default diagnostics options until the dialog is opened and closed.
- Make app header smaller.
- Put all pickers into one line to make more space for content.
- Add ability for the app to remember imodel, ruleset and unit system.
- Change the app to use a new client ID on every page load instead of using one from local store. Allows reloading all rulesets by refreshing the page instead of requiring a backend restart.