### PR TITLE
Fix geographicCoordinateSystem on imodelprops

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4011,7 +4011,6 @@ export abstract class IModel implements IModelProps {
     ecefToSpatial(ecef: XYAndZ, result?: Point3d): Point3d;
     // @internal
     protected _fileKey: string;
-    // (undocumented)
     get geographicCoordinateSystem(): GeographicCRS | undefined;
     set geographicCoordinateSystem(geoCRS: GeographicCRS | undefined);
     // @internal (undocumented)
@@ -4038,7 +4037,6 @@ export abstract class IModel implements IModelProps {
     rootSubject: RootSubjectProps;
     static readonly rootSubjectId: Id64String;
     setEcefLocation(ecef: EcefLocationProps): void;
-    // (undocumented)
     setGeographicCoordinateSystem(geoCRS: GeographicCRSProps): void;
     spatialToCartographicFromEcef(spatial: XYAndZ, result?: Cartographic): Cartographic;
     spatialToEcef(spatial: XYAndZ, result?: Point3d): Point3d;

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4084,7 +4084,7 @@ export class IModelNotFoundResponse extends RpcNotFoundResponse {
 // @public
 export interface IModelProps {
     ecefLocation?: EcefLocationProps;
-    geographicCoordinateSystem?: GeographicCRS;
+    geographicCoordinateSystem?: GeographicCRSProps;
     globalOrigin?: XYZProps;
     name?: string;
     projectExtents?: Range3dProps;

--- a/common/changes/@bentley/imodeljs-common/fix-gcrs-on-imodelprops_2021-05-20-19-06.json
+++ b/common/changes/@bentley/imodeljs-common/fix-gcrs-on-imodelprops_2021-05-20-19-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Corrected geographicCoordinateSystem property from GeographicCRS to GeographicCRSProps in iModelProps\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "73677355+AlainRobertAtBentley@users.noreply.github.com"
+}

--- a/core/common/src/IModel.ts
+++ b/core/common/src/IModel.ts
@@ -279,12 +279,13 @@ export abstract class IModel implements IModelProps {
     this._ecefTrans = undefined;
   }
 
-  /** The geographic coordinate reference system of the iModel.
-   * @alpha
-  */
+  /** The geographic coordinate reference system of the iModel. */
   private _geographicCoordinateSystem?: GeographicCRS;
+  /** The geographic coordinate reference system of the iModel. */
   public get geographicCoordinateSystem(): GeographicCRS | undefined { return this._geographicCoordinateSystem; }
   public set geographicCoordinateSystem(geoCRS: GeographicCRS | undefined) { this._geographicCoordinateSystem = geoCRS; }
+
+  /** Sets the geographic coordinate reference system from GeographicCRSProps. */
   public setGeographicCoordinateSystem(geoCRS: GeographicCRSProps) {
     this._geographicCoordinateSystem = new GeographicCRS(geoCRS);
   }

--- a/core/common/src/IModel.ts
+++ b/core/common/src/IModel.ts
@@ -73,7 +73,7 @@ export interface IModelProps {
   /** The location of the iModel in Earth Centered Earth Fixed coordinates. iModel units are always meters */
   ecefLocation?: EcefLocationProps;
   /** The Geographic Coordinate Reference System indicating the projection and datum used. */
-  geographicCoordinateSystem?: GeographicCRS;
+  geographicCoordinateSystem?: GeographicCRSProps;
   /** The name of the iModel. */
   name?: string;
 }


### PR DESCRIPTION
geographicCoordinateSystem property in iModelProps was incorrectly defined as GeographicCRS instead of GeographicCRSProps.