### PR TITLE
Presentation: Fix `PresentationRpcImpl.loadHierarchy` causing older frontends to throw

### DIFF
--- a/common/changes/@bentley/presentation-backend/presentation-patch-PresentationRpc-loadHierarchy_2021-05-04-19-07.json
+++ b/common/changes/@bentley/presentation-backend/presentation-patch-PresentationRpc-loadHierarchy_2021-05-04-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -192,7 +192,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface {
 
   /** @deprecated This is a noop now. Keeping just to avoid breaking the RPC interface. */
   public async loadHierarchy(_token: IModelRpcProps, _requestOptions: HierarchyRpcRequestOptions): PresentationRpcResponse<void> {
-    return { statusCode: PresentationStatus.Error };
+    return { statusCode: PresentationStatus.Success };
   }
 
   public async getContentDescriptor(token: IModelRpcProps, requestOptions: ContentRpcRequestOptions | ContentDescriptorRpcRequestOptions, displayType?: string, keys?: KeySetJSON, selection?: SelectionInfo): PresentationRpcResponse<DescriptorJSON | undefined> {

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -632,14 +632,14 @@ describe("PresentationRpcImpl", () => {
 
     describe("loadHierarchy", () => {
 
-      it("returns error status", async () => {
+      it("returns success status", async () => {
         const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never>> = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
         };
         // eslint-disable-next-line deprecation/deprecation
         const actualResult = await impl.loadHierarchy(testData.imodelToken, rpcOptions);
-        expect(actualResult.statusCode).to.equal(PresentationStatus.Error);
+        expect(actualResult.statusCode).to.equal(PresentationStatus.Success);
       });
 
     });


### PR DESCRIPTION
Return Success instead of Error to avoid frontends throwing. Doesn't matter anyway, since the function is a no-op.