### PR TITLE
Ecschema rpc interface name fix

### DIFF
--- a/common/api/ecschema-rpcinterface-common.api.md
+++ b/common/api/ecschema-rpcinterface-common.api.md
@@ -18,7 +18,7 @@ export abstract class ECSchemaRpcInterface extends RpcInterface {
     getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<string>;
     getSchemaKeys(_tokenProps: IModelRpcProps): Promise<SchemaKey[]>;
     // (undocumented)
-    static readonly interfaceName = "SchemaRpcInterface";
+    static readonly interfaceName = "ECSchemaRpcInterface";
     // (undocumented)
     static interfaceVersion: string;
     static version: string;

--- a/common/changes/@bentley/ecschema-rpcinterface-common/ecschema-rpc-interface-name-fix_2021-05-04-18-28.json
+++ b/common/changes/@bentley/ecschema-rpcinterface-common/ecschema-rpc-interface-name-fix_2021-05-04-18-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ecschema-rpcinterface-common",
+      "comment": "\"Fixed interface name to avoid duplicate naming\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ecschema-rpcinterface-common",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
@@ -15,7 +15,7 @@ export abstract class ECSchemaRpcInterface extends RpcInterface {
   /** The version of the RPC Interface. */
   public static version = "1.0.0";
 
-  public static readonly interfaceName = "SchemaRpcInterface";
+  public static readonly interfaceName = "ECSchemaRpcInterface";
   public static interfaceVersion = ECSchemaRpcInterface.version;
 
   /**


### PR DESCRIPTION
The interface name for ECSchemaRpcInterface must be different from SchemaRpcInterface.