### PR TITLE
UI: Fix array and struct property record contents rendering

### DIFF
--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -2773,9 +2773,11 @@ export class MutableCategorizedArrayProperty extends MutableCategorizedProperty 
     // (undocumented)
     getChildren(): IMutableCategorizedPropertyItem[];
     // (undocumented)
-    getDescendantsAndSelf(): import("./MutableFlatGridItem").IMutableFlatGridItem[];
+    getDescendantsAndSelf(): IMutableFlatGridItem[];
     // (undocumented)
-    getVisibleDescendantsAndSelf(): import("./MutableFlatGridItem").IMutableFlatGridItem[];
+    getVisibleDescendants(): IMutableFlatGridItem[];
+    // (undocumented)
+    getVisibleDescendantsAndSelf(): IMutableFlatGridItem[];
     // (undocumented)
     get type(): FlatGridItemType.Array;
 }
@@ -2814,9 +2816,11 @@ export class MutableCategorizedStructProperty extends MutableCategorizedProperty
     // (undocumented)
     getChildren(): IMutableCategorizedPropertyItem[];
     // (undocumented)
-    getDescendantsAndSelf(): import("./MutableFlatGridItem").IMutableFlatGridItem[];
+    getDescendantsAndSelf(): IMutableFlatGridItem[];
     // (undocumented)
-    getVisibleDescendantsAndSelf(): import("./MutableFlatGridItem").IMutableFlatGridItem[];
+    getVisibleDescendants(): IMutableFlatGridItem[];
+    // (undocumented)
+    getVisibleDescendantsAndSelf(): IMutableFlatGridItem[];
     // (undocumented)
     get type(): FlatGridItemType.Struct;
 }

--- a/common/changes/@bentley/ui-components/master_2021-05-20-06-21.json
+++ b/common/changes/@bentley/ui-components/master_2021-05-20-06-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Fix array and struct property contents not being rendered in property grid when the properties have `hideCompositePropertyLabel` flag.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/ui/components/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -233,6 +233,20 @@ describe("CategorizedArrayProperty", () => {
       });
     });
 
+    describe("getVisibleDescendants", () => {
+      it("Should return children even when not expanded when `PropertyRecord.property.hideCompositePropertyLabel` is set", () => {
+        const propertyRecord = TestUtils.createArrayProperty("Prop", arrayChildren);
+        propertyRecord.property.hideCompositePropertyLabel = true;
+
+        const expectedChildren = GridUtils.createCategorizedPropertyStub(propertyRecord.getChildrenRecords(), factoryStub);
+        const { expectedDescendants } = GridUtils.setupExpectedDescendants(expectedChildren, []);
+
+        const property = new MutableCategorizedArrayProperty(propertyRecord, "Cat1", "Cat1", 0, factoryStub);
+        property.isExpanded = false;
+        expect(property.getVisibleDescendants()).to.deep.equal(expectedDescendants);
+      });
+    });
+
     describe("getVisibleDescendantsAndSelf", () => {
       it("Should return self when called on array property with no children", () => {
         const propertyRecord = TestUtils.createArrayProperty("Prop", []);

--- a/ui/components/src/test/propertygrid/component/internal/flat-items/CategorizedStructProperty.test.ts
+++ b/ui/components/src/test/propertygrid/component/internal/flat-items/CategorizedStructProperty.test.ts
@@ -224,6 +224,20 @@ describe("CategorizedStructProperty", () => {
       });
     });
 
+    describe("getVisibleDescendants", () => {
+      it("Should return children even when not expanded when `PropertyRecord.property.hideCompositePropertyLabel` is set", () => {
+        const propertyRecord = TestUtils.createStructProperty("CADID1", structChildren);
+        propertyRecord.property.hideCompositePropertyLabel = true;
+
+        const expectedChildren = GridUtils.createCategorizedPropertyStub(propertyRecord.getChildrenRecords(), factoryStub);
+        const { expectedDescendants } = GridUtils.setupExpectedDescendants(expectedChildren, []);
+
+        const property = new MutableCategorizedStructProperty(propertyRecord, "Cat1", "Cat1", 0, factoryStub);
+        property.isExpanded = false;
+        expect(property.getVisibleDescendants()).to.deep.equal(expectedDescendants);
+      });
+    });
+
     describe("getVisibleDescendantsAndSelf", () => {
       it("Should return self when called on struct property with no children", () => {
         const propertyRecord = TestUtils.createStructProperty("Prop", {});

--- a/ui/components/src/ui-components/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
+++ b/ui/components/src/ui-components/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
@@ -7,7 +7,7 @@
  * @module PropertyGrid
  */
 import { PropertyRecord } from "@bentley/ui-abstract";
-import { FlatGridItemType, IMutableCategorizedPropertyItem, MutableCategorizedProperty } from "./MutableFlatGridItem";
+import { FlatGridItemType, IMutableCategorizedPropertyItem, IMutableFlatGridItem, MutableCategorizedProperty } from "./MutableFlatGridItem";
 import { IMutableGridItemFactory } from "./MutableGridItemFactory";
 
 /**
@@ -47,6 +47,16 @@ export class MutableCategorizedArrayProperty extends MutableCategorizedProperty 
 
   public getDescendantsAndSelf() {
     return this._renderLabel ? super.getDescendantsAndSelf() : this.getDescendants();
+  }
+
+  public getVisibleDescendants(): IMutableFlatGridItem[] {
+    const descendants: IMutableFlatGridItem[] = [];
+    if (this.isExpanded || !this._renderLabel) {
+      // always render children if not rendering the label, otherwise there's no way to expand
+      // this item to make children visible
+      this.getChildren().forEach((child) => descendants.push(...child.getVisibleDescendantsAndSelf()));
+    }
+    return descendants;
   }
 
   public getVisibleDescendantsAndSelf() {

--- a/ui/components/src/ui-components/propertygrid/internal/flat-items/MutableCategorizedStructProperty.ts
+++ b/ui/components/src/ui-components/propertygrid/internal/flat-items/MutableCategorizedStructProperty.ts
@@ -7,7 +7,7 @@
  * @module PropertyGrid
  */
 import { PropertyRecord } from "@bentley/ui-abstract";
-import { FlatGridItemType, IMutableCategorizedPropertyItem, MutableCategorizedProperty } from "./MutableFlatGridItem";
+import { FlatGridItemType, IMutableCategorizedPropertyItem, IMutableFlatGridItem, MutableCategorizedProperty } from "./MutableFlatGridItem";
 import { IMutableGridItemFactory } from "./MutableGridItemFactory";
 
 /**
@@ -45,6 +45,16 @@ export class MutableCategorizedStructProperty extends MutableCategorizedProperty
 
   public getDescendantsAndSelf() {
     return this._renderLabel ? super.getDescendantsAndSelf() : this.getDescendants();
+  }
+
+  public getVisibleDescendants(): IMutableFlatGridItem[] {
+    const descendants: IMutableFlatGridItem[] = [];
+    if (this.isExpanded || !this._renderLabel) {
+      // always render children if not rendering the label, otherwise there's no way to expand
+      // this item to make children visible
+      this.getChildren().forEach((child) => descendants.push(...child.getVisibleDescendantsAndSelf()));
+    }
+    return descendants;
   }
 
   public getVisibleDescendantsAndSelf() {


### PR DESCRIPTION
There's not way to expand a composite property if we're not rendering its label. So for such composite properties we have to assume content is visible even if the property is not set as expanded.