### PR TITLE
Presentation: Fix presentation-components incorectly specifying immer as a devDependency

### DIFF
--- a/common/changes/@bentley/presentation-components/master_2021-05-17-11-59.json
+++ b/common/changes/@bentley/presentation-components/master_2021-05-17-11-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "Move `immer` from `devDependencies` into `dependencies`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/presentation/components/package.json
+++ b/presentation/components/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "fast-sort": "^3.0.2",
     "fast-deep-equal": "^3.1.3",
+    "immer": "^9.0.1",
     "micro-memoize": "^4.0.9",
     "rxjs": "^6.6.2"
   },
@@ -98,7 +99,6 @@
     "eslint": "^6.8.0",
     "faker": "^4.1.0",
     "ignore-styles": "^5.0.1",
-    "immer": "^9.0.1",
     "jsdom-global": "3.0.2",
     "mocha": "^8.3.2",
     "nyc": "^15.1.0",


### PR DESCRIPTION
`immer` is being imported by `@bentley/presentation-components` library, thus it cannot be a `devDependency`.