### PR TITLE
External Textures Downsampling Improvements

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -7762,8 +7762,9 @@ export interface TextStringProps {
     widthFactor?: number;
 }
 
-// @alpha
+// @public
 export interface TextureLoadProps {
+    maxTextureSize?: number;
     name: Id64String;
 }
 

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -4608,7 +4608,6 @@ export abstract class IModelConnection extends IModel {
     getGeometryContainment(requestProps: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps>;
     getGeometrySummary(requestProps: GeometrySummaryRequestProps): Promise<string>;
     getMassProperties(requestProps: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps>;
-    // @alpha
     getTextureImage(textureLoadProps: TextureLoadProps): Promise<Uint8Array | undefined>;
     getToolTipMessage(id: Id64String): Promise<string[]>;
     // @beta

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -582,7 +582,7 @@ internal;TestRpcManager
 public;TextString
 public;TextStringPrimitive
 public;TextStringProps
-alpha;TextureLoadProps
+public;TextureLoadProps
 public;TextureMapping
 public;TextureMapping
 public;TextureMapProps

--- a/common/changes/@bentley/imodeljs-common/external-textures-downsample_2021-06-02-20-02.json
+++ b/common/changes/@bentley/imodeljs-common/external-textures-downsample_2021-06-02-20-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "TextureLoadProps takes a maxTextureSize.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/external-textures-downsample_2021-06-02-20-02.json
+++ b/common/changes/@bentley/imodeljs-frontend/external-textures-downsample_2021-06-02-20-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "External textures enabled by default for TileAdmin. External textures will downsample to maxTextureSize of client.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/core/common/src/TextureProps.ts
+++ b/core/common/src/TextureProps.ts
@@ -27,9 +27,11 @@ export interface TextureProps extends DefinitionElementProps {
 }
 
 /** Properties that specify what texture should be loaded and how it should be loaded.
- * @alpha
+ * @public
  */
 export interface TextureLoadProps {
   /** A valid Id64 string identifying the texture */
   name: Id64String;
+  /** Maximum texture size supported by the client. The texture will be downsampled so both of its dimensions adhere to this size. */
+  maxTextureSize: number;
 }

--- a/core/common/src/TextureProps.ts
+++ b/core/common/src/TextureProps.ts
@@ -32,6 +32,6 @@ export interface TextureProps extends DefinitionElementProps {
 export interface TextureLoadProps {
   /** A valid Id64 string identifying the texture */
   name: Id64String;
-  /** Maximum texture size supported by the client. The texture will be downsampled so both of its dimensions adhere to this size. */
-  maxTextureSize: number;
+  /** Maximum texture size supported by the client. If specified, the texture will be downsampled so both of its dimensions adhere to this size. */
+  maxTextureSize?: number;
 }

--- a/core/common/src/tile/IModelTileIO.ts
+++ b/core/common/src/tile/IModelTileIO.ts
@@ -33,7 +33,7 @@ export enum CurrentImdlVersion {
    * front-end is not capable of reading the tile content. Otherwise, this front-end can read the tile content even if the header specifies a
    * greater minor version than CurrentVersion.Minor, although some data may be skipped.
    */
-  Major = 23,
+  Major = 24,
   /** The unsigned 16-bit minor version number. If the major version in the tile header is equal to CurrentVersion.Major, then this package can
    * read the tile content even if the minor version in the tile header is greater than this value, although some data may be skipped.
    */

--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -70,7 +70,7 @@ export const defaultTileOptions: TileOptions = Object.freeze({
   enableInstancing: true,
   enableImprovedElision: true,
   ignoreAreaPatterns: false,
-  enableExternalTextures: false,
+  enableExternalTextures: true,
   useProjectExtents: true,
   disableMagnification: false,
   alwaysSubdivideIncompleteTiles: false,

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -444,9 +444,9 @@ export abstract class IModelConnection extends IModel {
   }
 
   /** Request a named texture image from the backend.
-   * @param textureLoadProps The texture load properties which must contain a name property (a valid 64-bit integer identifier)
+   * @param textureLoadProps The texture load properties which must contain a name property (a valid 64-bit integer identifier) and the maximum texture size supported by the client.
    * @see [[Id64]]
-   * @alpha
+   * @public
    */
   public async getTextureImage(textureLoadProps: TextureLoadProps): Promise<Uint8Array | undefined> {
     if (this.isOpen) {

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -444,7 +444,7 @@ export abstract class IModelConnection extends IModel {
   }
 
   /** Request a named texture image from the backend.
-   * @param textureLoadProps The texture load properties which must contain a name property (a valid 64-bit integer identifier) and the maximum texture size supported by the client.
+   * @param textureLoadProps The texture load properties which must contain a name property (a valid 64-bit integer identifier). It optionally can contain the maximum texture size supported by the client.
    * @see [[Id64]]
    * @public
    */

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -555,10 +555,8 @@ export class ExternalTextureLoader { /* currently exported for tests only */
         const maxTextureSize = System.instance.capabilities.maxTextureSize;
         const texBytes = await req.imodel.getTextureImage({ name: req.name, maxTextureSize });
         if (undefined !== texBytes) {
-          console.log(`texBytes.byteLength = ${  texBytes.byteLength}`);
           const imageSource = new ImageSource(texBytes, req.format);
           const image = await imageElementFromImageSource(imageSource);
-          console.log(`loaded external texture: name=${  req.name  }, width=${  image.naturalWidth  }, height=${  image.naturalHeight}`);
           if (!req.imodel.isClosed) {
             req.handle.reload(Texture2DCreateParams.createForImage(image, ImageSourceFormat.Png === req.format, req.type));
             IModelApp.tileAdmin.invalidateAllScenes();
@@ -567,7 +565,7 @@ export class ExternalTextureLoader { /* currently exported for tests only */
           }
         }
       }
-    } catch (_e) { console.log(`external texture exception: ${  _e}`); }
+    } catch (_e) { }
 
     return this._nextRequest(req);
   }
@@ -588,8 +586,6 @@ export class ExternalTextureLoader { /* currently exported for tests only */
     const req = { handle, name, imodel, type, format, onLoaded };
     if (this._requestExists(req))
       return;
-
-    console.log(`loading external texture: name=${  name}`);
 
     if (this._activeRequests.length + 1 > this._maxActiveRequests) {
       this._pendingRequests.push(req);

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -552,10 +552,13 @@ export class ExternalTextureLoader { /* currently exported for tests only */
 
     try {
       if (!req.imodel.isClosed) {
-        const texBytes = await req.imodel.getTextureImage({ name: req.name });
+        const maxTextureSize = System.instance.capabilities.maxTextureSize;
+        const texBytes = await req.imodel.getTextureImage({ name: req.name, maxTextureSize });
         if (undefined !== texBytes) {
+          console.log(`texBytes.byteLength = ${  texBytes.byteLength}`);
           const imageSource = new ImageSource(texBytes, req.format);
           const image = await imageElementFromImageSource(imageSource);
+          console.log(`loaded external texture: name=${  req.name  }, width=${  image.naturalWidth  }, height=${  image.naturalHeight}`);
           if (!req.imodel.isClosed) {
             req.handle.reload(Texture2DCreateParams.createForImage(image, ImageSourceFormat.Png === req.format, req.type));
             IModelApp.tileAdmin.invalidateAllScenes();
@@ -564,7 +567,7 @@ export class ExternalTextureLoader { /* currently exported for tests only */
           }
         }
       }
-    } catch (_e) { }
+    } catch (_e) { console.log(`external texture exception: ${  _e}`); }
 
     return this._nextRequest(req);
   }
@@ -585,6 +588,8 @@ export class ExternalTextureLoader { /* currently exported for tests only */
     const req = { handle, name, imodel, type, format, onLoaded };
     if (this._requestExists(req))
       return;
+
+    console.log(`loading external texture: name=${  name}`);
 
     if (this._activeRequests.length + 1 > this._maxActiveRequests) {
       this._pendingRequests.push(req);

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -899,9 +899,9 @@ export namespace TileAdmin { // eslint-disable-line no-redeclare
      */
     ignoreAreaPatterns?: boolean;
 
-    /** If true, during tile generation the backend will not embed all texture image data in the tile content. If texture image data is considered large enough by the backend, it will not be embedded in the tile content and the frontend will request that element texture data separately from the backend. This can help reduce the amount of memory consumed by the frontend and the amount of data sent to the frontend.
+    /** If true, during tile generation the backend will not embed all texture image data in the tile content. If texture image data is considered large enough by the backend, it will not be embedded in the tile content and the frontend will request that element texture data separately from the backend. This can help reduce the amount of memory consumed by the frontend and the amount of data sent to the frontend. Also, if this is enabled, requested textures that exceed the maximum texture size supported by the client will be downsampled.
      *
-     * Default value: false
+     * Default value: true
      */
     enableExternalTextures?: boolean;
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -26,3 +26,5 @@ To disable external textures, pass a `TileAdmin` to [IModelApp.startup]($fronten
   const tileAdmin = TileAdmin.create(tileAdminProps);
   IModelApp.startup({ tileAdmin });
 ```
+
+Disabling this feature will incur a performance penalty. The option to disable this feature will likely be removed in the future.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -10,3 +10,19 @@ publish: false
 Sometimes there's a need to associate content items with given input. For example, when requesting child elements' content based on given parent keys, we may want to know which child element content item is related to which
 given parent key. That information has been made available through [Item.inputKeys]($presentation-common) attribute. Because getting this information may be somewhat expensive and is needed only occasionally, it's only set
 when content is requested with [ContentFlags.IncludeInputKeys]($presentation-common) flag.
+
+## External textures
+
+The external textures feature is now enabled by default.
+
+Previously, by default the images for textured materials would be embedded in the tile contents. This increased the size of the tile, consumed bandwidth, and imposed other penalties. The external textures feature, however, requires only the Id of the texture element to be included in the tile; the image can then be requested separately. Texture images are cached, so the image need only be requested once no matter how many tiles reference it.
+
+Additionally, if a dimension of the external texture exceeds the client's maximum supported texture size, the image will be downsampled to adhere to that limit before being transmitted to the client.
+
+To disable external textures, pass a `TileAdmin` to [IModelApp.startup]($frontend) with the feature disabled as follows:
+
+```ts
+  const tileAdminProps: TileAdmin.Props = { enableExternalTextures: false };
+  const tileAdmin = TileAdmin.create(tileAdminProps);
+  IModelApp.startup({ tileAdmin });
+```

--- a/full-stack-tests/core/src/frontend/hub/ExternalTextures.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/ExternalTextures.test.ts
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { ImageSourceFormat, RenderTexture } from "@bentley/imodeljs-common";
-import { CheckpointConnection, IModelApp, IModelConnection } from "@bentley/imodeljs-frontend";
+import { ImageSource, ImageSourceFormat, RenderTexture } from "@bentley/imodeljs-common";
+import { CheckpointConnection, imageElementFromImageSource, IModelApp, IModelConnection } from "@bentley/imodeljs-frontend";
 import { ExternalTextureLoader, ExternalTextureRequest, GL, Texture2DHandle } from "@bentley/imodeljs-frontend/lib/webgl";
 import { TestUsers } from "@bentley/oidc-signin-tool/lib/frontend";
 import { TestUtility } from "./TestUtility";
@@ -21,6 +21,13 @@ describe("external texture requests (#integration)", () => {
     "0x82", "0x85", "0x8a", "0x8c", "0x8f", "0x91",
     "0x94", "0x97", "0x99", "0x9b", "0x9d", "0x9f",
     "0x03", // bad request
+    "0xa1", "0xa3", "0xa5"];
+  const goodTexNames = [
+    "0x48", "0x4b", "0x52", "0x54", "0x56", "0x59",
+    "0x5e", "0x60", "0x64", "0x66", "0x69", "0x6d",
+    "0x6f", "0x71", "0x73", "0x75", "0x7c", "0x7f",
+    "0x82", "0x85", "0x8a", "0x8c", "0x8f", "0x91",
+    "0x94", "0x97", "0x99", "0x9b", "0x9d", "0x9f",
     "0xa1", "0xa3", "0xa5"];
   const numExpectedBadRequests = 3;
   const finishedTexRequests: Array<ExternalTextureRequest> = [];
@@ -100,8 +107,33 @@ describe("external texture requests (#integration)", () => {
     });
   }
 
+  async function testDownsamplingTextures() {
+    const maxTextureSize = 8;
+    for (const name of goodTexNames) {
+      // check that requested textures are downsampled to maxTexturesize when requested.
+      let texBytes = await imodel.getTextureImage({ name, maxTextureSize });
+      expect(texBytes).to.not.be.undefined;
+      let imageSource = new ImageSource(texBytes!, ImageSourceFormat.Jpeg);
+      let image = await imageElementFromImageSource(imageSource);
+      expect(image.width).to.be.lessThanOrEqual(maxTextureSize);
+      expect(image.height).to.be.lessThanOrEqual(maxTextureSize);
+
+      // check that requests textures are not downsampled when not requested.
+      texBytes = await imodel.getTextureImage({ name });
+      expect(texBytes).to.not.be.undefined;
+      imageSource = new ImageSource(texBytes!, ImageSourceFormat.Jpeg);
+      image = await imageElementFromImageSource(imageSource);
+      expect(image.width).to.be.greaterThan(maxTextureSize);
+      expect(image.height).to.be.greaterThan(maxTextureSize);
+    }
+  }
+
   it("should process all external texture requests", async () => {
     await testExternalTextures();
+  });
+
+  it("should downsample external textures as needed", async () => {
+    await testDownsamplingTextures();
   });
 });
 

--- a/full-stack-tests/core/src/frontend/hub/ExternalTextures.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/ExternalTextures.test.ts
@@ -117,6 +117,7 @@ describe("external texture requests (#integration)", () => {
       let image = await imageElementFromImageSource(imageSource);
       expect(image.width).to.be.lessThanOrEqual(maxTextureSize);
       expect(image.height).to.be.lessThanOrEqual(maxTextureSize);
+      expect(image.width === maxTextureSize || image.height === maxTextureSize).to.be.true;
 
       // check that requests textures are not downsampled when not requested.
       texBytes = await imodel.getTextureImage({ name });


### PR DESCRIPTION
Corresponding native addon PR: https://bentleycs.visualstudio.com/iModelTechnologies/_git/imodel02/pullrequest/167800

The external textures feature is now enabled by default.

Previously, by default the images for textured materials would be embedded in the tile contents. This increased the size of the tile, consumed bandwidth, and imposed other penalties. The external textures feature, however, requires only the Id of the texture element to be included in the tile; the image can then be requested separately. Texture images are cached, so the image need only be requested once no matter how many tiles reference it.

Additionally, if a dimension of the external texture exceeds the client's maximum supported texture size, the image will be downsampled to adhere to that limit before being transmitted to the client.