### PR TITLE
UI: Remove padding around VirtualizedPropertyGrid

### DIFF
--- a/common/changes/@bentley/ui-components/ui-virtualized-property-grid_2021-05-26-08-19.json
+++ b/common/changes/@bentley/ui-components/ui-virtualized-property-grid_2021-05-26-08-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "`VirtualizedPropertyGrid`: Remove top and bottom padding.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/ui/components/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -1190,13 +1190,13 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
           highlight={highlightValue}
         />
       );
-      await waitForElement(() => container.querySelector('[class="components-property-grid"]'));
+      await waitForElement(() => container.querySelector('[class="components-virtualized-property-grid"]'));
 
       rerender(<VirtualizedPropertyGridWithDataProvider
         orientation={Orientation.Horizontal}
         dataProvider={providerMock.object}
       />);
-      await waitForElement(() => container.querySelector('[class="components-property-grid"]'));
+      await waitForElement(() => container.querySelector('[class="components-virtualized-property-grid"]'));
 
       expect(scrollToItemFake).to.not.have.been.called;
     });

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -12,13 +12,8 @@
   top: calc(50% - 24px);
 }
 
-.components-property-grid {
-  @include uicore-expandable-blocks-list;
-
-  padding-top: 6px;
-  padding-bottom: 6px;
-  display: grid;
-  grid-row-gap: 6px;
+.components-virtualized-property-grid {
+  padding: 0;
   user-select: none;
   color: $buic-foreground-body;
 

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -359,8 +359,8 @@ export class VirtualizedPropertyGrid extends React.Component<VirtualizedProperty
                 };
 
                 return (
-                  <PropertyGridInternalContextProvider value={renderContext} >
-                    <div className="components-property-grid">
+                  <PropertyGridInternalContextProvider value={renderContext}>
+                    <div className="components-virtualized-property-grid">
                       <VariableSizeList
                         className={classnames("components-property-grid-wrapper", "ReactWindow__VariableSizeList", this.props.className)}
                         width={width}


### PR DESCRIPTION
`VirtualizedPropertyGrid` is overflowing due to padding being inserted *after* container measurements are made. This is noticeable when applying `overflow: auto` style to the parent element. One common place where we would see overflow scrollbars is in ui-framework widgets.

This also removes `uicore-expandable-blocks-list` mixin because the expanding and contracting animations are not working in the virtualized list anyways.