### PR TITLE
Remove source target ellipsoid ids from transform

### DIFF
--- a/common/changes/@bentley/imodeljs-common/remove-source-target-ellipsoid-ids-from-transform_2021-05-11-02-56.json
+++ b/common/changes/@bentley/imodeljs-common/remove-source-target-ellipsoid-ids-from-transform_2021-05-11-02-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Removed unrequired sourceEllipsoidId and targetEllipsoidId from GeodeticTransform and minor documentation changes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "73677355+AlainRobertAtBentley@users.noreply.github.com"
+}

--- a/core/common/src/geometry/AdditionalTransform.ts
+++ b/core/common/src/geometry/AdditionalTransform.ts
@@ -57,17 +57,21 @@ export class Helmert2DWithZOffset implements Helmert2DWithZOffsetProps {
     }
   }
 
-  /** @internal */
+  /** Creates an Helmert Transform from JSON representation.
+   * @public */
   public static fromJSON(data: Helmert2DWithZOffsetProps): Helmert2DWithZOffset {
     return new Helmert2DWithZOffset(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Helmert Transform definition
+   * @public */
   public toJSON(): Helmert2DWithZOffsetProps {
     return { translationX: this.translationX, translationY: this.translationY, translationZ: this.translationZ, rotDeg: this.rotDeg, scale: this.scale };
   }
 
-  /** @internal */
+  /** Compares two Helmert2DWithZOffset objects. It is a strict compare operation.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: Helmert2DWithZOffset): boolean {
     return (this.translationX === other.translationX &&
       this.translationY === other.translationY &&
@@ -101,17 +105,21 @@ export class AdditionalTransform implements AdditionalTransformProps {
       this.helmert2DWithZOffset = data.helmert2DWithZOffset ? Helmert2DWithZOffset.fromJSON(data.helmert2DWithZOffset) : undefined;
   }
 
-  /** @internal */
+  /** Creates an Additional Transform from JSON representation.
+   * @public */
   public static fromJSON(data: AdditionalTransformProps): AdditionalTransform {
     return new AdditionalTransform(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Additional Transform definition
+   * @public */
   public toJSON(): AdditionalTransformProps {
     return { helmert2DWithZOffset: this.helmert2DWithZOffset };
   }
 
-  /** @internal */
+  /** Compares two additional transforms. It is a strict compare operation.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: AdditionalTransform): boolean {
     if ((this.helmert2DWithZOffset === undefined) !== (other.helmert2DWithZOffset === undefined))
       return false;

--- a/core/common/src/geometry/CoordinateReferenceSystem.ts
+++ b/core/common/src/geometry/CoordinateReferenceSystem.ts
@@ -42,17 +42,21 @@ export class HorizontalCRSArea implements HorizontalCRSAreaProps {
     }
   }
 
-  /** @internal */
+  /** Creates an Area object from JSON representation.
+   * @public */
   public static fromJSON(data: HorizontalCRSAreaProps): HorizontalCRSArea {
     return new HorizontalCRSArea(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Area definition
+   * @public */
   public toJSON(): HorizontalCRSAreaProps {
     return { latitude: this.latitude.toJSON(), longitude: this.longitude.toJSON() };
   }
 
-  /** @internal */
+  /** Compares two Areas. It is a strict compare operation.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: HorizontalCRSArea): boolean {
     return this.latitude.equals(other.latitude) && this.longitude.equals(other.longitude);
   }
@@ -183,12 +187,14 @@ export class HorizontalCRS implements HorizontalCRSProps {
     }
   }
 
-  /** @internal */
+  /** Creates an Horizontal CRS from JSON representation.
+   * @public */
   public static fromJSON(data: HorizontalCRSProps): HorizontalCRS {
     return new HorizontalCRS(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Horizontal CRS definition
+   * @public */
   public toJSON(): HorizontalCRSProps {
     const data: HorizontalCRSProps = {};
     data.id = this.id;
@@ -207,7 +213,10 @@ export class HorizontalCRS implements HorizontalCRSProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two horizontal CRS. It is a strict compare operation not an equivalence test.
+   * It takes into account descriptive properties not only mathematical definition properties.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: HorizontalCRS): boolean {
     if (this.id !== other.id ||
       this.description !== other.description ||
@@ -272,17 +281,22 @@ export class VerticalCRS implements VerticalCRSProps {
       this.id = data.id;
   }
 
-  /** @internal */
+  /** Creates a Vertical CRS from JSON representation.
+   * @public */
   public static fromJSON(data: VerticalCRSProps): VerticalCRS {
     return new VerticalCRS(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Vertical CRS definition
+   * @public */
   public toJSON(): VerticalCRSProps {
     return { id: this.id };
   }
 
-  /** @internal */
+  /** Compares two vertical CRS. It is a strict compare operation not an equivalence test.
+   * It takes into account descriptive properties not only mathematical definition properties.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: VerticalCRS): boolean {
     return (this.id === other.id);
   }
@@ -341,12 +355,14 @@ export class GeographicCRS implements GeographicCRSProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Geographic CRS from JSON representation.
+   * @public */
   public static fromJSON(data: GeographicCRSProps): GeographicCRS {
     return new GeographicCRS(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Geographic CRS definition
+   * @public */
   public toJSON(): GeographicCRSProps {
     const data: GeographicCRSProps = {};
     data.horizontalCRS = this.horizontalCRS ? this.horizontalCRS.toJSON() : undefined;
@@ -355,7 +371,10 @@ export class GeographicCRS implements GeographicCRSProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two Geographic CRS. It is a strict compare operation not an equivalence test.
+   * It takes into account descriptive properties not only mathematical definition properties.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GeographicCRS): boolean {
     if ((this.horizontalCRS === undefined) !== (other.horizontalCRS === undefined))
       return false;

--- a/core/common/src/geometry/GeodeticDatum.ts
+++ b/core/common/src/geometry/GeodeticDatum.ts
@@ -38,17 +38,21 @@ export class XyzRotation implements XyzRotationProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Rotations object from JSON representation.
+   * @public */
   public static fromJSON(data: XyzRotationProps): XyzRotation {
     return new XyzRotation(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Rotations definition
+   * @public */
   public toJSON(): XyzRotationProps {
     return { x: this.x, y: this.y, z: this.z };
   }
 
-  /** @internal */
+  /** Compares two geodetic rotations. It is a strict compare operation.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: XyzRotation): boolean {
     return (this.x === other.x && this.y === other.y && this.z === other.z);
   }
@@ -84,17 +88,21 @@ export class GeocentricTransform implements GeocentricTransformProps {
     this.delta = data ? Vector3d.fromJSON(data.delta) : new Vector3d();
   }
 
-  /** @internal */
+  /** Creates a Geocentric Transform from JSON representation.
+   * @public */
   public static fromJSON(data: GeocentricTransformProps): GeocentricTransform {
     return new GeocentricTransform(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Geodetic GeocentricTransform definition
+   * @public */
   public toJSON(): GeocentricTransformProps {
     return { delta: { x: this.delta.x, y: this.delta.y, z: this.delta.z } };
   }
 
-  /** @internal */
+  /** Compares two geodetic transforms. It is a strict compare operation not equivalence test.
+   *  It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GeocentricTransform): boolean {
     return (this.delta.x === other.delta.x && this.delta.z === other.delta.z);
   }
@@ -137,12 +145,14 @@ export class PositionalVectorTransform implements PositionalVectorTransformProps
     }
   }
 
-  /** @internal */
+  /** Creates a Positional Vector Transform from JSON representation.
+   * @public */
   public static fromJSON(data: PositionalVectorTransformProps): PositionalVectorTransform {
     return new PositionalVectorTransform(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Positional Vector Transform definition
+   * @public */
   public toJSON(): PositionalVectorTransformProps {
     return {
       delta: { x: this.delta.x, y: this.delta.y, z: this.delta.z },
@@ -151,7 +161,9 @@ export class PositionalVectorTransform implements PositionalVectorTransformProps
     };
   }
 
-  /** @internal */
+  /** Compares two Positional Vector Transforms. It is a strict compare operation not an equivalence test.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: PositionalVectorTransform): boolean {
     if (this.delta.x !== other.delta.x || this.delta.z !== other.delta.z || this.scalePPM !== other.scalePPM)
       return false;
@@ -219,17 +231,21 @@ export class GridFileDefinition implements GridFileDefinitionProps {
     this.direction = data ? data.direction : "Direct";
   }
 
-  /** @internal */
+  /** Creates a Grid File Definition from JSON representation.
+   * @public */
   public static fromJSON(data: GridFileDefinitionProps): GridFileDefinition {
     return new GridFileDefinition(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Grid File Definition
+   * @public */
   public toJSON(): GridFileDefinitionProps {
     return { fileName: this.fileName, format: this.format, direction: this.direction };
   }
 
-  /** @internal */
+  /** Compares two grid file definition. It is a strict compare operation not an equivalence test.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GridFileDefinition): boolean {
     return (this.fileName === other.fileName && this.direction === other.direction && this.format === other.format);
   }
@@ -268,12 +284,14 @@ export class GridFileTransform implements GridFileTransformProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Grid File Transform from JSON representation.
+   * @public */
   public static fromJSON(data: GridFileTransformProps): GridFileTransform {
     return new GridFileTransform(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Grid File Transform definition
+   * @public */
   public toJSON(): GridFileTransformProps {
     const data: GridFileTransformProps = { files: [] };
     data.fallback = this.fallback ? this.fallback.toJSON() : undefined;
@@ -284,7 +302,9 @@ export class GridFileTransform implements GridFileTransformProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two Grid File Transforms. It is a strict compare operation not an equivalence test.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GridFileTransform): boolean {
     if (this.files.length !== other.files.length)
       return false;
@@ -310,19 +330,11 @@ export class GridFileTransform implements GridFileTransformProps {
 export interface GeodeticTransformProps {
   /* The method used by the geodetic transform */
   method: GeodeticTransformMethod;
-  /** The identifier of the source geodetic datum as stored in the dictionary or the service database.
-   *  This identifier is optional and informational only.
-   */
-  sourceEllipsoidId?: string;
   /** The complete definition of the source geodetic ellipsoid referred to by ellipsoidId.
    *  The source ellipsoid identifier enables obtaining the shape of the Earth mathematical model
    *  for the purpose of performing the transformation.
   */
   sourceEllipsoid?: GeodeticEllipsoidProps;
-  /** The identifier of the target geodetic datum as stored in the dictionary or the service database.
-   *  This identifier is optional and informational only.
-   */
-  targetEllipsoidId?: string;
   /** The complete definition of the target geodetic ellipsoid referred to by ellipsoidId.
    *  The target ellipsoid identifier enables obtaining the shape of the Earth mathematical model
    *  for the purpose of performing the transformation.*/
@@ -345,16 +357,7 @@ export class GeodeticTransform implements GeodeticTransformProps {
   /** The identifier of the source geodetic datum as stored in the dictionary or the service database.
    *  This identifier is optional and informational only.
    */
-  public readonly sourceEllipsoidId?: string;
-  /** The complete definition of the source geodetic ellipsoid referred to by ellipsoidId.
-   *  The source ellipsoid identifier enables obtaining the shape of the Earth mathematical model
-   *  for the purpose of performing the transformation.
-  */
   public readonly sourceEllipsoid?: GeodeticEllipsoid;
-  /** The identifier of the target geodetic datum as stored in the dictionary or the service database.
-   *  This identifier is optional and informational only.
-   */
-  public readonly targetEllipsoidId?: string;
   /** The complete definition of the target geodetic ellipsoid referred to by ellipsoidId.
    *  The target ellipsoid identifier enables obtaining the shape of the Earth mathematical model
    *  for the purpose of performing the transformation.*/
@@ -370,8 +373,6 @@ export class GeodeticTransform implements GeodeticTransformProps {
     this.method = "None";
     if (data) {
       this.method = data.method;
-      this.sourceEllipsoidId = data.sourceEllipsoidId;
-      this.targetEllipsoidId = data.targetEllipsoidId;
       this.sourceEllipsoid = data.sourceEllipsoid ? GeodeticEllipsoid.fromJSON(data.sourceEllipsoid) : undefined;
       this.targetEllipsoid = data.targetEllipsoid ? GeodeticEllipsoid.fromJSON(data.targetEllipsoid) : undefined;
       this.geocentric = data.geocentric ? GeocentricTransform.fromJSON(data.geocentric) : undefined;
@@ -380,16 +381,16 @@ export class GeodeticTransform implements GeodeticTransformProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Geodetic Transform from JSON representation.
+   * @public */
   public static fromJSON(data: GeodeticTransformProps): GeodeticTransform {
     return new GeodeticTransform(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Geodetic Transform definition
+   * @public */
   public toJSON(): GeodeticTransformProps {
     const data: GeodeticTransformProps = { method: this.method };
-    data.sourceEllipsoidId = this.sourceEllipsoidId;
-    data.targetEllipsoidId = this.targetEllipsoidId;
     data.sourceEllipsoid = this.sourceEllipsoid ? this.sourceEllipsoid.toJSON() : undefined;
     data.targetEllipsoid = this.targetEllipsoid ? this.targetEllipsoid.toJSON() : undefined;
     data.geocentric = this.geocentric ? this.geocentric.toJSON() : undefined;
@@ -398,11 +399,11 @@ export class GeodeticTransform implements GeodeticTransformProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two geodetic Transforms. It is a strict compare operation not an equivalence test.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GeodeticTransform): boolean {
-    if (this.method !== other.method ||
-      this.sourceEllipsoidId !== other.sourceEllipsoidId ||
-      this.targetEllipsoidId !== other.targetEllipsoidId)
+    if (this.method !== other.method)
       return false;
 
     if ((this.sourceEllipsoid === undefined) !== (other.sourceEllipsoid === undefined))
@@ -527,12 +528,14 @@ export class GeodeticDatum implements GeodeticDatumProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Geodetic Datum from JSON representation.
+   * @public */
   public static fromJSON(data: GeodeticDatumProps): GeodeticDatum {
     return new GeodeticDatum(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Geodetic Datum definition
+   * @public */
   public toJSON(): GeodeticDatumProps {
     const data: GeodeticDatumProps = {};
     data.id = this.id;
@@ -551,7 +554,10 @@ export class GeodeticDatum implements GeodeticDatumProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two Geodetic Datums. It is a strict compare operation not an equivalence test.
+   * It takes into account descriptive properties not only mathematical definition properties.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GeodeticDatum): boolean {
     if (this.id !== other.id ||
       this.description !== other.description ||

--- a/core/common/src/geometry/GeodeticEllipsoid.ts
+++ b/core/common/src/geometry/GeodeticEllipsoid.ts
@@ -73,12 +73,14 @@ export class GeodeticEllipsoid implements GeodeticEllipsoidProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Geodetic Ellipsoid from JSON representation.
+   * @public */
   public static fromJSON(data: GeodeticEllipsoidProps): GeodeticEllipsoid {
     return new GeodeticEllipsoid(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Geodetic Ellipsoid definition
+   * @public */
   public toJSON(): GeodeticEllipsoidProps {
     const data: GeodeticEllipsoidProps = { equatorialRadius: this.equatorialRadius, polarRadius: this.polarRadius };
     data.id = this.id;
@@ -92,7 +94,10 @@ export class GeodeticEllipsoid implements GeodeticEllipsoidProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two Geodetic Ellipsoid. It is a strict compare operation not an equivalence test.
+   * It takes into account descriptive properties not only mathematical definition properties.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: GeodeticEllipsoid): boolean {
     return this.id === other.id &&
       this.description === other.description &&

--- a/core/common/src/geometry/Projection.ts
+++ b/core/common/src/geometry/Projection.ts
@@ -114,17 +114,21 @@ export class AffineTransform implements AffineTransformProps {
     }
   }
 
-  /** @internal */
+  /** Creates an Affine Transform from JSON representation.
+   * @public */
   public static fromJSON(data: AffineTransformProps): AffineTransform {
     return new AffineTransform(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Affine Transform definition
+   * @public */
   public toJSON(): AffineTransformProps {
     return { translationX: this.translationX, a1: this.a1, a2: this.a2, translationY: this.translationY, b1: this.b1, b2: this.b2 };
   }
 
-  /** @internal */
+  /** Compares two Affine Transforms. It is a strict compare operation.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: AffineTransform): boolean {
     return (this.translationX === other.translationX &&
       this.translationY === other.translationY &&
@@ -301,12 +305,14 @@ export class Projection implements ProjectionProps {
     }
   }
 
-  /** @internal */
+  /** Creates a Projection from JSON representation.
+   * @public */
   public static fromJSON(data: ProjectionProps): Projection {
     return new Projection(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the Projection definition
+   * @public */
   public toJSON(): ProjectionProps {
     const data: ProjectionProps = { method: this.method };
     data.falseEasting = this.falseEasting;
@@ -334,7 +340,9 @@ export class Projection implements ProjectionProps {
     return data;
   }
 
-  /** @internal */
+  /** Compares two projections. It is a strict compare operation and not an equivalence test.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: Projection): boolean {
     if (this.method !== other.method ||
       this.falseEasting !== other.falseEasting ||
@@ -397,17 +405,21 @@ export class MinMax implements MinMaxProps {
     }
   }
 
-  /** @internal */
+  /** Creates a MinMax object from JSON representation.
+   * @public */
   public static fromJSON(data: MinMaxProps): MinMax {
     return new MinMax(data);
   }
 
-  /** @internal */
+  /** Creates a JSON from the MinMax definition
+   * @public */
   public toJSON(): MinMaxProps {
     return { min: this.min, max: this.max };
   }
 
-  /** @internal */
+  /** Compares two Min Max object. It is a strict compare operation.
+   * It is useful for tests purposes only.
+   *  @internal */
   public equals(other: MinMax): boolean {
     return (this.min === other.min && this.max === other.max);
   }

--- a/core/common/src/test/CoordinateReferenceSystem.test.ts
+++ b/core/common/src/test/CoordinateReferenceSystem.test.ts
@@ -26,8 +26,6 @@ describe("Geodetic Settings", () => {
       const outTransform = GeodeticTransform.fromJSON(output);
 
       expect(output.method === expected.method).to.be.true;
-      expect(output.sourceEllipsoidId === expected.sourceEllipsoidId).to.be.true;
-      expect(output.targetEllipsoidId === expected.targetEllipsoidId).to.be.true;
       expect((output.sourceEllipsoid === undefined) === (expected.sourceEllipsoid === undefined)).to.be.true;
       // No need to verify the ellipsoid content as they were verified in another test.
       expect((output.targetEllipsoid === undefined) === (expected.targetEllipsoid === undefined)).to.be.true;
@@ -92,7 +90,6 @@ describe("Geodetic Settings", () => {
 
     roundTrip({
       method: "GridFiles",
-      sourceEllipsoidId: "CLRK66",
       sourceEllipsoid: {
         id: "CLRK66",
         epsg: 7008,
@@ -101,7 +98,6 @@ describe("Geodetic Settings", () => {
         equatorialRadius: 6378160.0,
         polarRadius: 6356774.719195305951,
       },
-      targetEllipsoidId: "WGS84",
       targetEllipsoid: {
         id: "WGS84",
         epsg: 6326,
@@ -327,7 +323,6 @@ describe("Geodetic Settings", () => {
       transforms: [
         {
           method: "GridFiles",
-          sourceEllipsoidId: "CLRK66",
           sourceEllipsoid: {
             id: "CLRK66",
             epsg: 7008,
@@ -336,7 +331,6 @@ describe("Geodetic Settings", () => {
             equatorialRadius: 6378160.0,
             polarRadius: 6356774.719195305951,
           },
-          targetEllipsoidId: "WGS84",
           targetEllipsoid: {
             id: "WGS84",
             epsg: 6326,
@@ -485,7 +479,6 @@ describe("Geodetic Settings", () => {
         transforms: [
           {
             method: "GridFiles",
-            sourceEllipsoidId: "CLRK66",
             sourceEllipsoid: {
               id: "CLRK66",
               epsg: 7008,
@@ -494,7 +487,6 @@ describe("Geodetic Settings", () => {
               equatorialRadius: 6378160.0,
               polarRadius: 6356774.719195305951,
             },
-            targetEllipsoidId: "WGS84",
             targetEllipsoid: {
               id: "WGS84",
               epsg: 6326,
@@ -613,7 +605,6 @@ describe("Geodetic Settings", () => {
           transforms: [
             {
               method: "GridFiles",
-              sourceEllipsoidId: "CLRK66",
               sourceEllipsoid: {
                 id: "CLRK66",
                 epsg: 7008,
@@ -622,7 +613,6 @@ describe("Geodetic Settings", () => {
                 equatorialRadius: 6378160.0,
                 polarRadius: 6356774.719195305951,
               },
-              targetEllipsoidId: "WGS84",
               targetEllipsoid: {
                 id: "WGS84",
                 epsg: 6326,


### PR DESCRIPTION
Modified model to remove sourceEllipsoidId and targetEllipsoidId. These could be specified in the sourceEllipsoid and targetEllipsoid definitions provided. The previous model was copied from the previous Geodetic Datum model which made an indirect reference to an ellipsoid. In the case of a geodetic transform such indirection was unrequired an the sourceEllipsoid and targetEllipsoid contained the definition data required (polar and equatorial radiuses).
Note that since JSON def of transforms are not stored anywhere(yet) these changes do not not break any backward compatibility.