### PR TITLE
Presentation: Fix PresentationRpcImpl.loadHierarchy causing older frontends to throw

### DIFF
--- a/common/changes/@bentley/presentation-backend/presentation-patch-PresentationRpc-loadHierarchy_2021-05-04-19-07.json
+++ b/common/changes/@bentley/presentation-backend/presentation-patch-PresentationRpc-loadHierarchy_2021-05-04-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -197,7 +197,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface {
   /** @deprecated This is a noop now. Keeping just to avoid breaking the RPC interface. */
   // eslint-disable-next-line deprecation/deprecation
   public async loadHierarchy(_token: IModelRpcProps, _requestOptions: HierarchyRpcRequestOptions): PresentationRpcResponse<void> {
-    return { statusCode: PresentationStatus.Error };
+    return { statusCode: PresentationStatus.Success };
   }
 
   // eslint-disable-next-line deprecation/deprecation

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -633,14 +633,14 @@ describe("PresentationRpcImpl", () => {
 
     describe("loadHierarchy", () => {
 
-      it("returns error status", async () => {
+      it("returns success status", async () => {
         const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never>> = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
         };
         // eslint-disable-next-line deprecation/deprecation
         const actualResult = await impl.loadHierarchy(testData.imodelToken, rpcOptions);
-        expect(actualResult.statusCode).to.equal(PresentationStatus.Error);
+        expect(actualResult.statusCode).to.equal(PresentationStatus.Success);
       });
 
     });


### PR DESCRIPTION
Cherry pick of this pull request https://github.com/imodeljs/imodeljs/pull/1332

loadHierarchy was made a no op, but older frontends and rpc tests would receive an "error" status when calling method. Return success instead of error to avoid breaking older frontends.