### PR TITLE
Fix parsing of buddi fallback for clients #1073

### DIFF
--- a/clients/itwin/src/Client.ts
+++ b/clients/itwin/src/Client.ts
@@ -5,8 +5,8 @@
 /** @packageDocumentation
  * @module iTwinServiceClients
  */
-import * as deepAssign from "deep-assign";
 import { ClientRequestContext, Config, Logger } from "@bentley/bentleyjs-core";
+import * as deepAssign from "deep-assign";
 import { AuthorizedClientRequestContext } from "./AuthorizedClientRequestContext";
 import { ITwinClientLoggerCategory } from "./ITwinClientLoggerCategory";
 import { request, RequestGlobalOptions, RequestOptions, RequestTimeoutOptions, Response, ResponseError } from "./Request";
@@ -97,9 +97,11 @@ export abstract class Client {
       if (undefined === prefix) {
         const region = Config.App.query("imjs_buddi_resolve_url_using_region");
         switch (region) {
+          case 102:
           case "102":
             prefix = "qa-";
             break;
+          case 103:
           case "103":
             prefix = "dev-";
             break;

--- a/common/changes/@bentley/itwin-client/fix-ApimFallback_2021-04-29-18-44.json
+++ b/common/changes/@bentley/itwin-client/fix-ApimFallback_2021-04-29-18-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-client",
+      "comment": "fix parsing of buddi fallback for clients. imjs_buddi_resolve_url_using_region should support both strings and numbers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/itwin-client",
+  "email": "aruniverse@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixing issue found in https://github.com/imodeljs/imodeljs/pull/1073

`imjs_buddi_resolve_url_using_region` should support both `string` and `number`

itwin-viewer and many other apps uses a number for this env value