### PR TITLE
Don't apply view clip to section graphics.

### DIFF
--- a/common/changes/@bentley/hypermodeling-frontend/fix-hypermodeling_2021-05-11-16-55.json
+++ b/common/changes/@bentley/hypermodeling-frontend/fix-hypermodeling_2021-05-11-16-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/hypermodeling-frontend",
+      "comment": "Fix regression causing section graphics to be clipped by view clip.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/hypermodeling-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/hypermodeling/src/SectionGraphicsProvider.ts
+++ b/core/hypermodeling/src/SectionGraphicsProvider.ts
@@ -122,6 +122,10 @@ class ProxyTreeReference extends TileTreeReference {
     return false;
   }
 
+  public getClipVolume(tree: TileTree) {
+    return true !== HyperModeling.graphicsConfig.ignoreClip ? super.getClipVolume(tree) : undefined;
+  }
+
   public get treeOwner() { return this._owner; }
 
   private get _proxiedRef(): TileTreeReference | undefined {
@@ -172,7 +176,9 @@ abstract class ProxyTree extends TileTree {
 
     this._viewFlagOverrides = new ViewFlagOverrides(view.viewFlags);
     this._viewFlagOverrides.setApplyLighting(false);
-    this._viewFlagOverrides.setShowClipVolume(undefined !== clipVolume);
+
+    // View clip (section clip) should not apply to 2d graphics.
+    this._viewFlagOverrides.setShowClipVolume(false);
 
     this._rootTile = new ProxyTile(this, range);
   }
@@ -188,9 +194,6 @@ abstract class ProxyTree extends TileTree {
   public draw(args: TileDrawArgs): void {
     if (!this.isDisplayed)
       return;
-
-    if (this.clipVolume)
-      this.viewFlagOverrides.setShowClipVolume(true !== HyperModeling.graphicsConfig.ignoreClip);
 
     const tiles = this.selectTiles(args);
     for (const tile of tiles)


### PR DESCRIPTION
#1148 added support for nested clip volumes. That caused the view clip to start affecting section drawing graphics, which have their own clip.
Ensure view clip does not apply to section drawing graphics.