### PR TITLE
Presentation: Fix presentation-test-app layout issue

### DIFF
--- a/test-apps/presentation-test-app/src/frontend/components/diagnostics-selector/DiagnosticsSelector.tsx
+++ b/test-apps/presentation-test-app/src/frontend/components/diagnostics-selector/DiagnosticsSelector.tsx
@@ -44,8 +44,8 @@ export function DiagnosticsSelector(props: DiagnosticsSelectorProps) {
   }, [onDiagnosticsOptionsChanged, result]);
 
   return (
-    <React.Fragment>
-      <button onClick={(e) => setPosition({ x: e.clientX, y: e.clientY })}>Diagnostics</button>
+    <button onClick={(e) => setPosition({ x: e.clientX, y: e.clientY })}>
+      Diagnostics
       <GlobalContextMenu
         className="DiagnosticsSelector"
         opened={undefined !== position}
@@ -61,6 +61,6 @@ export function DiagnosticsSelector(props: DiagnosticsSelectorProps) {
         <LabeledSelect label="Dev severity" options={["error", "warning", "info", "debug", "trace"]} value={devSeverity} onChange={(e) => setDevSeverity(e.currentTarget.value)}></LabeledSelect>
         <LabeledToggle label="Measure performance" isOn={shouldMeasurePerformance} onChange={toggleMeasurePerformance} />
       </GlobalContextMenu>
-    </React.Fragment>
+    </button>
   );
 }


### PR DESCRIPTION
After #1280, `GlobalContextMenu` started rendering a `<div />`, which broke presentation-test-app layout. This PR fixes it.