### PR TITLE
WsgClient.getUrl returns incomplete URL when querying concurrently for the first time

### DIFF
--- a/clients/itwin/package.json
+++ b/clients/itwin/package.json
@@ -45,6 +45,7 @@
     "@types/chai": "^4.1.4",
     "@types/deep-assign": "^0.1.0",
     "@types/js-base64": "^2.3.1",
+    "@types/lodash": "^4.14.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "10.14.1",
     "@types/qs": "^6.5.0",
@@ -63,6 +64,7 @@
   "dependencies": {
     "deep-assign": "^2.0.0",
     "js-base64": "^2.4.5",
+    "lodash": "^4.17.10",
     "qs": "^6.5.1",
     "superagent": "^5.2.2",
     "xmldom": "^0.5.0",

--- a/clients/itwin/src/WsgClient.ts
+++ b/clients/itwin/src/WsgClient.ts
@@ -13,6 +13,7 @@ import { ECJsonTypeMap, WsgInstance } from "./ECJsonTypeMap";
 import { ITwinClientLoggerCategory } from "./ITwinClientLoggerCategory";
 import { request, RequestOptions, RequestQueryOptions, RequestTimeoutOptions, Response, ResponseError } from "./Request";
 import { ChunkedQueryContext } from "./ChunkedQueryContext";
+import { once } from "lodash";
 
 const loggerCategory: string = ITwinClientLoggerCategory.Clients;
 
@@ -253,17 +254,17 @@ export abstract class WsgClient extends Client {
    * @returns URL for the service
    */
   public async getUrl(requestContext: ClientRequestContext, excludeApiVersion?: boolean): Promise<string> {
-    if (this._url) {
-      return this._url;
-    }
+    return this._getUrlHelper(requestContext, excludeApiVersion);
+  }
 
+  private _getUrlHelper = once(async (requestContext: ClientRequestContext, excludeApiVersion?: boolean) => {
     const url = await super.getUrl(requestContext);
     this._url = url;
     if (!excludeApiVersion) {
       this._url = `${this._url}/${this.apiVersion}`;
     }
     return this._url; // TODO: On the server this really needs a lifetime!!
-  }
+  });
 
   /** used by clients to delete strongly typed instances through the standard WSG REST API */
   protected async deleteInstance<T extends WsgInstance>(requestContext: AuthorizedClientRequestContext, relativeUrlPath: string, instance?: T, requestOptions?: WsgRequestOptions, httpRequestOptions?: HttpRequestOptions): Promise<void> {

--- a/clients/itwin/src/test/WsgClient.test.ts
+++ b/clients/itwin/src/test/WsgClient.test.ts
@@ -53,6 +53,18 @@ export class TestWsgClient extends WsgClient {
   }
 }
 
+class TestUrlWsgClient extends WsgClient {
+
+  public constructor(apiVersion: string) {
+    super(apiVersion);
+    this.baseUrl = "https://api.bentley.com/testservice";
+  }
+
+  protected getRelyingPartyUrl() { return ""; }
+  protected getUrlSearchKey() { return ""; }
+
+}
+
 @ECJsonTypeMap.classToJson("wsg", "TestClass", { classKeyPropertyName: "className" })
 export class TestClass extends WsgInstance {
 }
@@ -182,4 +194,37 @@ describe("WsgClient", async () => {
       };
     };
   });
+
+  describe("getUrl method", () => {
+
+    it("should return correct url #1", async () => {
+      // Arrange
+      const wsgClient = new TestUrlWsgClient("2.5");
+
+      // Act
+      const url1 = await wsgClient.getUrl({} as any);
+      const url2 = await wsgClient.getUrl({} as any);
+
+      // Assert
+      expect(url1).to.be.equal("https://api.bentley.com/testservice/2.5");
+      expect(url2).to.be.equal("https://api.bentley.com/testservice/2.5");
+    });
+
+    it("should return correct url #2", async () => {
+      // Arrange
+      const wsgClient = new TestUrlWsgClient("2.5");
+
+      // Act
+      const [url1, url2] = await Promise.all([
+        wsgClient.getUrl({} as any),
+        wsgClient.getUrl({} as any),
+      ]);
+
+      // Assert
+      expect(url1).to.be.equal("https://api.bentley.com/testservice/2.5");
+      expect(url2).to.be.equal("https://api.bentley.com/testservice/2.5");
+    });
+
+  });
+
 });

--- a/common/changes/@bentley/itwin-client/wsg-client-fix_2021-05-24-13-13.json
+++ b/common/changes/@bentley/itwin-client/wsg-client-fix_2021-05-24-13-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-client",
+      "comment": "WsgClient.getUrl returns incomplete URL when querying concurently for the first time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/itwin-client",
+  "email": "17436829+GintV@users.noreply.github.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -668,7 +668,7 @@
     },
     {
       "name": "lodash",
-      "allowedCategories": [ "frontend", "tools" ]
+      "allowedCategories": [ "common", "frontend", "tools" ]
     },
     {
       "name": "lolex",


### PR DESCRIPTION
WsgClient.getUrl returns incomplete URL when querying concurrently for the first time