### PR TITLE
Fix stale animation clips being assigned to tile graphics.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-animation-clips_2021-05-10-17-02.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-animation-clips_2021-05-10-17-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix animations from schedule script being erroneously applied to tile graphics.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/Graphic.ts
+++ b/core/frontend/src/render/webgl/Graphic.ts
@@ -203,7 +203,7 @@ export class Batch extends Graphic {
 export class Branch extends Graphic {
   public readonly branch: GraphicBranch;
   public localToWorldTransform: Transform;
-  public clips?: ClipVolume;
+  public readonly clips?: ClipVolume;
   public readonly planarClassifier?: PlanarClassifier;
   public readonly textureDrape?: TextureDrape;
   public readonly edgeSettings?: EdgeSettings;
@@ -223,7 +223,7 @@ export class Branch extends Graphic {
       return;
 
     this.appearanceProvider = opts.appearanceProvider;
-    this.clips = opts.clipVolume as any;
+    this.clips = opts.clipVolume as ClipVolume | undefined;
     this.iModel = opts.iModel;
     this.frustum = opts.frustum;
 

--- a/core/frontend/src/render/webgl/RenderCommands.ts
+++ b/core/frontend/src/render/webgl/RenderCommands.ts
@@ -12,12 +12,13 @@ import { Frustum, FrustumPlanes, RenderMode, ViewFlags } from "@bentley/imodeljs
 import { Decorations } from "../Decorations";
 import { SurfaceType } from "../primitives/VertexTable";
 import { GraphicList, RenderGraphic } from "../RenderGraphic";
+import { AnimationBranchState } from "../GraphicBranch";
 import { BranchStack } from "./BranchStack";
 import { BatchState } from "./BatchState";
 import { BranchState } from "./BranchState";
 import {
-  DrawCommands, getAnimationBranchState, PopBatchCommand, PopBranchCommand, PopCommand, PrimitiveCommand, PushBatchCommand,
-  PushBranchCommand, PushCommand, PushStateCommand,
+  DrawCommands, PopBatchCommand, PopBranchCommand, PopClipCommand, PopCommand, PrimitiveCommand, PushBatchCommand,
+  PushBranchCommand, PushClipCommand, PushCommand, PushStateCommand,
 } from "./DrawCommand";
 import { Batch, Branch, Graphic, GraphicsArray } from "./Graphic";
 import { Layer, LayerContainer } from "./Layer";
@@ -27,6 +28,7 @@ import { Primitive } from "./Primitive";
 import { CompositeFlags, RenderOrder, RenderPass } from "./RenderFlags";
 import { TargetGraphics } from "./TargetGraphics";
 import { Target } from "./Target";
+import { ClipVolume } from "./ClipVolume";
 
 /** A list of DrawCommands to be rendered, ordered by render pass.
  * @internal
@@ -313,15 +315,16 @@ export class RenderCommands {
     this._forcedRenderPass = prevPass;
   }
 
-  private shouldOmitBranch(branch: Branch): boolean {
-    const anim = getAnimationBranchState(branch, this.target);
-    return undefined !== anim && true === anim.omit;
+  private getAnimationBranchState(branch: Branch): AnimationBranchState | undefined {
+    const animId = branch.branch.animationId;
+    return undefined !== animId ? this.target.animationBranches?.get(animId) : undefined;
   }
 
   private pushAndPopBranchForPass(pass: RenderPass, branch: Branch, func: () => void): void {
     assert(!this.isDrawingLayers);
 
-    if (this.shouldOmitBranch(branch))
+    const animState = this.getAnimationBranchState(branch);
+    if (animState?.omit)
       return;
 
     assert(RenderPass.None !== pass);
@@ -330,17 +333,27 @@ export class RenderCommands {
     if (branch.planarClassifier)
       branch.planarClassifier.pushBatchState(this._batchState);
 
-    const push = new PushBranchCommand(branch);
     const cmds = this.getCommands(pass);
+    const clip = animState?.clip as ClipVolume | undefined;
+    const pushClip = undefined !== clip ? new PushClipCommand(clip) : undefined;
+    if (pushClip)
+      cmds.push(pushClip);
+
+    const push = new PushBranchCommand(branch);
     cmds.push(push);
 
     func();
 
     this._stack.pop();
-    if (cmds[cmds.length - 1] === push)
+    if (cmds[cmds.length - 1] === push) {
       cmds.pop();
-    else
+      if (pushClip)
+        cmds.pop();
+    } else {
       cmds.push(PopBranchCommand.instance);
+      if (pushClip)
+        cmds.push(PopClipCommand.instance);
+    }
   }
 
   private pushAndPop(push: PushCommand, pop: PopCommand, func: () => void): void {
@@ -397,9 +410,17 @@ export class RenderCommands {
   }
 
   public pushAndPopBranch(branch: Branch, func: () => void): void {
-    if (this.shouldOmitBranch(branch))
+    const animState = this.getAnimationBranchState(branch);
+    if (animState?.omit)
       return;
 
+    if (animState?.clip)
+      this.pushAndPop(new PushClipCommand(animState.clip as ClipVolume), PopClipCommand.instance, () => this._pushAndPopBranch(branch, func));
+    else
+      this._pushAndPopBranch(branch, func);
+  }
+
+  private _pushAndPopBranch(branch: Branch, func: () => void): void {
     this._stack.pushBranch(branch);
     if (branch.planarClassifier)
       branch.planarClassifier.pushBatchState(this._batchState);


### PR DESCRIPTION
When pushing a branch we would assign directly to its `clips` property if the schedule script applied a clip volume to it.
This would leave random ClipVolumes applied to tiles' graphics.
Previously, this went unnoticed because we would `dispose` of those ClipVolumes each time we updated the target's animation branch states - we'd push an empty clip which was wasteful but had no visual effect.
In #1148 ClipVolume became no longer disposable so random bits of the models started disappearing.

`clips` is now a read-only property and the animation clips are pushed and popped using new dedicated `DrawCommand`s.