### PR TITLE
Fixes to desktop/mobile authorization

### DIFF
--- a/common/api/electron-manager.api.md
+++ b/common/api/electron-manager.api.md
@@ -4,16 +4,19 @@
 
 ```ts
 
+import { AccessToken } from '@bentley/itwin-client';
 import { AsyncMethodsOf } from '@bentley/imodeljs-frontend';
 import { BrowserWindow } from 'electron';
 import { BrowserWindowConstructorOptions } from 'electron';
 import { IpcHandler } from '@bentley/imodeljs-backend';
+import { NativeAppAuthorizationBackend } from '@bentley/imodeljs-backend';
 import { NativeAppAuthorizationConfiguration } from '@bentley/imodeljs-common';
 import { NativeAppOpts } from '@bentley/imodeljs-frontend';
 import { NativeHostOpts } from '@bentley/imodeljs-backend';
 import { PromiseReturnType } from '@bentley/imodeljs-frontend';
 import { RpcConfiguration } from '@bentley/imodeljs-common';
 import { RpcInterfaceDefinition } from '@bentley/imodeljs-common';
+import { TokenResponse } from '@openid/appauth';
 
 // @beta
 export class ElectronApp {
@@ -36,6 +39,8 @@ export class ElectronHost {
     static get app(): Electron.App;
     // (undocumented)
     static appIconPath: string;
+    // @internal (undocumented)
+    static get authorization(): ElectronAuthorizationBackend;
     // (undocumented)
     static get electron(): typeof Electron;
     // (undocumented)
@@ -65,6 +70,7 @@ export interface ElectronHostOptions {
     frontendURL?: string;
     iconName?: string;
     ipcHandlers?: (typeof IpcHandler)[];
+    noInitializeAuthClient?: boolean;
     rpcInterfaces?: RpcInterfaceDefinition[];
     webResourcesPath?: string;
 }

--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -3404,10 +3404,11 @@ export class ModelSelector extends DefinitionElement implements ModelSelectorPro
 
 // @internal (undocumented)
 export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClient {
+    protected constructor(config?: NativeAppAuthorizationConfiguration);
     // (undocumented)
     protected _accessToken?: AccessToken;
     // (undocumented)
-    config: NativeAppAuthorizationConfiguration;
+    config?: NativeAppAuthorizationConfiguration;
     // (undocumented)
     expireSafety: number;
     // (undocumented)
@@ -3415,9 +3416,11 @@ export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClie
     // (undocumented)
     getClientRequestContext(): ClientRequestContext;
     // (undocumented)
-    initialize(props: SessionProps, config?: NativeAppAuthorizationConfiguration): Promise<void>;
+    initialize(config?: NativeAppAuthorizationConfiguration): Promise<void>;
     // (undocumented)
     get isAuthorized(): boolean;
+    // (undocumented)
+    issuerUrl?: string;
     // (undocumented)
     protected abstract refreshToken(): Promise<AccessToken>;
     // (undocumented)

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4708,11 +4708,10 @@ export enum MonochromeMode {
     Scaled = 1
 }
 
-// @alpha
+// @beta
 export interface NativeAppAuthorizationConfiguration {
     readonly clientId: string;
     readonly expiryBuffer?: number;
-    // (undocumented)
     issuerUrl?: string;
     readonly redirectUri?: string;
     readonly scope: string;
@@ -4735,10 +4734,10 @@ export interface NativeAppFunctions {
     initializeAuth: (props: ClientRequestContextProps, config?: NativeAppAuthorizationConfiguration) => Promise<number>;
     overrideInternetConnectivity: (_overriddenBy: OverriddenBy, _status: InternetConnectivityStatus) => Promise<void>;
     requestCancelDownloadBriefcase: (_fileName: string) => Promise<boolean>;
+    // (undocumented)
+    setAccessTokenProps: (token: AccessTokenProps) => Promise<void>;
     signIn: () => Promise<void>;
     signOut: () => Promise<void>;
-    // (undocumented)
-    silentLogin: (token: AccessTokenProps) => Promise<void>;
     storageGet: (_storageId: string, _key: string) => Promise<StorageValue | undefined>;
     storageKeys: (_storageId: string) => Promise<string[]>;
     storageMgrClose: (_storageId: string, _deleteOnClose: boolean) => Promise<void>;

--- a/common/api/mobile-manager.api.md
+++ b/common/api/mobile-manager.api.md
@@ -4,11 +4,13 @@
 
 ```ts
 
+import { AccessToken } from '@bentley/itwin-client';
 import { AsyncMethodsOf } from '@bentley/imodeljs-frontend';
 import { BeEvent } from '@bentley/bentleyjs-core';
 import { CancelRequest } from '@bentley/itwin-client';
 import { ClientRequestContext } from '@bentley/bentleyjs-core';
 import { IModelAppOptions } from '@bentley/imodeljs-frontend';
+import { NativeAppAuthorizationBackend } from '@bentley/imodeljs-backend';
 import { NativeAppAuthorizationConfiguration } from '@bentley/imodeljs-common';
 import { NativeAppOpts } from '@bentley/imodeljs-frontend';
 import { NativeHostOpts } from '@bentley/imodeljs-backend';
@@ -150,6 +152,8 @@ export abstract class MobileDevice {
 
 // @beta (undocumented)
 export class MobileHost {
+    // @internal (undocumented)
+    static get authorization(): MobileAuthorizationBackend;
     // (undocumented)
     static get device(): MobileDevice;
     // @internal (undocumented)
@@ -178,6 +182,7 @@ export interface MobileHostOpts extends NativeHostOpts {
         device?: MobileDevice;
         rpcInterfaces?: RpcInterfaceDefinition[];
         authConfig?: NativeAppAuthorizationConfiguration;
+        noInitializeAuthClient?: boolean;
     };
 }
 

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -336,7 +336,7 @@ public;ModelProps
 public;ModelQueryParams 
 public;ModelSelectorProps 
 public;MonochromeMode
-alpha;NativeAppAuthorizationConfiguration
+beta;NativeAppAuthorizationConfiguration
 internal;nativeAppChannel = "nativeApp"
 internal;NativeAppFunctions
 internal;NativeAppNotifications

--- a/common/changes/@bentley/electron-manager/native-auth-fixes_2021-04-28-15-40.json
+++ b/common/changes/@bentley/electron-manager/native-auth-fixes_2021-04-28-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/electron-manager",
+      "comment": "Fixes to desktop/mobile authorization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/electron-manager",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/common/changes/@bentley/extension-cli/native-auth-fixes_2021-04-28-15-40.json
+++ b/common/changes/@bentley/extension-cli/native-auth-fixes_2021-04-28-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/extension-cli",
+      "comment": "Fixes to desktop/mobile authorization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/extension-cli",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/native-auth-fixes_2021-04-28-15-40.json
+++ b/common/changes/@bentley/imodeljs-backend/native-auth-fixes_2021-04-28-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Fixes to desktop/mobile authorization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/native-auth-fixes_2021-04-28-15-40.json
+++ b/common/changes/@bentley/imodeljs-common/native-auth-fixes_2021-04-28-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Fixes to desktop/mobile authorization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/native-auth-fixes_2021-04-28-15-40.json
+++ b/common/changes/@bentley/imodeljs-frontend/native-auth-fixes_2021-04-28-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fixes to desktop/mobile authorization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/common/changes/@bentley/mobile-manager/native-auth-fixes_2021-04-28-15-40.json
+++ b/common/changes/@bentley/mobile-manager/native-auth-fixes_2021-04-28-15-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/mobile-manager",
+      "comment": "Fixes to desktop/mobile authorization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/mobile-manager",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/core/backend/src/NativeHost.ts
+++ b/core/backend/src/NativeHost.ts
@@ -56,7 +56,7 @@ export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClie
   public async initialize(config?: NativeAppAuthorizationConfiguration) {
     this.config = config ?? this.config;
     if (!this.config)
-      throw new IModelError(AuthStatus.Error, 'Must specify a valid configuration when initializing authorization');
+      throw new IModelError(AuthStatus.Error, "Must specify a valid configuration when initializing authorization");
     if (this.config.expiryBuffer)
       this.expireSafety = this.config.expiryBuffer;
     this.issuerUrl = this.config.issuerUrl ?? await this.getUrl(this.getClientRequestContext());

--- a/core/backend/src/NativeHost.ts
+++ b/core/backend/src/NativeHost.ts
@@ -7,9 +7,9 @@
  */
 
 import { join } from "path";
-import { BeEvent, ClientRequestContext, Config, GuidString, SessionProps } from "@bentley/bentleyjs-core";
+import { AuthStatus, BeEvent, ClientRequestContext, Config, GuidString, SessionProps } from "@bentley/bentleyjs-core";
 import {
-  BriefcaseProps, InternetConnectivityStatus, LocalBriefcaseProps, NativeAppAuthorizationConfiguration, nativeAppChannel, NativeAppFunctions,
+  BriefcaseProps, IModelError, InternetConnectivityStatus, LocalBriefcaseProps, NativeAppAuthorizationConfiguration, nativeAppChannel, NativeAppFunctions,
   NativeAppNotifications, nativeAppNotify, OverriddenBy, RequestNewBriefcaseProps, StorageValue,
 } from "@bentley/imodeljs-common";
 import { AccessToken, AccessTokenProps, ImsAuthorizationClient, RequestGlobalOptions } from "@bentley/itwin-client";
@@ -25,8 +25,15 @@ export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClie
   public abstract signIn(): Promise<void>;
   public abstract signOut(): Promise<void>;
   protected abstract refreshToken(): Promise<AccessToken>;
-  public config!: NativeAppAuthorizationConfiguration;
+  public config?: NativeAppAuthorizationConfiguration;
   public expireSafety = 60 * 10; // refresh token 10 minutes before real expiration time
+  public issuerUrl?: string;
+
+  protected constructor(config?: NativeAppAuthorizationConfiguration) {
+    super();
+    this.config = config;
+  }
+
   public get isAuthorized(): boolean {
     return undefined !== this._accessToken && !this._accessToken.isExpired(this.expireSafety);
   }
@@ -37,6 +44,7 @@ export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClie
     this._accessToken = token;
     NativeHost.onUserStateChanged.raiseEvent(token);
   }
+
   public async getAccessToken(): Promise<AccessToken> {
     if (!this.isAuthorized)
       this.setAccessToken(await this.refreshToken());
@@ -44,14 +52,14 @@ export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClie
   }
 
   public getClientRequestContext() { return ClientRequestContext.fromJSON(IModelHost.session); }
-  public async initialize(props: SessionProps, config?: NativeAppAuthorizationConfiguration) {
-    if (config)
-      this.config = config;
+
+  public async initialize(config?: NativeAppAuthorizationConfiguration) {
+    this.config = config ?? this.config;
+    if (!this.config)
+      throw new IModelError(AuthStatus.Error, 'Must specify a valid configuration when initializing authorization');
     if (this.config.expiryBuffer)
       this.expireSafety = this.config.expiryBuffer;
-    IModelHost.session.applicationId = props.applicationId;
-    IModelHost.applicationVersion = props.applicationVersion;
-    IModelHost.sessionId = props.sessionId;
+    this.issuerUrl = this.config.issuerUrl ?? await this.getUrl(this.getClientRequestContext());
   }
 }
 
@@ -61,11 +69,15 @@ export abstract class NativeAppAuthorizationBackend extends ImsAuthorizationClie
 class NativeAppHandler extends IpcHandler implements NativeAppFunctions {
   public get channelName() { return nativeAppChannel; }
 
-  public async silentLogin(token: AccessTokenProps) {
+  public async setAccessTokenProps(token: AccessTokenProps) {
     NativeHost.authorization.setAccessToken(AccessToken.fromJson(token));
   }
   public async initializeAuth(props: SessionProps, config?: NativeAppAuthorizationConfiguration): Promise<number> {
-    await NativeHost.authorization.initialize(props, config);
+    IModelHost.session.applicationId = props.applicationId;
+    IModelHost.applicationVersion = props.applicationVersion;
+    IModelHost.sessionId = props.sessionId;
+
+    await NativeHost.authorization.initialize(config);
     return NativeHost.authorization.expireSafety;
   }
   public async signIn(): Promise<void> {

--- a/core/common/src/NativeAppProps.ts
+++ b/core/common/src/NativeAppProps.ts
@@ -48,9 +48,12 @@ export interface NativeAppNotifications {
 
 /**
  * Client configuration to generate OIDC/OAuth tokens for native applications
- * @alpha
+ * @beta
  */
 export interface NativeAppAuthorizationConfiguration {
+  /**
+   * The OAuth token issuer URL. Defaults to Bentley's auth URL if undefined.
+   */
   issuerUrl?: string;
 
   /**
@@ -79,7 +82,7 @@ export interface NativeAppAuthorizationConfiguration {
  * @internal
  */
 export interface NativeAppFunctions {
-  silentLogin: (token: AccessTokenProps) => Promise<void>;
+  setAccessTokenProps: (token: AccessTokenProps) => Promise<void>;
 
   /** returns expirySafety, in seconds */
   initializeAuth: (props: ClientRequestContextProps, config?: NativeAppAuthorizationConfiguration) => Promise<number>;

--- a/core/electron-manager/src/backend/ElectronAuthorizationBackend.ts
+++ b/core/electron-manager/src/backend/ElectronAuthorizationBackend.ts
@@ -11,8 +11,8 @@
 // cSpell:ignore openid appauth signin Pkce Signout
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { assert, AuthStatus, BentleyError, ClientRequestContext, Logger, SessionProps } from "@bentley/bentleyjs-core";
-import { IModelHost, NativeAppAuthorizationBackend, NativeHost } from "@bentley/imodeljs-backend";
+import { assert, AuthStatus, BentleyError, ClientRequestContext, Logger } from "@bentley/bentleyjs-core";
+import { IModelHost, NativeAppAuthorizationBackend } from "@bentley/imodeljs-backend";
 import { NativeAppAuthorizationConfiguration } from "@bentley/imodeljs-common";
 import { AccessToken, request as httpRequest, RequestOptions } from "@bentley/itwin-client";
 import {
@@ -52,12 +52,12 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
    */
   public async initialize(config?: NativeAppAuthorizationConfiguration): Promise<void> {
     await super.initialize(config);
-    assert(this.config !== undefined && this.issuerUrl != undefined, "URL of authorization provider was not initialized");
+    assert(this.config !== undefined && this.issuerUrl !== undefined, "URL of authorization provider was not initialized");
 
-    this._tokenStore = new ElectronTokenStore(this.config!.clientId);
+    this._tokenStore = new ElectronTokenStore(this.config.clientId);
 
     const tokenRequestor = new NodeRequestor(); // the Node.js based HTTP client
-    this._configuration = await AuthorizationServiceConfiguration.fetchFromIssuer(this.issuerUrl!, tokenRequestor);
+    this._configuration = await AuthorizationServiceConfiguration.fetchFromIssuer(this.issuerUrl, tokenRequestor);
     Logger.logTrace(loggerCategory, "Initialized service configuration", () => ({ configuration: this._configuration }));
 
     // Attempt to load the access token from store

--- a/core/electron-manager/src/backend/ElectronAuthorizationBackend.ts
+++ b/core/electron-manager/src/backend/ElectronAuthorizationBackend.ts
@@ -96,6 +96,7 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
   public async signIn(): Promise<void> {
     if (!this._configuration)
       throw new BentleyError(AuthStatus.Error, "Not initialized. First call initialize()", Logger.logError, loggerCategory);
+    assert(this.config !== undefined);
 
     // Attempt to load the access token from store
     const token = await this.loadAccessToken();
@@ -103,7 +104,7 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
       return this.setAccessToken(token);
 
     // Create the authorization request
-    const nativeConfig = this.config!;
+    const nativeConfig = this.config;
     const authReqJson: AuthorizationRequestJson = {
       client_id: nativeConfig.clientId,
       redirect_uri: this.redirectUri,
@@ -228,8 +229,9 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
   private async swapAuthorizationCodeForTokens(authCode: string, codeVerifier: string): Promise<TokenResponse> {
     if (!this._configuration)
       throw new BentleyError(AuthStatus.Error, "Not initialized. First call initialize()", Logger.logError, loggerCategory);
+    assert(this.config !== undefined);
 
-    const nativeConfig = this.config!;
+    const nativeConfig = this.config;
     const extras: StringMap = { code_verifier: codeVerifier };
     const tokenRequestJson: TokenRequestJson = {
       grant_type: GRANT_TYPE_AUTHORIZATION_CODE,
@@ -248,12 +250,13 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
   private async makeRefreshAccessTokenRequest(refreshToken: string): Promise<TokenResponse> {
     if (!this._configuration)
       throw new BentleyError(AuthStatus.Error, "Not initialized. First call initialize()", Logger.logError, loggerCategory);
+    assert(this.config !== undefined);
 
     const tokenRequestJson: TokenRequestJson = {
       grant_type: GRANT_TYPE_REFRESH_TOKEN,
       refresh_token: refreshToken,
       redirect_uri: this.redirectUri,
-      client_id: this.config!.clientId,
+      client_id: this.config.clientId,
     };
 
     const tokenRequest = new TokenRequest(tokenRequestJson);
@@ -265,13 +268,14 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
   private async makeRevokeTokenRequest(): Promise<void> {
     if (!this._tokenResponse)
       throw new BentleyError(AuthStatus.Error, "Missing refresh token. First call signIn() and ensure it's successful", Logger.logError, loggerCategory);
+    assert(this.config !== undefined);
 
     const refreshToken = this._tokenResponse.refreshToken!;
 
     const revokeTokenRequestJson: RevokeTokenRequestJson = {
       token: refreshToken,
       token_type_hint: "refresh_token",
-      client_id: this.config!.clientId,
+      client_id: this.config.clientId,
     };
 
     const revokeTokenRequest = new RevokeTokenRequest(revokeTokenRequestJson);

--- a/core/electron-manager/src/backend/ElectronAuthorizationBackend.ts
+++ b/core/electron-manager/src/backend/ElectronAuthorizationBackend.ts
@@ -44,7 +44,6 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
   }
 
   public get redirectUri() { return this.config?.redirectUri ?? ElectronAuthorizationBackend.defaultRedirectUri; }
-  private get isInitialized() { return this._configuration !== undefined; }
 
   /**
    * Used to initialize the client - must be awaited before any other methods are called.
@@ -95,7 +94,7 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
    *   (ii) an interactive signin that requires user input.
    */
   public async signIn(): Promise<void> {
-    if (!this.isInitialized)
+    if (!this._configuration)
       throw new BentleyError(AuthStatus.Error, "Not initialized. First call initialize()", Logger.logError, loggerCategory);
 
     // Attempt to load the access token from store
@@ -183,7 +182,7 @@ export class ElectronAuthorizationBackend extends NativeAppAuthorizationBackend 
     const options: RequestOptions = {
       method: "GET",
       headers: {
-        authorization: `Bearer ${tokenResponse.accessToken} `,
+        authorization: `Bearer ${tokenResponse.accessToken}`,
       },
       accept: "application/json",
     };

--- a/core/electron-manager/src/backend/ElectronHost.ts
+++ b/core/electron-manager/src/backend/ElectronHost.ts
@@ -119,11 +119,7 @@ export class ElectronHost {
     let assetPath = requestedUrl.substr(this._electronFrontend.length);
     if (assetPath.length === 0)
       assetPath = "index.html";
-
-    // NEEDS_WORK: Remove this after migration to DesktopAuthorizationClient
-    assetPath = assetPath.replace("signin-callback", "index.html");
     assetPath = path.normalize(`${this.webResourcesPath}/${assetPath}`);
-
     // File protocols don't follow symlinks, so we need to resolve this to a real path.
     // However, if the file doesn't exist, it's fine to return an invalid path here - the request will just fail with net::ERR_FILE_NOT_FOUND
     try {

--- a/core/electron-manager/src/backend/ElectronHost.ts
+++ b/core/electron-manager/src/backend/ElectronHost.ts
@@ -286,7 +286,7 @@ export class ElectronHost {
 
     const authorizationBackend = new ElectronAuthorizationBackend(opts.electronHost?.authConfig);
     const connectivityStatus = NativeHost.checkInternetConnectivity();
-    if (opts.electronHost?.authConfig && true != opts.electronHost?.noInitializeAuthClient && connectivityStatus === InternetConnectivityStatus.Online) {
+    if (opts.electronHost?.authConfig && true !== opts.electronHost?.noInitializeAuthClient && connectivityStatus === InternetConnectivityStatus.Online) {
       await authorizationBackend.initialize(opts.electronHost?.authConfig);
     }
     IModelHost.authorizationClient = authorizationBackend;

--- a/core/electron-manager/src/backend/ElectronHost.ts
+++ b/core/electron-manager/src/backend/ElectronHost.ts
@@ -13,7 +13,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { BeDuration, IModelStatus, ProcessDetector } from "@bentley/bentleyjs-core";
 import { IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@bentley/imodeljs-backend";
-import { IModelError, IpcListener, IpcSocketBackend, NativeAppAuthorizationConfiguration, RemoveFunction, RpcConfiguration, RpcInterfaceDefinition } from "@bentley/imodeljs-common";
+import { IModelError, InternetConnectivityStatus, IpcListener, IpcSocketBackend, NativeAppAuthorizationConfiguration, RemoveFunction, RpcConfiguration, RpcInterfaceDefinition } from "@bentley/imodeljs-common";
 import { ElectronRpcConfiguration, ElectronRpcManager } from "../common/ElectronRpcManager";
 import { ElectronAuthorizationBackend } from "./ElectronAuthorizationBackend";
 
@@ -57,8 +57,10 @@ export interface ElectronHostOptions {
   rpcInterfaces?: RpcInterfaceDefinition[];
   /** list of [IpcHandler]($common) classes to register */
   ipcHandlers?: (typeof IpcHandler)[];
-  /** Authorization configuration */
+  /** if present, [[NativeHost.authorizationClient]] will be set to an instance of NativeAppAuthorizationBackend and will be initialized. */
   authConfig?: NativeAppAuthorizationConfiguration;
+  /** if true, do not attempt to initialize AuthorizationClient on startup */
+  noInitializeAuthClient?: boolean;
   applicationName?: never; // this should be supplied in NativeHostOpts
 }
 
@@ -99,6 +101,9 @@ export class ElectronHost {
   public static get ipcMain() { return this._electron.ipcMain; }
   public static get app() { return this._electron.app; }
   public static get electron() { return this._electron; }
+
+  /** @internal */
+  public static get authorization() { return IModelHost.authorizationClient as ElectronAuthorizationBackend; }
 
   private constructor() { }
 
@@ -278,7 +283,13 @@ export class ElectronHost {
       ElectronAppHandler.register();
       opts.electronHost?.ipcHandlers?.forEach((ipc) => ipc.register());
     }
-    IModelHost.authorizationClient = new ElectronAuthorizationBackend(opts.electronHost?.authConfig);
+
+    const authorizationBackend = new ElectronAuthorizationBackend(opts.electronHost?.authConfig);
+    const connectivityStatus = NativeHost.checkInternetConnectivity();
+    if (opts.electronHost?.authConfig && true != opts.electronHost?.noInitializeAuthClient && connectivityStatus === InternetConnectivityStatus.Online) {
+      await authorizationBackend.initialize(opts.electronHost?.authConfig);
+    }
+    IModelHost.authorizationClient = authorizationBackend;
   }
 }
 

--- a/core/electron-manager/src/backend/LoopbackWebServer.ts
+++ b/core/electron-manager/src/backend/LoopbackWebServer.ts
@@ -71,7 +71,7 @@ export class LoopbackWebServer {
   }
 
   /** Listen/Handle browser events */
-  private static onBrowserRequest(httpRequest: Http.IncomingMessage, _httpResponse: Http.ServerResponse): void {
+  private static onBrowserRequest(httpRequest: Http.IncomingMessage, httpResponse: Http.ServerResponse): void {
     if (!httpRequest.url)
       return;
 
@@ -101,6 +101,9 @@ export class LoopbackWebServer {
       authorizationError = { error, error_description: errorDescription, error_uri: errorUri, state }; // eslint-disable-line @typescript-eslint/naming-convention
     } else {
       authorizationResponse = { code: code!, state };
+      httpResponse.writeHead(200, { "Content-Type": 'text/html' });
+      httpResponse.write('<h1><h1>Sign in was successful!</h1>Close this window and return to the application</h1>'); // TODO: Needs localization
+      httpResponse.end();
     }
     authorizationEvents.onAuthorizationResponse.raiseEvent(authorizationError, authorizationResponse);
 

--- a/core/electron-manager/src/backend/LoopbackWebServer.ts
+++ b/core/electron-manager/src/backend/LoopbackWebServer.ts
@@ -99,10 +99,12 @@ export class LoopbackWebServer {
       const errorUri = searchParams.get("error_uri") || undefined;
       const errorDescription = searchParams.get("error_description") || undefined;
       authorizationError = { error, error_description: errorDescription, error_uri: errorUri, state }; // eslint-disable-line @typescript-eslint/naming-convention
+      httpResponse.write('<h1>Sign in error!</h1>'); // TODO: Needs localization
+      httpResponse.end();
     } else {
       authorizationResponse = { code: code!, state };
       httpResponse.writeHead(200, { "Content-Type": 'text/html' });
-      httpResponse.write('<h1><h1>Sign in was successful!</h1>Close this window and return to the application</h1>'); // TODO: Needs localization
+      httpResponse.write('<h1>Sign in was successful!</h1>You can close this browser window and return to the application'); // TODO: Needs localization
       httpResponse.end();
     }
     authorizationEvents.onAuthorizationResponse.raiseEvent(authorizationError, authorizationResponse);

--- a/core/electron-manager/src/backend/LoopbackWebServer.ts
+++ b/core/electron-manager/src/backend/LoopbackWebServer.ts
@@ -99,12 +99,12 @@ export class LoopbackWebServer {
       const errorUri = searchParams.get("error_uri") || undefined;
       const errorDescription = searchParams.get("error_description") || undefined;
       authorizationError = { error, error_description: errorDescription, error_uri: errorUri, state }; // eslint-disable-line @typescript-eslint/naming-convention
-      httpResponse.write('<h1>Sign in error!</h1>'); // TODO: Needs localization
+      httpResponse.write("<h1>Sign in error!</h1>"); // TODO: Needs localization
       httpResponse.end();
     } else {
       authorizationResponse = { code: code!, state };
-      httpResponse.writeHead(200, { "Content-Type": 'text/html' });
-      httpResponse.write('<h1>Sign in was successful!</h1>You can close this browser window and return to the application'); // TODO: Needs localization
+      httpResponse.writeHead(200, { "Content-Type": "text/html" }); //  eslint-disable-line @typescript-eslint/naming-convention
+      httpResponse.write("<h1>Sign in was successful!</h1>You can close this browser window and return to the application"); // TODO: Needs localization
       httpResponse.end();
     }
     authorizationEvents.onAuthorizationResponse.raiseEvent(authorizationError, authorizationResponse);

--- a/core/frontend/src/NativeApp.ts
+++ b/core/frontend/src/NativeApp.ts
@@ -182,11 +182,12 @@ export class NativeApp {
       await this.setConnectivity(OverriddenBy.Browser, window.navigator.onLine ? InternetConnectivityStatus.Online : InternetConnectivityStatus.Offline);
     }
 
-    const auth = new NativeAppAuthorization(opts?.nativeApp?.authConfig);
+    const auth = new NativeAppAuthorization(opts?.nativeApp?.authConfig); // eslint-disable-line deprecation/deprecation
     IModelApp.authorizationClient = auth;
     const connStatus = await NativeApp.checkInternetConnectivity();
-    if (opts?.nativeApp?.authConfig && true !== opts?.nativeApp?.noInitializeAuthClient && connStatus === InternetConnectivityStatus.Online)
+    if (opts?.nativeApp?.authConfig && true !== opts?.nativeApp?.noInitializeAuthClient && connStatus === InternetConnectivityStatus.Online) { // eslint-disable-line deprecation/deprecation
       await auth.initialize({ applicationId: IModelApp.applicationId, applicationVersion: IModelApp.applicationVersion, sessionId: IModelApp.sessionId });
+    }
   }
 
   public static async shutdown() {

--- a/core/frontend/src/NativeApp.ts
+++ b/core/frontend/src/NativeApp.ts
@@ -185,7 +185,7 @@ export class NativeApp {
     const auth = new NativeAppAuthorization(opts?.nativeApp?.authConfig);
     IModelApp.authorizationClient = auth;
     const connStatus = await NativeApp.checkInternetConnectivity();
-    if (true !== opts?.nativeApp?.noInitializeAuthClient && connStatus === InternetConnectivityStatus.Online)
+    if (opts?.nativeApp?.authConfig && true !== opts?.nativeApp?.noInitializeAuthClient && connStatus === InternetConnectivityStatus.Online)
       await auth.initialize({ applicationId: IModelApp.applicationId, applicationVersion: IModelApp.applicationVersion, sessionId: IModelApp.sessionId });
   }
 

--- a/core/mobile-manager/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile-manager/src/backend/MobileAuthorizationBackend.ts
@@ -44,7 +44,8 @@ export class MobileAuthorizationBackend extends NativeAppAuthorizationBackend {
     };
 
     return new Promise<void>((resolve, reject) => {
-      MobileHost.device.authInit(this.getClientRequestContext(), this.config!, (err?: string) => {
+      assert(this.config !== undefined);
+      MobileHost.device.authInit(this.getClientRequestContext(), this.config, (err?: string) => {
         if (!err) {
           resolve();
         } else {

--- a/core/mobile-manager/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile-manager/src/backend/MobileAuthorizationBackend.ts
@@ -6,7 +6,7 @@
  * @module OIDC
  */
 
-import { assert, ClientRequestContext, SessionProps } from "@bentley/bentleyjs-core";
+import { assert } from "@bentley/bentleyjs-core";
 import { NativeAppAuthorizationBackend } from "@bentley/imodeljs-backend";
 import { NativeAppAuthorizationConfiguration } from "@bentley/imodeljs-common";
 import { AccessToken, AccessTokenProps, UserInfo } from "@bentley/itwin-client";
@@ -26,7 +26,7 @@ export class MobileAuthorizationBackend extends NativeAppAuthorizationBackend {
   /** Used to initialize the client - must be awaited before any other methods are called */
   public async initialize(config?: NativeAppAuthorizationConfiguration): Promise<void> {
     await super.initialize(config);
-    assert(this.config !== undefined && this.issuerUrl != undefined, "URL of authorization provider was not initialized");
+    assert(this.config !== undefined && this.issuerUrl !== undefined, "URL of authorization provider was not initialized");
 
     MobileHost.device.authStateChanged = (tokenString?: string) => {
       let token: AccessToken | undefined;

--- a/core/mobile-manager/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile-manager/src/backend/MobileAuthorizationBackend.ts
@@ -6,8 +6,8 @@
  * @module OIDC
  */
 
-import { ClientRequestContext, SessionProps } from "@bentley/bentleyjs-core";
-import { NativeAppAuthorizationBackend, NativeHost } from "@bentley/imodeljs-backend";
+import { assert, ClientRequestContext, SessionProps } from "@bentley/bentleyjs-core";
+import { NativeAppAuthorizationBackend } from "@bentley/imodeljs-backend";
 import { NativeAppAuthorizationConfiguration } from "@bentley/imodeljs-common";
 import { AccessToken, AccessTokenProps, UserInfo } from "@bentley/itwin-client";
 import { MobileHost } from "./MobileHost";
@@ -17,23 +17,16 @@ import { MobileHost } from "./MobileHost";
  */
 export class MobileAuthorizationBackend extends NativeAppAuthorizationBackend {
   public static defaultRedirectUri = "imodeljs://app/signin-callback";
-  public get redirectUri() { return this.config.redirectUri ?? MobileAuthorizationBackend.defaultRedirectUri; }
+  public get redirectUri() { return this.config?.redirectUri ?? MobileAuthorizationBackend.defaultRedirectUri; }
 
   public constructor(config?: NativeAppAuthorizationConfiguration) {
-    super();
-    this.config = config ?? {
-      clientId: NativeHost.applicationName ?? "mobile-app",
-      scope: "openid email profile organization offline_access",
-    };
+    super(config);
   }
 
   /** Used to initialize the client - must be awaited before any other methods are called */
-  public async initialize(props: SessionProps, config?: NativeAppAuthorizationConfiguration): Promise<void> {
-    await super.initialize(props, config);
-
-    const requestContext = ClientRequestContext.fromJSON(props);
-    if (!this.config.issuerUrl)
-      this.config.issuerUrl = await this.getUrl(requestContext);
+  public async initialize(config?: NativeAppAuthorizationConfiguration): Promise<void> {
+    await super.initialize(config);
+    assert(this.config !== undefined && this.issuerUrl != undefined, "URL of authorization provider was not initialized");
 
     MobileHost.device.authStateChanged = (tokenString?: string) => {
       let token: AccessToken | undefined;
@@ -51,7 +44,7 @@ export class MobileAuthorizationBackend extends NativeAppAuthorizationBackend {
     };
 
     return new Promise<void>((resolve, reject) => {
-      MobileHost.device.authInit(requestContext, this.config, (err?: string) => {
+      MobileHost.device.authInit(this.getClientRequestContext(), this.config!, (err?: string) => {
         if (!err) {
           resolve();
         } else {

--- a/core/mobile-manager/src/backend/MobileHost.ts
+++ b/core/mobile-manager/src/backend/MobileHost.ts
@@ -4,8 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeEvent, BriefcaseStatus, ClientRequestContext, Logger } from "@bentley/bentleyjs-core";
-import { BackendRequestContext, IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@bentley/imodeljs-backend";
-import { IModel, IModelReadRpcInterface, IModelTileRpcInterface, InternetConnectivityStatus, NativeAppAuthorizationConfiguration, RpcInterfaceDefinition, SnapshotIModelRpcInterface } from "@bentley/imodeljs-common";
+import { IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@bentley/imodeljs-backend";
+import { IModelReadRpcInterface, IModelTileRpcInterface, InternetConnectivityStatus, NativeAppAuthorizationConfiguration, RpcInterfaceDefinition, SnapshotIModelRpcInterface } from "@bentley/imodeljs-common";
 import { CancelRequest, DownloadFailed, ProgressCallback, UserCancelledError } from "@bentley/itwin-client";
 import { PresentationRpcInterface } from "@bentley/presentation-common";
 import { BatteryState, DeviceEvents, mobileAppChannel, MobileAppFunctions, Orientation } from "../common/MobileAppProps";

--- a/core/mobile-manager/src/backend/MobileHost.ts
+++ b/core/mobile-manager/src/backend/MobileHost.ts
@@ -4,8 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeEvent, BriefcaseStatus, ClientRequestContext, Logger } from "@bentley/bentleyjs-core";
-import { IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@bentley/imodeljs-backend";
-import { IModelReadRpcInterface, IModelTileRpcInterface, NativeAppAuthorizationConfiguration, RpcInterfaceDefinition, SnapshotIModelRpcInterface } from "@bentley/imodeljs-common";
+import { BackendRequestContext, IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@bentley/imodeljs-backend";
+import { IModel, IModelReadRpcInterface, IModelTileRpcInterface, InternetConnectivityStatus, NativeAppAuthorizationConfiguration, RpcInterfaceDefinition, SnapshotIModelRpcInterface } from "@bentley/imodeljs-common";
 import { CancelRequest, DownloadFailed, ProgressCallback, UserCancelledError } from "@bentley/itwin-client";
 import { PresentationRpcInterface } from "@bentley/presentation-common";
 import { BatteryState, DeviceEvents, mobileAppChannel, MobileAppFunctions, Orientation } from "../common/MobileAppProps";
@@ -81,8 +81,10 @@ export interface MobileHostOpts extends NativeHostOpts {
     device?: MobileDevice;
     /** list of RPC interface definitions to register */
     rpcInterfaces?: RpcInterfaceDefinition[];
-    /** Authorization configuration */
+    /** if present, [[NativeHost.authorizationClient]] will be set to an instance of NativeAppAuthorizationBackend and will be initialized. */
     authConfig?: NativeAppAuthorizationConfiguration;
+    /** if true, do not attempt to initialize AuthorizationClient on startup */
+    noInitializeAuthClient?: boolean;
   };
 }
 
@@ -97,6 +99,9 @@ export class MobileHost {
   public static readonly onEnterForeground = new BeEvent();
   public static readonly onEnterBackground = new BeEvent();
   public static readonly onWillTerminate = new BeEvent();
+
+  /** @internal */
+  public static get authorization() { return IModelHost.authorizationClient as MobileAuthorizationBackend; }
 
   /**  @internal */
   public static reconnect(connection: number) {
@@ -151,7 +156,6 @@ export class MobileHost {
     await NativeHost.startup(opt);
     if (IpcHost.isValid)
       MobileAppHandler.register();
-    IModelHost.authorizationClient = new MobileAuthorizationBackend(opt?.mobileHost?.authConfig);
 
     const rpcInterfaces = opt?.mobileHost?.rpcInterfaces ?? [
       IModelReadRpcInterface,
@@ -161,5 +165,12 @@ export class MobileHost {
     ];
 
     MobileRpcManager.initializeImpl(rpcInterfaces);
+
+    const authorizationBackend = new MobileAuthorizationBackend(opt?.mobileHost?.authConfig);
+    const connectivityStatus = NativeHost.checkInternetConnectivity();
+    if (opt?.mobileHost?.authConfig && true !== opt?.mobileHost?.noInitializeAuthClient && connectivityStatus === InternetConnectivityStatus.Online) {
+      await authorizationBackend.initialize(opt?.mobileHost?.authConfig);
+    }
+    IModelHost.authorizationClient = authorizationBackend;
   }
 }

--- a/full-stack-tests/core/src/frontend/hub/TestUtility.ts
+++ b/full-stack-tests/core/src/frontend/hub/TestUtility.ts
@@ -58,7 +58,7 @@ export class TestUtility {
     let authorizationClient: FrontendAuthorizationClient;
     if (NativeApp.isValid) {
       authorizationClient = new NativeAppAuthorization({ clientId: "testapp", redirectUri: "", scope: "" });
-      await NativeApp.callNativeHost("silentLogin", (await getAccessTokenFromBackend(user)).toJSON());
+      await NativeApp.callNativeHost("setAccessTokenProps", (await getAccessTokenFromBackend(user)).toJSON());
     } else {
       authorizationClient = this.imodelCloudEnv.getAuthorizationClient(undefined, user);
       await authorizationClient.signIn();

--- a/full-stack-tests/native-app/src/frontend/hub/NativeApp.test.ts
+++ b/full-stack-tests/native-app/src/frontend/hub/NativeApp.test.ts
@@ -14,7 +14,7 @@ import { rpcInterfaces } from "../../common/RpcInterfaces";
 import { usingOfflineScope } from "./HttpRequestHook";
 import { TestUtility } from "./TestUtility";
 
-describe.only("NativeApp (offline)", () => {
+describe("NativeApp (offline)", () => {
   before(async () => {
     await ElectronApp.startup({
       iModelApp: {

--- a/full-stack-tests/native-app/src/frontend/hub/NativeApp.test.ts
+++ b/full-stack-tests/native-app/src/frontend/hub/NativeApp.test.ts
@@ -5,6 +5,7 @@
 import { assert } from "chai";
 import { Config, GuidString } from "@bentley/bentleyjs-core";
 import { ElectronApp } from "@bentley/electron-manager/lib/ElectronFrontend";
+
 import { BriefcaseDownloader, IModelVersion, SyncMode } from "@bentley/imodeljs-common";
 import { BriefcaseConnection, IModelApp, NativeApp, NativeAppAuthorization, NativeAppLogger } from "@bentley/imodeljs-frontend";
 import { ProgressInfo } from "@bentley/itwin-client";
@@ -12,6 +13,39 @@ import { getAccessTokenFromBackend, TestUsers } from "@bentley/oidc-signin-tool/
 import { rpcInterfaces } from "../../common/RpcInterfaces";
 import { usingOfflineScope } from "./HttpRequestHook";
 import { TestUtility } from "./TestUtility";
+
+describe.only("NativeApp (offline)", () => {
+  before(async () => {
+    await ElectronApp.startup({
+      iModelApp: {
+        rpcInterfaces,
+        applicationId: "1234",
+        applicationVersion: "testappversion",
+        sessionId: "testsessionid",
+      },
+    });
+  });
+
+  it("must startup offline without errors", async () => {
+    await ElectronApp.shutdown();
+
+    await usingOfflineScope(async () => {
+      await ElectronApp.startup({
+        iModelApp: {
+          rpcInterfaces,
+          applicationId: "1234",
+          applicationVersion: "testappversion",
+          sessionId: "testsessionid",
+        },
+      });
+      assert.isTrue(ElectronApp.isValid);
+    });
+  });
+
+  after(async () => {
+    await ElectronApp.shutdown();
+  });
+});
 
 describe("NativeApp (#integration)", () => {
   let testProjectName: string;
@@ -29,7 +63,7 @@ describe("NativeApp (#integration)", () => {
       },
     });
 
-    await NativeApp.callNativeHost("silentLogin", (await getAccessTokenFromBackend(TestUsers.regular)).toJSON());
+    await NativeApp.callNativeHost("setAccessTokenProps", (await getAccessTokenFromBackend(TestUsers.regular)).toJSON());
     IModelApp.authorizationClient = new NativeAppAuthorization({ clientId: "testapp", redirectUri: "", scope: "" });
 
     testProjectName = Config.App.get("imjs_test_project_name");

--- a/test-apps/imodel-transformer/src/IModelHubUtils.ts
+++ b/test-apps/imodel-transformer/src/IModelHubUtils.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 // cspell:words buddi urlps
 
-import { assert, ClientRequestContext, Config, GuidString } from "@bentley/bentleyjs-core";
+import { assert, Config, GuidString } from "@bentley/bentleyjs-core";
 import { ElectronAuthorizationBackend } from "@bentley/electron-manager/lib/ElectronBackend";
 import { BriefcaseQuery, ChangeSet, HubIModel, IModelQuery, Version } from "@bentley/imodelhub-client";
 import { BriefcaseDb, BriefcaseManager, IModelHost, IModelJsFs, NativeHost, RequestNewBriefcaseArg } from "@bentley/imodeljs-backend";
@@ -20,8 +20,7 @@ export namespace IModelHubUtils {
 
   async function signIn(): Promise<AccessToken> {
     const client = new ElectronAuthorizationBackend();
-    const requestContext = new ClientRequestContext();
-    await client.initialize(requestContext, {
+    await client.initialize({
       clientId: "imodeljs-electron-test",
       redirectUri: "http://localhost:3000/signin-callback",
       scope: "openid email profile organization imodelhub context-registry-service:read-only reality-data:read product-settings-service projectwise-share urlps-third-party imodel-extension-service-api offline_access",

--- a/tools/extension-cli/src/helpers.ts
+++ b/tools/extension-cli/src/helpers.ts
@@ -3,7 +3,6 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { AccessToken } from "@bentley/itwin-client";
-import { ClientRequestContext } from "@bentley/bentleyjs-core";
 import { ElectronAuthorizationBackend } from "@bentley/electron-manager/lib/ElectronBackend";
 import { ExtensionProps } from "@bentley/extension-client";
 import { NativeHost } from "@bentley/imodeljs-backend";
@@ -11,9 +10,8 @@ import { NativeHost } from "@bentley/imodeljs-backend";
 export async function signIn(): Promise<AccessToken> {
   const clientId = "imodeljs-extension-publisher";
   const redirectUri = "http://localhost:5001/signin-oidc";
-  const requestContext = new ClientRequestContext();
   const client = new ElectronAuthorizationBackend();
-  await client.initialize(requestContext, {
+  await client.initialize({
     clientId,
     redirectUri,
     scope: "openid imodel-extension-service-api context-registry-service:read-only offline_access imodel-extension-service:modify",

--- a/tools/extension-cli/src/test/basic.test.ts
+++ b/tools/extension-cli/src/test/basic.test.ts
@@ -6,7 +6,6 @@
 import * as chai from "chai";
 const assert = chai.assert;
 
-import { ClientRequestContext } from "@bentley/bentleyjs-core";
 import { IModelHost } from "@bentley/imodeljs-backend";
 import { signIn } from "../helpers";
 import { ElectronAuthorizationBackend } from "@bentley/electron-manager/lib/ElectronBackend";
@@ -16,9 +15,8 @@ describe.skip("ExtensionClient CLI (#integration)", () => {
     await IModelHost.startup();
 
     // Initialize an DesktopAuthorizationClient to delete refresh token from global store, then dispose it.
-    const requestContext = new ClientRequestContext();
     const client = new ElectronAuthorizationBackend();
-    await client.initialize(requestContext, {
+    await client.initialize({
       clientId: "imodeljs-extension-publisher",
       redirectUri: "",
       scope: "",


### PR DESCRIPTION
Fixes to desktop/mobile authorization
* Deprecated authorization at the frontend. 
* Allowed backend startup to initialize authorization. 
* Avoided initialization of authorization client if offline (Closes #594844)
  + Added test for the same

Fixes to desktop authorization
* Successful/Error in authorization shows message in browser window. 
* Added wrapper methods around signIn() and signOut() to not just start the sign-in/sign-out process, but also to complete it. 
