### PR TITLE
Footer separator fix

### DIFF
--- a/common/changes/@bentley/ui-ninezone/footer-separator-fix_2021-05-25-13-43.json
+++ b/common/changes/@bentley/ui-ninezone/footer-separator-fix_2021-05-25-13-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-ninezone",
+      "comment": "Footer separator fix",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-ninezone",
+  "email": "17436829+GintV@users.noreply.github.com"
+}

--- a/ui/ninezone/src/ui-ninezone/footer/Separator.scss
+++ b/ui/ninezone/src/ui-ninezone/footer/Separator.scss
@@ -6,6 +6,7 @@
 @import "variables";
 
 .nz-footer-separator {
+  height: fill-available;
   width: 1px;
   filter: drop-shadow(1px 0 $buic-foreground-body-reverse);
   margin: $nz-footer-indicator-vertical-padding 0;


### PR DESCRIPTION
Footer separator fix

After #1249 footer separator in status bar (when StatusBarComposer is used to build it) has disappeared. I guess setting _align-items: center;_ in _uifw-statusbar-item-container_ somehow collapses separator to nothing (I'm not sure, I'm not really css savvy). This seems to fix it. Also, #1249 was backported to 2.15 (#1279), so I guess this should be backported all the way back to 2.15 too.