### PR TITLE
Fix GlobalContextMenu layout issue in presentation-test-app

### DIFF
--- a/common/changes/@bentley/ui-core/updateGlobalContextMenu_2021-05-20-12-35.json
+++ b/common/changes/@bentley/ui-core/updateGlobalContextMenu_2021-05-20-12-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Fix GlobalContextMenu layout issue in presentation-test-app by setting display:none on anchoring div.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/core/src/ui-core/contextmenu/GlobalContextMenu.tsx
+++ b/ui/core/src/ui-core/contextmenu/GlobalContextMenu.tsx
@@ -78,7 +78,7 @@ export class GlobalContextMenu extends React.PureComponent<GlobalContextMenuProp
     const CtxMenu = contextMenuComponent || ContextMenu; // eslint-disable-line @typescript-eslint/naming-convention
 
     return (
-      <div ref={this._handleRefSet}>
+      <div ref={this._handleRefSet} style={{ display: "none" }}>
         {this.state.parentDocument &&
           ReactDOM.createPortal(
             <div className="core-context-menu-global" style={positioningStyle}>


### PR DESCRIPTION
Fix GlobalContextMenu layout issue in presentation-test-app by setting display:none on anchoring div.  