### PR TITLE
Backport override symbology of unanimated nodes (#1333)

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -2570,7 +2570,7 @@ export class FeatureOverrides implements FeatureAppearanceSource {
     // @internal (undocumented)
     protected getElementOverrides(idLo: number, idHi: number, animationNodeId: number): FeatureAppearance | undefined;
     getElementOverridesById(id: Id64String): FeatureAppearance | undefined;
-    getFeatureAppearance(feature: Feature, modelId: Id64String, type?: BatchType): FeatureAppearance | undefined;
+    getFeatureAppearance(feature: Feature, modelId: Id64String, type?: BatchType, animationNodeId?: number): FeatureAppearance | undefined;
     // @internal (undocumented)
     protected getModelOverrides(idLo: number, idHi: number): FeatureAppearance | undefined;
     getModelOverridesById(id: Id64String): FeatureAppearance | undefined;

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -2945,6 +2945,8 @@ export class EmphasizeElements implements FeatureOverrideProvider {
     // @internal
     setNeverDrawnElements(ids: Id64Arg, vp: Viewport, replace?: boolean): boolean;
     toJSON(vp: Viewport): EmphasizeElementsProps;
+    get unanimatedAppearance(): FeatureAppearance | undefined;
+    set unanimatedAppearance(appearance: FeatureAppearance | undefined);
     // @internal (undocumented)
     protected updateIdSet(ids: Id64Arg, replace: boolean, existingIds?: Id64Set): Id64Set | undefined;
     wantEmphasis: boolean;
@@ -2964,6 +2966,8 @@ export interface EmphasizeElementsProps {
     isAlwaysDrawnExclusive?: boolean;
     // (undocumented)
     neverDrawn?: Id64Array;
+    // (undocumented)
+    unanimatedAppearance?: FeatureAppearanceProps;
     // (undocumented)
     wantEmphasis?: boolean;
 }

--- a/common/changes/@bentley/imodeljs-common/default-animation-node-appearance_2021-05-04-17-40.json
+++ b/common/changes/@bentley/imodeljs-common/default-animation-node-appearance_2021-05-04-17-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "FeatureOverrides can hide or override the symbology of unanimated nodes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/default-animation-node-appearance_2021-05-04-17-40.json
+++ b/common/changes/@bentley/imodeljs-frontend/default-animation-node-appearance_2021-05-04-17-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "EmphasizeElements can override the appearance of unanimated schedule script nodes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/common/src/FeatureSymbology.ts
+++ b/core/common/src/FeatureSymbology.ts
@@ -345,7 +345,7 @@ export class FeatureOverrides implements FeatureAppearanceSource {
     if (this._neverDrawn.has(elemIdLo, elemIdHi))
       return true;
     else
-      return 0 !== animationNodeId && this.neverDrawnAnimationNodes.has(animationNodeId);
+      return this.neverDrawnAnimationNodes.has(animationNodeId);
   }
   /** @internal */
   protected isAlwaysDrawn(idLo: number, idHi: number): boolean { return this._alwaysDrawn.has(idLo, idHi); }
@@ -369,7 +369,7 @@ export class FeatureOverrides implements FeatureAppearanceSource {
   /** @internal */
   protected getElementOverrides(idLo: number, idHi: number, animationNodeId: number): FeatureAppearance | undefined {
     const app = this._elementOverrides.get(idLo, idHi);
-    if (app !== undefined || 0 === animationNodeId)
+    if (app !== undefined)
       return app;
 
     return this.animationNodeOverrides.get(animationNodeId);
@@ -395,13 +395,13 @@ export class FeatureOverrides implements FeatureAppearanceSource {
   }
 
   /** Returns the feature's appearance overrides, or undefined if the feature is not visible. */
-  public getFeatureAppearance(feature: Feature, modelId: Id64String, type: BatchType = BatchType.Primary): FeatureAppearance | undefined {
+  public getFeatureAppearance(feature: Feature, modelId: Id64String, type: BatchType = BatchType.Primary, animationNodeId = 0): FeatureAppearance | undefined {
     return this.getAppearance(
       Id64.getLowerUint32(feature.elementId), Id64.getUpperUint32(feature.elementId),
       Id64.getLowerUint32(feature.subCategoryId), Id64.getUpperUint32(feature.subCategoryId),
       feature.geometryClass,
       Id64.getLowerUint32(modelId), Id64.getUpperUint32(modelId),
-      type, 0);
+      type, animationNodeId);
   }
 
   private static readonly _weight1Appearance = FeatureAppearance.fromJSON({ weight: 1 });

--- a/core/common/src/test/FeatureSymbology.test.ts
+++ b/core/common/src/test/FeatureSymbology.test.ts
@@ -278,6 +278,36 @@ describe("FeatureOverrides", () => {
     expect(ovrs.isSubCategoryVisible(3, 0)).to.be.false;
     expect(ovrs.isSubCategoryVisible(4, 0)).to.be.false;
   });
+
+  it("hides animation nodes", () => {
+    const feature = new Feature("0x123");
+    const modelId = "0x456";
+    const ovrs = new Overrides();
+
+    ovrs.neverDrawnAnimationNodes.add(1);
+    ovrs.neverDrawnAnimationNodes.add(0);
+    expect(ovrs.getFeatureAppearance(feature, modelId, undefined, 1)).to.be.undefined;
+    expect(ovrs.getFeatureAppearance(feature, modelId, undefined, 2)).not.to.be.undefined;
+    expect(ovrs.getFeatureAppearance(feature, modelId, undefined, 0)).to.be.undefined;
+  });
+
+  it("overrides animation nodes", () => {
+    const ovrs = new Overrides();
+
+    const expectAppearance = (nodeId: number, expected: FeatureAppearance) => {
+      const actual = ovrs.getFeatureAppearance(new Feature("0x123"), "0x456", undefined, nodeId)!;
+      expect(actual).not.to.be.undefined;
+      expect(JSON.stringify(actual)).to.equal(JSON.stringify(expected));
+    };
+
+    const green = FeatureAppearance.fromRgb(ColorDef.green);
+    const blue = FeatureAppearance.fromRgb(ColorDef.blue);
+    ovrs.animationNodeOverrides.set(0, green);
+    ovrs.animationNodeOverrides.set(1, blue);
+    expectAppearance(1, blue);
+    expectAppearance(2, FeatureAppearance.defaults);
+    expectAppearance(0, green);
+  });
 });
 
 describe("FeatureAppearanceProvider", () => {

--- a/core/frontend/src/EmphasizeElements.ts
+++ b/core/frontend/src/EmphasizeElements.ts
@@ -47,6 +47,7 @@ export interface EmphasizeElementsProps {
   defaultAppearance?: FeatureAppearanceProps;
   appearanceOverride?: AppearanceOverrideProps[];
   wantEmphasis?: boolean;
+  unanimatedAppearance?: FeatureAppearanceProps;
 }
 
 /** An implementation of [[FeatureOverrideProvider]] for emphasizing selected elements through simple color/transparency appearance overrides.
@@ -54,6 +55,7 @@ export interface EmphasizeElementsProps {
  */
 export class EmphasizeElements implements FeatureOverrideProvider {
   private _defaultAppearance?: FeatureAppearance;
+  private _unanimatedAppearance?: FeatureAppearance;
   private _emphasizeIsolated?: Id64Set;
   private _overrideAppearance?: Map<number, Id64Set>;
   private readonly _emphasizedAppearance = FeatureAppearance.fromJSON({ emphasized: true });
@@ -71,6 +73,7 @@ export class EmphasizeElements implements FeatureOverrideProvider {
       const app = this.wantEmphasis ? this._emphasizedAppearance : FeatureAppearance.defaults;
       emphasizedElements.forEach((id) => { overrides.overrideElement(id, app); });
     }
+
     const overriddenElements = this.getOverriddenElements();
     if (undefined !== overriddenElements) {
       if (undefined !== this._defaultAppearance)
@@ -79,6 +82,13 @@ export class EmphasizeElements implements FeatureOverrideProvider {
         const ovrApp = this.createAppearanceFromKey(key);
         ids.forEach((id) => { overrides.overrideElement(id, ovrApp); });
       }
+    }
+
+    if (this._unanimatedAppearance) {
+      if (this._unanimatedAppearance.isFullyTransparent)
+        overrides.neverDrawnAnimationNodes.add(0);
+      else
+        overrides.animationNodeOverrides.set(0, this._unanimatedAppearance);
     }
   }
 
@@ -135,11 +145,23 @@ export class EmphasizeElements implements FeatureOverrideProvider {
   }
 
   /** Establish a default appearance to apply to elements without overrides. If changing the default appearance
-   * without also calling overrideElements, an explicit refresh must be requested for the change to take affect.
+   * without also calling overrideElements, an explicit refresh must be requested for the change to take effect.
    * @see [[Viewport.setFeatureOverrideProviderChanged]]
    */
   public get defaultAppearance(): FeatureAppearance | undefined { return this._defaultAppearance; }
   public set defaultAppearance(appearance: FeatureAppearance | undefined) { this._defaultAppearance = appearance; }
+
+  /** Establish a default appearance to apply to elements that are not animated by the view's [RenderSchedule.Script]($common).
+   * @note If this is the only change made to EmphasizeElements, you must call [[Viewport.setFeatureOverrideProviderChanged]] for
+   * the change to take immediate effect.
+   * @see [[createDefaultAppearance]] to create an appearance suitable for de-emphasizing the non-animated elements.
+   */
+  public get unanimatedAppearance(): FeatureAppearance | undefined {
+    return this._unanimatedAppearance;
+  }
+  public set unanimatedAppearance(appearance: FeatureAppearance | undefined) {
+    this._unanimatedAppearance = appearance;
+  }
 
   /** Create default appearance to use for emphasizeElements when not supplied by caller. */
   public createDefaultAppearance(): FeatureAppearance {
@@ -151,21 +173,44 @@ export class EmphasizeElements implements FeatureOverrideProvider {
   }
 
   /** Get the IDs of the currently never drawn elements. */
-  public getNeverDrawnElements(vp: Viewport): Id64Set | undefined { return (undefined !== vp.neverDrawn && 0 !== vp.neverDrawn.size ? vp.neverDrawn : undefined); }
+  public getNeverDrawnElements(vp: Viewport): Id64Set | undefined {
+    return (undefined !== vp.neverDrawn && 0 !== vp.neverDrawn.size ? vp.neverDrawn : undefined);
+  }
+
   /** Get the IDs of the currently always drawn elements. */
-  public getAlwaysDrawnElements(vp: Viewport): Id64Set | undefined { return (undefined !== vp.alwaysDrawn && 0 !== vp.alwaysDrawn.size ? vp.alwaysDrawn : undefined); }
+  public getAlwaysDrawnElements(vp: Viewport): Id64Set | undefined {
+    return (undefined !== vp.alwaysDrawn && 0 !== vp.alwaysDrawn.size ? vp.alwaysDrawn : undefined);
+  }
+
   /** Get the IDs of the currently hidden elements. */
-  public getHiddenElements(vp: Viewport): Id64Set | undefined { return this.getNeverDrawnElements(vp); }
+  public getHiddenElements(vp: Viewport): Id64Set | undefined {
+    return this.getNeverDrawnElements(vp);
+  }
+
   /** Get the IDs of the currently isolated elements. */
-  public getIsolatedElements(vp: Viewport): Id64Set | undefined { return (vp.isAlwaysDrawnExclusive ? this.getAlwaysDrawnElements(vp) : undefined); }
+  public getIsolatedElements(vp: Viewport): Id64Set | undefined {
+    return (vp.isAlwaysDrawnExclusive ? this.getAlwaysDrawnElements(vp) : undefined);
+  }
+
   /** Get the IDs of the currently emphasized isolated elements. */
-  public getEmphasizedIsolatedElements(): Id64Set | undefined { return (undefined !== this._defaultAppearance && undefined !== this._emphasizeIsolated && 0 !== this._emphasizeIsolated.size ? this._emphasizeIsolated : undefined); }
+  public getEmphasizedIsolatedElements(): Id64Set | undefined {
+    return (undefined !== this._defaultAppearance && undefined !== this._emphasizeIsolated && 0 !== this._emphasizeIsolated.size ? this._emphasizeIsolated : undefined);
+  }
+
   /** Get the IDs of the currently emphasized elements. */
-  public getEmphasizedElements(vp: Viewport): Id64Set | undefined { return (undefined !== this.getEmphasizedIsolatedElements() ? this._emphasizeIsolated : (undefined !== this._defaultAppearance && !vp.isAlwaysDrawnExclusive ? this.getAlwaysDrawnElements(vp) : undefined)); }
+  public getEmphasizedElements(vp: Viewport): Id64Set | undefined {
+    return (undefined !== this.getEmphasizedIsolatedElements() ? this._emphasizeIsolated : (undefined !== this._defaultAppearance && !vp.isAlwaysDrawnExclusive ? this.getAlwaysDrawnElements(vp) : undefined));
+  }
+
   /** Get the map of current elements with color/transparency overrides. */
-  public getOverriddenElements(): Map<number, Id64Set> | undefined { return (undefined !== this._overrideAppearance && 0 !== this._overrideAppearance.size ? this._overrideAppearance : undefined); }
+  public getOverriddenElements(): Map<number, Id64Set> | undefined {
+    return (undefined !== this._overrideAppearance && 0 !== this._overrideAppearance.size ? this._overrideAppearance : undefined);
+  }
+
   /** Get the IDs of current elements with the specified color/transparency override. */
-  public getOverriddenElementsByKey(key: number): Id64Set | undefined { return (undefined !== this._overrideAppearance ? this._overrideAppearance.get(key) : undefined); }
+  public getOverriddenElementsByKey(key: number): Id64Set | undefined {
+    return (undefined !== this._overrideAppearance ? this._overrideAppearance.get(key) : undefined);
+  }
 
   /** Clear never drawn elements.
    * @return false if nothing to clear.
@@ -211,10 +256,13 @@ export class EmphasizeElements implements FeatureOverrideProvider {
   public clearEmphasizedElements(vp: Viewport): boolean {
     if (undefined === this.getEmphasizedElements(vp))
       return false;
+
     if (this.clearEmphasizedIsolatedElements(vp, false))
       return true;
+
     if (!this.clearAlwaysDrawnElements(vp))
       return false;
+
     this._defaultAppearance = undefined;
     return true;
   }
@@ -227,8 +275,10 @@ export class EmphasizeElements implements FeatureOverrideProvider {
     this._emphasizeIsolated = undefined; // Always clear in case default appearance was unset...
     if (undefined === emphasizedIsolated)
       return false;
+
     if (setToAlwaysDrawn && this.setAlwaysDrawnElements(emphasizedIsolated, vp, false))
       return true;
+
     this._defaultAppearance = undefined;
     vp.setFeatureOverrideProviderChanged();
     return true;
@@ -360,8 +410,10 @@ export class EmphasizeElements implements FeatureOverrideProvider {
     const wasEmphasized = (undefined !== this.getEmphasizedElements(vp));
     if (!this.setAlwaysDrawnElements(ids, vp, true, replace))
       return false;
+
     if (wasEmphasized)
       this._defaultAppearance = this._emphasizeIsolated = undefined; // Don't clear defaultAppearance unless it was established by emphasize...
+
     return true;
   }
 
@@ -396,13 +448,16 @@ export class EmphasizeElements implements FeatureOverrideProvider {
       const emphasizeIds = this.updateIdSet(ids, replace, this._emphasizeIsolated);
       if (undefined === emphasizeIds)
         return false;
+
       this._emphasizeIsolated = emphasizeIds;
       vp.setFeatureOverrideProviderChanged();
     } else {
       if (!this.setAlwaysDrawnElements(ids, vp, false, replace))
         return false;
+
       this._emphasizeIsolated = undefined;
     }
+
     this._defaultAppearance = (undefined === defaultAppearance ? this.createDefaultAppearance() : defaultAppearance);
     return true;
   }
@@ -520,6 +575,9 @@ export class EmphasizeElements implements FeatureOverrideProvider {
     if (undefined !== this.defaultAppearance)
       props.defaultAppearance = this.defaultAppearance; // emphasize (or specifically set for override)
 
+    if (this.unanimatedAppearance)
+      props.unanimatedAppearance = this.unanimatedAppearance;
+
     const overriddenElements = this.getOverriddenElements();
     if (undefined !== overriddenElements) {
       const appearanceOverride: AppearanceOverrideProps[] = [];
@@ -554,6 +612,9 @@ export class EmphasizeElements implements FeatureOverrideProvider {
 
     if (undefined !== props.defaultAppearance)
       this.defaultAppearance = FeatureAppearance.fromJSON(props.defaultAppearance); // changed status determined by setAlwaysDrawnElements or overrideElements...
+
+    if (props.unanimatedAppearance)
+      this.unanimatedAppearance = FeatureAppearance.fromJSON(props.unanimatedAppearance);
 
     if (undefined !== props.appearanceOverride) {
       for (const ovrApp of props.appearanceOverride) {

--- a/core/frontend/src/EmphasizeElements.ts
+++ b/core/frontend/src/EmphasizeElements.ts
@@ -151,7 +151,7 @@ export class EmphasizeElements implements FeatureOverrideProvider {
   public get defaultAppearance(): FeatureAppearance | undefined { return this._defaultAppearance; }
   public set defaultAppearance(appearance: FeatureAppearance | undefined) { this._defaultAppearance = appearance; }
 
-  /** Establish a default appearance to apply to elements that are not animated by the view's [RenderSchedule.Script]($common).
+  /** Establish a default appearance to apply to elements that are not animated by the view's schedule script.
    * @note If this is the only change made to EmphasizeElements, you must call [[Viewport.setFeatureOverrideProviderChanged]] for
    * the change to take immediate effect.
    * @see [[createDefaultAppearance]] to create an appearance suitable for de-emphasizing the non-animated elements.

--- a/full-stack-tests/core/src/frontend/standalone/EmphasizeElements.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/EmphasizeElements.test.ts
@@ -355,15 +355,14 @@ describe("EmphasizeElements tests", () => {
       const aApp = after.defaultAppearance;
       const bApp = before.defaultAppearance;
       expect(undefined === aApp).to.equal(undefined === bApp);
-      if (undefined !== aApp && undefined !== bApp) {
-        expect(undefined !== aApp.rgb).to.equal(undefined !== bApp.rgb);
-        expect(aApp.weight).to.equal(bApp.weight);
-        expect(aApp.transparency).to.equal(bApp.transparency);
-        expect(aApp.linePixels).to.equal(bApp.linePixels);
-        expect(aApp.ignoresMaterial).to.equal(bApp.ignoresMaterial);
-        expect(aApp.nonLocatable).to.equal(bApp.nonLocatable);
-        expect(aApp.emphasized).to.equal(bApp.emphasized);
-      }
+      if (undefined !== aApp && undefined !== bApp)
+        expect(aApp.equals(bApp)).to.be.true;
+
+      const aUnanimated = after.unanimatedAppearance;
+      const bUnanimated = before.unanimatedAppearance;
+      expect(undefined === aUnanimated).to.equal(undefined === bUnanimated);
+      if (aUnanimated && bUnanimated)
+        expect(aUnanimated.equals(bUnanimated)).to.be.true;
 
       expectEqualSets(after.getHiddenElements(vp2), before.getHiddenElements(vp1));
       expectEqualSets(after.getEmphasizedElements(vp2), before.getEmphasizedElements(vp1));
@@ -458,6 +457,39 @@ describe("EmphasizeElements tests", () => {
       expect(emph.overrideElements(blueIds, vp, ColorDef.blue, undefined, true)).to.be.true;
       const currBlueIds = emph.getOverriddenElementsByKey(blueKey);
       assert.isTrue(undefined !== currBlueIds && blueIds.size === currBlueIds.size);
+    });
+
+    roundTrip((emph, vp) => {
+      const blue = FeatureAppearance.fromRgb(ColorDef.blue);
+      emph.unanimatedAppearance = blue;
+      expect(emph.unanimatedAppearance).not.to.be.undefined;
+      expect(JSON.stringify(emph.unanimatedAppearance.toJSON())).to.equal(JSON.stringify(blue.toJSON()));
+
+      const ovrs = new FeatureSymbology.Overrides();
+      const feature = new Feature("0x123");
+      let app = ovrs.getFeatureAppearance(feature, "0x456")!;
+      expect(app).not.to.be.undefined;
+      expect(app.matchesDefaults).to.be.true;
+
+      emph.addFeatureOverrides(ovrs, vp);
+      app = ovrs.getFeatureAppearance(feature, "0x456")!;
+      expect(app).not.to.be.undefined;
+      expect(app.matchesDefaults).to.be.false;
+      expect(app.equals(blue)).to.be.true;
+    });
+
+    roundTrip((emph, vp) => {
+      const transp = FeatureAppearance.fromTransparency(1.0);
+      emph.unanimatedAppearance = transp;
+
+      const ovrs = new FeatureSymbology.Overrides();
+      const feature = new Feature("0x123");
+      const app = ovrs.getFeatureAppearance(feature, "0x456");
+      expect(app).not.to.be.undefined;
+      expect(app!.matchesDefaults).to.be.true;
+
+      emph.addFeatureOverrides(ovrs, vp);
+      expect(ovrs.getFeatureAppearance(feature, "0x456")).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
(cherry picked from commit d201129fb8fb68bc3b4be1cbfbe152f0a33d8535)