### PR TITLE
Presentation: Handling large number of IDs in a ruleset variable

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -42,7 +42,6 @@ import { SelectionScope } from '@bentley/presentation-common';
 import { SelectionScopeRequestOptions } from '@bentley/presentation-common';
 import { UpdateInfoJSON } from '@bentley/presentation-common';
 import { VariableValue } from '@bentley/presentation-common';
-import { VariableValueJSON } from '@bentley/presentation-common';
 import { VariableValueTypes } from '@bentley/presentation-common';
 
 // @beta
@@ -350,7 +349,7 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
     // (undocumented)
     getValue(variableId: string, type: VariableValueTypes): VariableValue;
     // (undocumented)
-    getValueJSON(variableId: string, type: VariableValueTypes): VariableValueJSON;
+    getValueInternal(variableId: string, type: VariableValueTypes): VariableValue;
     setBool(variableId: string, value: boolean): void;
     setId64(variableId: string, value: Id64String): void;
     setId64s(variableId: string, value: Id64String[]): void;
@@ -360,7 +359,7 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
     // (undocumented)
     setValue(variableId: string, type: VariableValueTypes, value: VariableValue): void;
     // (undocumented)
-    setValueJSON(variableId: string, type: VariableValueTypes, value: VariableValueJSON): void;
+    setValueInternal(variableId: string, type: VariableValueTypes, value: VariableValue): void;
 }
 
 // @alpha

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { BentleyError } from '@bentley/bentleyjs-core';
+import { CompressedId64Set } from '@bentley/bentleyjs-core';
 import { EntityProps } from '@bentley/imodeljs-common';
 import { FormatProps } from '@bentley/imodeljs-quantity';
 import { GetMetaDataFunction } from '@bentley/bentleyjs-core';
@@ -59,6 +60,22 @@ export interface BaseNodeKey {
 export interface BaseTypeDescription {
     typeName: string;
     valueFormat: PropertyValueFormat;
+}
+
+// @public
+export interface BooleanRulesetVariable extends RulesetVariableBase {
+    // (undocumented)
+    type: VariableValueTypes.Bool;
+    // (undocumented)
+    value: boolean;
+}
+
+// @public
+export interface BooleanRulesetVariableJSON extends RulesetVariableBaseJSON {
+    // (undocumented)
+    type: VariableValueTypes.Bool;
+    // (undocumented)
+    value: boolean;
 }
 
 // @public
@@ -215,14 +232,14 @@ export class Content {
 }
 
 // @public
-export interface ContentDescriptorRequestOptions<TIModel, TKeySet> extends RequestOptionsWithRuleset<TIModel> {
+export interface ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
     displayType: string;
     keys: TKeySet;
     selection?: SelectionInfo;
 }
 
 // @public
-export type ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions<ContentDescriptorRequestOptions<never, KeySetJSON>>;
+export type ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions<ContentDescriptorRequestOptions<never, KeySetJSON, RulesetVariableJSON>>;
 
 // @public
 export enum ContentFlags {
@@ -284,11 +301,11 @@ export interface ContentRelatedInstancesSpecificationNew extends ContentSpecific
 }
 
 // @public @deprecated
-export interface ContentRequestOptions<TIModel> extends RequestOptionsWithRuleset<TIModel> {
+export interface ContentRequestOptions<TIModel, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
 }
 
 // @public @deprecated
-export type ContentRpcRequestOptions = PresentationRpcRequestOptions<ContentRequestOptions<never>>;
+export type ContentRpcRequestOptions = PresentationRpcRequestOptions<ContentRequestOptions<never, RulesetVariableJSON>>;
 
 // @public
 export interface ContentRule extends RuleBase, ConditionContainer {
@@ -655,14 +672,14 @@ export interface DisplayValuesMapJSON extends ValuesDictionary<DisplayValueJSON>
 }
 
 // @public
-export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet> extends Paged<RequestOptionsWithRuleset<TIModel>> {
+export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable = RulesetVariable> extends Paged<RequestOptionsWithRuleset<TIModel, TRulesetVariable>> {
     descriptor: TDescriptor | DescriptorOverrides;
     fieldDescriptor: FieldDescriptor;
     keys: TKeySet;
 }
 
 // @public
-export type DistinctValuesRpcRequestOptions = PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON>>;
+export type DistinctValuesRpcRequestOptions = PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>;
 
 // @public
 export interface ECClassGroupingNodeKey extends GroupingNodeKey {
@@ -744,13 +761,13 @@ export interface ExpandedNodeUpdateRecordJSON {
 }
 
 // @public
-export interface ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet> extends RequestOptionsWithRuleset<TIModel> {
+export interface ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
     descriptor: TDescriptor | DescriptorOverrides;
     keys: TKeySet;
 }
 
 // @public
-export type ExtendedContentRpcRequestOptions = PresentationRpcRequestOptions<ExtendedContentRequestOptions<never, DescriptorJSON, KeySetJSON>>;
+export type ExtendedContentRpcRequestOptions = PresentationRpcRequestOptions<ExtendedContentRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>;
 
 // @public
 export interface ExtendedDataRule extends RuleBase, ConditionContainer {
@@ -762,12 +779,12 @@ export interface ExtendedDataRule extends RuleBase, ConditionContainer {
 }
 
 // @public
-export interface ExtendedHierarchyRequestOptions<TIModel, TNodeKey> extends RequestOptionsWithRuleset<TIModel> {
+export interface ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
     parentKey?: TNodeKey;
 }
 
 // @public
-export type ExtendedHierarchyRpcRequestOptions = PresentationRpcRequestOptions<ExtendedHierarchyRequestOptions<never, NodeKeyJSON>>;
+export type ExtendedHierarchyRpcRequestOptions = PresentationRpcRequestOptions<ExtendedHierarchyRequestOptions<never, NodeKeyJSON, RulesetVariableJSON>>;
 
 // @public
 export class Field {
@@ -893,7 +910,7 @@ export interface HierarchyCompareInfoJSON {
 }
 
 // @public
-export interface HierarchyCompareOptions<TIModel, TNodeKey> extends RequestOptionsWithRuleset<TIModel> {
+export interface HierarchyCompareOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
     // (undocumented)
     continuationToken?: {
         prevHierarchyNode: string;
@@ -904,21 +921,21 @@ export interface HierarchyCompareOptions<TIModel, TNodeKey> extends RequestOptio
     // (undocumented)
     prev: {
         rulesetOrId?: Ruleset | string;
-        rulesetVariables?: RulesetVariable[];
+        rulesetVariables?: TRulesetVariable[];
     };
     // (undocumented)
     resultSetSize?: number;
 }
 
 // @public
-export type HierarchyCompareRpcOptions = PresentationRpcRequestOptions<HierarchyCompareOptions<never, NodeKeyJSON>>;
+export type HierarchyCompareRpcOptions = PresentationRpcRequestOptions<HierarchyCompareOptions<never, NodeKeyJSON, RulesetVariableJSON>>;
 
 // @public @deprecated
-export interface HierarchyRequestOptions<TIModel> extends RequestOptionsWithRuleset<TIModel> {
+export interface HierarchyRequestOptions<TIModel, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
 }
 
 // @public @deprecated
-export type HierarchyRpcRequestOptions = PresentationRpcRequestOptions<HierarchyRequestOptions<never>>;
+export type HierarchyRpcRequestOptions = PresentationRpcRequestOptions<HierarchyRequestOptions<never, RulesetVariableJSON>>;
 
 // @alpha (undocumented)
 export type HierarchyUpdateInfo = typeof UPDATE_FULL | HierarchyUpdateRecord[];
@@ -956,6 +973,38 @@ export interface HierarchyUpdateRecordJSON {
     nodesCount: number;
     // (undocumented)
     parent?: NodeKeyJSON;
+}
+
+// @public
+export interface Id64RulesetVariable extends RulesetVariableBase {
+    // (undocumented)
+    type: VariableValueTypes.Id64;
+    // (undocumented)
+    value: Id64String;
+}
+
+// @public
+export interface Id64RulesetVariableJSON extends RulesetVariableBaseJSON {
+    // (undocumented)
+    type: VariableValueTypes.Id64;
+    // (undocumented)
+    value: Id64String;
+}
+
+// @public
+export interface Id64sRulesetVariable extends RulesetVariableBase {
+    // (undocumented)
+    type: VariableValueTypes.Id64Array;
+    // (undocumented)
+    value: Id64String[];
+}
+
+// @public
+export interface Id64sRulesetVariableJSON extends RulesetVariableBaseJSON {
+    // (undocumented)
+    type: VariableValueTypes.Id64Array;
+    // (undocumented)
+    value: CompressedId64Set;
 }
 
 // @public
@@ -1094,8 +1143,40 @@ export interface InstanceNodesOfSpecificClassesSpecification extends ChildNodeSp
     specType: ChildNodeSpecificationTypes.InstanceNodesOfSpecificClasses;
 }
 
+// @public
+export interface IntRulesetVariable extends RulesetVariableBase {
+    // (undocumented)
+    type: VariableValueTypes.Int;
+    // (undocumented)
+    value: number;
+}
+
+// @public
+export interface IntRulesetVariableJSON extends RulesetVariableBaseJSON {
+    // (undocumented)
+    type: VariableValueTypes.Int;
+    // (undocumented)
+    value: number;
+}
+
+// @public
+export interface IntsRulesetVariable extends RulesetVariableBase {
+    // (undocumented)
+    type: VariableValueTypes.IntArray;
+    // (undocumented)
+    value: number[];
+}
+
+// @public
+export interface IntsRulesetVariableJSON extends RulesetVariableBaseJSON {
+    // (undocumented)
+    type: VariableValueTypes.IntArray;
+    // (undocumented)
+    value: number[];
+}
+
 // @internal (undocumented)
-export const isContentDescriptorRequestOptions: <TIModel, TKeySet>(opts: ContentRequestOptions<TIModel> | ContentDescriptorRequestOptions<TIModel, TKeySet>) => opts is ContentDescriptorRequestOptions<TIModel, TKeySet>;
+export const isContentDescriptorRequestOptions: <TIModel, TKeySet, TRulesetVariable>(opts: ContentRequestOptions<TIModel, RulesetVariable> | ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable>) => opts is ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable>;
 
 // @internal (undocumented)
 export const isDisplayLabelRequestOptions: <TIModel, TInstanceKey>(opts: LabelRequestOptions<TIModel> | DisplayLabelRequestOptions<TIModel, TInstanceKey>) => opts is DisplayLabelRequestOptions<TIModel, TInstanceKey>;
@@ -1104,10 +1185,10 @@ export const isDisplayLabelRequestOptions: <TIModel, TInstanceKey>(opts: LabelRe
 export const isDisplayLabelsRequestOptions: <TIModel, TInstanceKey>(opts: LabelRequestOptions<TIModel> | DisplayLabelsRequestOptions<TIModel, TInstanceKey>) => opts is DisplayLabelsRequestOptions<TIModel, TInstanceKey>;
 
 // @internal (undocumented)
-export const isExtendedContentRequestOptions: <TIModel, TDescriptor, TKeySet>(opts: ContentRequestOptions<TIModel> | ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet>) => opts is ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet>;
+export const isExtendedContentRequestOptions: <TIModel, TDescriptor, TKeySet, TRulesetVariable>(opts: ContentRequestOptions<TIModel, RulesetVariable> | ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable>) => opts is ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable>;
 
 // @internal (undocumented)
-export const isExtendedHierarchyRequestOptions: <TIModel, TNodeKey>(opts: HierarchyRequestOptions<TIModel> | ExtendedHierarchyRequestOptions<TIModel, TNodeKey>) => opts is ExtendedHierarchyRequestOptions<TIModel, TNodeKey>;
+export const isExtendedHierarchyRequestOptions: <TIModel, TNodeKey, TRulesetVariable>(opts: HierarchyRequestOptions<TIModel, RulesetVariable> | ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable>) => opts is ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable>;
 
 // @public
 export class Item {
@@ -1671,7 +1752,7 @@ export const PRESENTATION_COMMON_ROOT: string;
 export const PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface";
 
 // @public @deprecated
-export type PresentationDataCompareOptions<TIModel, TNodeKey> = HierarchyCompareOptions<TIModel, TNodeKey>;
+export type PresentationDataCompareOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> = HierarchyCompareOptions<TIModel, TNodeKey, TRulesetVariable>;
 
 // @public
 export class PresentationError extends BentleyError {
@@ -2196,9 +2277,9 @@ export interface RequestOptions<TIModel> {
 }
 
 // @public
-export interface RequestOptionsWithRuleset<TIModel> extends RequestOptions<TIModel> {
+export interface RequestOptionsWithRuleset<TIModel, TRulesetVariable = RulesetVariable> extends RequestOptions<TIModel> {
     rulesetOrId: Ruleset | string;
-    rulesetVariables?: RulesetVariable[];
+    rulesetVariables?: TRulesetVariable[];
 }
 
 // @public
@@ -2226,38 +2307,38 @@ export class RpcRequestsHandler implements IDisposable {
     constructor(props?: RpcRequestsHandlerProps);
     readonly clientId: string;
     // (undocumented)
-    compareHierarchies(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON>): Promise<PartialHierarchyModificationJSON[]>;
+    compareHierarchies(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<PartialHierarchyModificationJSON[]>;
     // (undocumented)
-    compareHierarchiesPaged(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON>): Promise<HierarchyCompareInfoJSON>;
+    compareHierarchiesPaged(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<HierarchyCompareInfoJSON>;
     // (undocumented)
     computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string): Promise<KeySetJSON>;
     // (undocumented)
     dispose(): void;
     // (undocumented)
-    getContentDescriptor(options: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON>): Promise<DescriptorJSON | undefined>;
+    getContentDescriptor(options: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>): Promise<DescriptorJSON | undefined>;
     // (undocumented)
-    getContentSetSize(options: ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>): Promise<number>;
+    getContentSetSize(options: ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>): Promise<number>;
     // (undocumented)
     getDisplayLabelDefinition(options: DisplayLabelRequestOptions<IModelRpcProps, InstanceKeyJSON>): Promise<LabelDefinitionJSON>;
     // (undocumented)
-    getFilteredNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never>, filterText: string): Promise<NodePathElementJSON[]>;
+    getFilteredNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON>, filterText: string): Promise<NodePathElementJSON[]>;
     // (undocumented)
-    getNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never>, paths: InstanceKeyJSON[][], markedIndex: number): Promise<NodePathElementJSON[]>;
+    getNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON>, paths: InstanceKeyJSON[][], markedIndex: number): Promise<NodePathElementJSON[]>;
     // (undocumented)
-    getNodesCount(options: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>): Promise<number>;
+    getNodesCount(options: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<number>;
     // (undocumented)
-    getPagedContent(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>): Promise<{
+    getPagedContent(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>): Promise<{
         descriptor: DescriptorJSON;
         contentSet: PagedResponse<ItemJSON>;
     } | undefined>;
     // (undocumented)
-    getPagedContentSet(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>): Promise<PagedResponse<ItemJSON>>;
+    getPagedContentSet(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>): Promise<PagedResponse<ItemJSON>>;
     // (undocumented)
     getPagedDisplayLabelDefinitions(options: DisplayLabelsRequestOptions<IModelRpcProps, InstanceKeyJSON>): Promise<PagedResponse<LabelDefinitionJSON>>;
     // (undocumented)
-    getPagedDistinctValues(options: DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>): Promise<PagedResponse<DisplayValueGroupJSON>>;
+    getPagedDistinctValues(options: DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>): Promise<PagedResponse<DisplayValueGroupJSON>>;
     // (undocumented)
-    getPagedNodes(options: Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>>): Promise<PagedResponse<NodeJSON>>;
+    getPagedNodes(options: Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>): Promise<PagedResponse<NodeJSON>>;
     // (undocumented)
     getSelectionScopes(options: SelectionScopeRequestOptions<IModelRpcProps>): Promise<SelectionScope[]>;
     request<TResult, TOptions extends RequestOptions<IModelRpcProps>, TArg = any>(func: (token: IModelRpcProps, options: PresentationRpcRequestOptions<TOptions>, ...args: TArg[]) => PresentationRpcResponse<TResult>, options: TOptions, ...additionalOptions: TArg[]): Promise<TResult>;
@@ -2303,7 +2384,16 @@ export class RulesetsFactory {
     }
 
 // @public
-export interface RulesetVariable {
+export type RulesetVariable = BooleanRulesetVariable | StringRulesetVariable | IntRulesetVariable | IntsRulesetVariable | Id64RulesetVariable | Id64sRulesetVariable;
+
+// @public (undocumented)
+export namespace RulesetVariable {
+    export function fromJSON(json: RulesetVariableJSON): RulesetVariable;
+    export function toJSON(variable: RulesetVariable): RulesetVariableJSON;
+}
+
+// @public
+export interface RulesetVariableBase {
     // (undocumented)
     id: string;
     // (undocumented)
@@ -2313,7 +2403,7 @@ export interface RulesetVariable {
 }
 
 // @public
-export interface RulesetVariableJSON {
+export interface RulesetVariableBaseJSON {
     // (undocumented)
     id: string;
     // (undocumented)
@@ -2321,6 +2411,9 @@ export interface RulesetVariableJSON {
     // (undocumented)
     value: VariableValueJSON;
 }
+
+// @public
+export type RulesetVariableJSON = BooleanRulesetVariableJSON | StringRulesetVariableJSON | IntRulesetVariableJSON | IntsRulesetVariableJSON | Id64RulesetVariableJSON | Id64sRulesetVariableJSON;
 
 // @public
 export enum RuleTypes {
@@ -2485,6 +2578,22 @@ export interface StringQuerySpecification extends QuerySpecificationBase {
 }
 
 // @public
+export interface StringRulesetVariable extends RulesetVariableBase {
+    // (undocumented)
+    type: VariableValueTypes.String;
+    // (undocumented)
+    value: string;
+}
+
+// @public
+export interface StringRulesetVariableJSON extends RulesetVariableBaseJSON {
+    // (undocumented)
+    type: VariableValueTypes.String;
+    // (undocumented)
+    value: string;
+}
+
+// @public
 export interface StrippedRelatedClassInfo {
     // (undocumented)
     isForwardRelationship: boolean;
@@ -2638,10 +2747,10 @@ export interface VariablesGroup {
 }
 
 // @public
-export type VariableValue = boolean | string | number | number[] | Id64String[];
+export type VariableValue = boolean | string | number | number[] | Id64String | Id64String[];
 
 // @public
-export type VariableValueJSON = boolean | string | string[] | number | number[];
+export type VariableValueJSON = boolean | string | number | number[] | Id64String | CompressedId64Set;
 
 // @public
 export enum VariableValueType {

--- a/common/api/presentation-components.api.md
+++ b/common/api/presentation-components.api.md
@@ -513,7 +513,7 @@ export class PresentationTreeDataProvider implements IPresentationTreeDataProvid
 // @beta
 export interface PresentationTreeDataProviderDataSourceEntryPoints {
     // (undocumented)
-    getFilteredNodePaths: (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>, filterText: string) => Promise<NodePathElement[]>;
+    getFilteredNodePaths: (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never>, filterText: string) => Promise<NodePathElement[]>;
     // (undocumented)
     getNodesAndCount: (requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>) => Promise<{
         nodes: Node[];

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -257,27 +257,27 @@ export class PresentationManager implements IDisposable {
     // (undocumented)
     dispose(): void;
     // @deprecated
-    getContent(requestOptions: Paged<ContentRequestOptions<IModelConnection>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<Content | undefined>;
+    getContent(requestOptions: Paged<ContentRequestOptions<IModelConnection, RulesetVariable>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<Content | undefined>;
     // (undocumented)
-    getContent(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>>): Promise<Content | undefined>;
+    getContent(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>>): Promise<Content | undefined>;
     // @deprecated
-    getContentAndSize(requestOptions: Paged<ContentRequestOptions<IModelConnection>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<{
+    getContentAndSize(requestOptions: Paged<ContentRequestOptions<IModelConnection, RulesetVariable>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<{
         content: Content;
         size: number;
     } | undefined>;
     // (undocumented)
-    getContentAndSize(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>>): Promise<{
+    getContentAndSize(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>>): Promise<{
         content: Content;
         size: number;
     } | undefined>;
     // @deprecated
-    getContentDescriptor(requestOptions: ContentRequestOptions<IModelConnection>, displayType: string, keys: KeySet, selection: SelectionInfo | undefined): Promise<Descriptor | undefined>;
+    getContentDescriptor(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable>, displayType: string, keys: KeySet, selection: SelectionInfo | undefined): Promise<Descriptor | undefined>;
     // (undocumented)
-    getContentDescriptor(requestOptions: ContentDescriptorRequestOptions<IModelConnection, KeySet>): Promise<Descriptor | undefined>;
+    getContentDescriptor(requestOptions: ContentDescriptorRequestOptions<IModelConnection, KeySet, RulesetVariable>): Promise<Descriptor | undefined>;
     // @deprecated
-    getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<number>;
+    getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<number>;
     // (undocumented)
-    getContentSetSize(requestOptions: ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>): Promise<number>;
+    getContentSetSize(requestOptions: ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>): Promise<number>;
     // @deprecated
     getDisplayLabelDefinition(requestOptions: LabelRequestOptions<IModelConnection>, key: InstanceKey): Promise<LabelDefinition>;
     // (undocumented)
@@ -287,25 +287,25 @@ export class PresentationManager implements IDisposable {
     // (undocumented)
     getDisplayLabelDefinitions(requestOptions: DisplayLabelsRequestOptions<IModelConnection, InstanceKey>): Promise<LabelDefinition[]>;
     // @deprecated
-    getDistinctValues(requestOptions: ContentRequestOptions<IModelConnection>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet, fieldName: string, maximumValueCount?: number): Promise<string[]>;
-    getFilteredNodePaths(requestOptions: HierarchyRequestOptions<IModelConnection>, filterText: string): Promise<NodePathElement[]>;
-    getNodePaths(requestOptions: HierarchyRequestOptions<IModelConnection>, paths: InstanceKey[][], markedIndex: number): Promise<NodePathElement[]>;
+    getDistinctValues(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet, fieldName: string, maximumValueCount?: number): Promise<string[]>;
+    getFilteredNodePaths(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never, RulesetVariable>, filterText: string): Promise<NodePathElement[]>;
+    getNodePaths(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never, RulesetVariable>, paths: InstanceKey[][], markedIndex: number): Promise<NodePathElement[]>;
     // @deprecated
-    getNodes(requestOptions: Paged<HierarchyRequestOptions<IModelConnection>>, parentKey: NodeKey | undefined): Promise<Node[]>;
-    getNodes(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>): Promise<Node[]>;
+    getNodes(requestOptions: Paged<HierarchyRequestOptions<IModelConnection, RulesetVariable>>, parentKey: NodeKey | undefined): Promise<Node[]>;
+    getNodes(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>>): Promise<Node[]>;
     // @deprecated
-    getNodesAndCount(requestOptions: Paged<HierarchyRequestOptions<IModelConnection>>, parentKey: NodeKey | undefined): Promise<{
+    getNodesAndCount(requestOptions: Paged<HierarchyRequestOptions<IModelConnection, RulesetVariable>>, parentKey: NodeKey | undefined): Promise<{
         count: number;
         nodes: Node[];
     }>;
-    getNodesAndCount(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>): Promise<{
+    getNodesAndCount(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>>): Promise<{
         count: number;
         nodes: Node[];
     }>;
     // @deprecated
-    getNodesCount(requestOptions: HierarchyRequestOptions<IModelConnection>, parentKey: NodeKey | undefined): Promise<number>;
-    getNodesCount(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>): Promise<number>;
-    getPagedDistinctValues(requestOptions: DistinctValuesRequestOptions<IModelConnection, Descriptor, KeySet>): Promise<PagedResponse<DisplayValueGroup>>;
+    getNodesCount(requestOptions: HierarchyRequestOptions<IModelConnection, RulesetVariable>, parentKey: NodeKey | undefined): Promise<number>;
+    getNodesCount(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>): Promise<number>;
+    getPagedDistinctValues(requestOptions: DistinctValuesRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>): Promise<PagedResponse<DisplayValueGroup>>;
     // @internal (undocumented)
     get ipcRequestsHandler(): IpcRequestsHandler | undefined;
     // @alpha @deprecated
@@ -369,7 +369,7 @@ export class RulesetManagerImpl implements RulesetManager {
 // @public
 export interface RulesetVariablesManager {
     // @internal
-    getAllVariables(): Promise<RulesetVariable[]>;
+    getAllVariables(): RulesetVariable[];
     getBool(variableId: string): Promise<boolean>;
     getId64(variableId: string): Promise<Id64String>;
     getId64s(variableId: string): Promise<Id64String[]>;
@@ -389,7 +389,7 @@ export interface RulesetVariablesManager {
 export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
     constructor(rulesetId: string, ipcHandler?: IpcRequestsHandler);
     // (undocumented)
-    getAllVariables(): Promise<RulesetVariable[]>;
+    getAllVariables(): RulesetVariable[];
     getBool(variableId: string): Promise<boolean>;
     getId64(variableId: string): Promise<Id64String>;
     getId64s(variableId: string): Promise<Id64String[]>;

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -5,6 +5,8 @@ internal;AsyncTasksTracker
 public;BaseFieldJSON
 public;BaseNodeKey
 public;BaseTypeDescription
+public;BooleanRulesetVariable 
+public;BooleanRulesetVariableJSON 
 public;CalculatedPropertiesSpecification
 public;CategoryDescription
 public;CategoryDescription
@@ -137,6 +139,10 @@ alpha;HierarchyUpdateInfoJSON = typeof UPDATE_FULL | HierarchyUpdateRecordJSON[]
 alpha;HierarchyUpdateRecord
 alpha;HierarchyUpdateRecord
 alpha;HierarchyUpdateRecordJSON
+public;Id64RulesetVariable 
+public;Id64RulesetVariableJSON 
+public;Id64sRulesetVariable 
+public;Id64sRulesetVariableJSON 
 public;ImageIdOverride 
 public;InstanceId = Id64String
 public;InstanceKey
@@ -155,6 +161,10 @@ public;InstanceLabelOverrideValueSpecification = InstanceLabelOverrideCompositeV
 public;InstanceLabelOverrideValueSpecificationBase
 public;InstanceLabelOverrideValueSpecificationType
 public;InstanceNodesOfSpecificClassesSpecification 
+public;IntRulesetVariable 
+public;IntRulesetVariableJSON 
+public;IntsRulesetVariable 
+public;IntsRulesetVariableJSON 
 internal;isContentDescriptorRequestOptions: 
 internal;isDisplayLabelRequestOptions: 
 internal;isDisplayLabelsRequestOptions: 
@@ -311,8 +321,11 @@ public;Rule = CustomizationRule | NavigationRule | ContentRule | ContentModifier
 public;RuleBase
 public;Ruleset
 public;RulesetsFactory
+public;RulesetVariable = BooleanRulesetVariable | StringRulesetVariable | IntRulesetVariable | IntsRulesetVariable | Id64RulesetVariable | Id64sRulesetVariable
 public;RulesetVariable
-public;RulesetVariableJSON
+public;RulesetVariableBase
+public;RulesetVariableBaseJSON
+public;RulesetVariableJSON = BooleanRulesetVariableJSON | StringRulesetVariableJSON | IntRulesetVariableJSON | IntsRulesetVariableJSON | Id64RulesetVariableJSON | Id64sRulesetVariableJSON
 public;RuleTypes
 public;SameLabelInstanceGroup 
 public;SameLabelInstanceGroupApplicationStage
@@ -332,6 +345,8 @@ public;SortingRule = PropertySortingRule | DisabledSortingRule
 public;SortingRuleBase 
 public;StandardNodeTypes
 public;StringQuerySpecification 
+public;StringRulesetVariable 
+public;StringRulesetVariableJSON 
 public;StrippedRelatedClassInfo
 public;StrippedRelationshipPath = StrippedRelatedClassInfo[]
 public;StructFieldMemberDescription
@@ -356,7 +371,7 @@ public;ValuesMap
 public;ValuesMapJSON 
 public;Variable
 public;VariablesGroup
-public;VariableValue = boolean | string | number | number[] | Id64String[]
-public;VariableValueJSON = boolean | string | string[] | number | number[]
+public;VariableValue = boolean | string | number | number[] | Id64String | Id64String[]
+public;VariableValueJSON = boolean | string | number | number[] | Id64String | CompressedId64Set
 public;VariableValueType
 public;VariableValueTypes

--- a/common/changes/@bentley/presentation-common/presentation-ruleset-variables-id64--_2021-06-02-14-39.json
+++ b/common/changes/@bentley/presentation-common/presentation-ruleset-variables-id64--_2021-06-02-14-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Send `Id64[]` ruleset variables as `CompressedId64Set`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/src/frontend/RulesetVariables.test.ts
+++ b/full-stack-tests/presentation/src/frontend/RulesetVariables.test.ts
@@ -351,7 +351,9 @@ describe("Ruleset Variables", async () => {
 
       // https://www.sqlite.org/limits.html#max_variable_number
       const maxNumberOfSupportedBindParams = 32766;
-      const ids = [...Array(maxNumberOfSupportedBindParams + 1).keys()].map(() => "0x61");
+      const largestECInstanceIdInTestDataset = 117;
+      const ids = [...Array(maxNumberOfSupportedBindParams).keys()].map((key) => Id64.fromUint32Pair(key + largestECInstanceIdInTestDataset + 1, 0));
+      ids.push("0x61");
 
       await Presentation.presentation.vars(ruleset.id).setId64s("ids", ids);
       content = await Presentation.presentation.getContent({ imodel, rulesetOrId: ruleset, keys: new KeySet(), descriptor: {} });

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -9,7 +9,7 @@
 import { ClientRequestContext, IDisposable } from "@bentley/bentleyjs-core";
 import { IModelDb, IModelHost, IModelJsNative } from "@bentley/imodeljs-backend";
 import {
-  DiagnosticsScopeLogs, PresentationError, PresentationStatus, UpdateInfoJSON, VariableValueJSON, VariableValueTypes,
+  DiagnosticsScopeLogs, PresentationError, PresentationStatus, UpdateInfoJSON, VariableValue, VariableValueJSON, VariableValueTypes,
 } from "@bentley/presentation-common";
 import { HierarchyCacheMode, PresentationManagerMode, UnitSystemFormat } from "./PresentationManager";
 
@@ -53,8 +53,8 @@ export interface NativePlatformDefinition extends IDisposable {
 
   handleRequest(db: any, options: string): Promise<NativePlatformResponse<string>>;
 
-  getRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes): NativePlatformResponse<VariableValueJSON>;
-  setRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes, value: VariableValueJSON): NativePlatformResponse<void>;
+  getRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes): NativePlatformResponse<VariableValue>;
+  setRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes, value: VariableValue): NativePlatformResponse<void>;
 
   getUpdateInfo(): NativePlatformResponse<UpdateInfoJSON | undefined>;
   updateHierarchyState(db: any, rulesetId: string, changeType: "nodesExpanded" | "nodesCollapsed", serializedKeys: string): NativePlatformResponse<void>;

--- a/presentation/backend/src/presentation-backend/RulesetVariablesManager.ts
+++ b/presentation/backend/src/presentation-backend/RulesetVariablesManager.ts
@@ -6,8 +6,8 @@
  * @module Core
  */
 
-import { Id64, Id64String } from "@bentley/bentleyjs-core";
-import { VariableValue, VariableValueJSON, VariableValueTypes } from "@bentley/presentation-common";
+import { Id64String } from "@bentley/bentleyjs-core";
+import { VariableValue, VariableValueTypes } from "@bentley/presentation-common";
 import { NativePlatformDefinition } from "./NativePlatform";
 
 /**
@@ -94,11 +94,11 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
     this._rulesetId = rulesetId;
   }
 
-  public setValueJSON(variableId: string, type: VariableValueTypes, value: VariableValueJSON): void {
+  public setValueInternal(variableId: string, type: VariableValueTypes, value: VariableValue): void {
     this._getNativePlatform().setRulesetVariableValue(this._rulesetId, variableId, type, value);
   }
 
-  public getValueJSON(variableId: string, type: VariableValueTypes): VariableValueJSON {
+  public getValueInternal(variableId: string, type: VariableValueTypes): VariableValue {
     return this._getNativePlatform().getRulesetVariableValue(this._rulesetId, variableId, type).result;
   }
 
@@ -128,14 +128,14 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
    * Returns empty string if variable does not exist or does not convert to string.
    */
   public getString(variableId: string): string {
-    return (this.getValueJSON(variableId, VariableValueTypes.String)) as string;
+    return (this.getValueInternal(variableId, VariableValueTypes.String)) as string;
   }
 
   /**
    * Sets `string` variable value
    */
   public setString(variableId: string, value: string): void {
-    this.setValueJSON(variableId, VariableValueTypes.String, value);
+    this.setValueInternal(variableId, VariableValueTypes.String, value);
   }
 
   /**
@@ -143,14 +143,14 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
    * Returns `false` if variable does not exist or does not convert to boolean.
    */
   public getBool(variableId: string): boolean {
-    return (this.getValueJSON(variableId, VariableValueTypes.Bool)) as boolean;
+    return (this.getValueInternal(variableId, VariableValueTypes.Bool)) as boolean;
   }
 
   /**
    * Sets `boolean` variable value
    */
   public setBool(variableId: string, value: boolean): void {
-    this.setValueJSON(variableId, VariableValueTypes.Bool, value);
+    this.setValueInternal(variableId, VariableValueTypes.Bool, value);
   }
 
   /**
@@ -158,14 +158,14 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
    * Returns `0` if variable does not exist or does not convert to integer.
    */
   public getInt(variableId: string): number {
-    return (this.getValueJSON(variableId, VariableValueTypes.Int)) as number;
+    return (this.getValueInternal(variableId, VariableValueTypes.Int)) as number;
   }
 
   /**
    * Sets `number` variable value
    */
   public setInt(variableId: string, value: number): void {
-    this.setValueJSON(variableId, VariableValueTypes.Int, value);
+    this.setValueInternal(variableId, VariableValueTypes.Int, value);
   }
 
   /**
@@ -173,14 +173,14 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
    * Returns empty array if variable does not exist or does not convert to integer array.
    */
   public getInts(variableId: string): number[] {
-    return (this.getValueJSON(variableId, VariableValueTypes.IntArray)) as number[];
+    return (this.getValueInternal(variableId, VariableValueTypes.IntArray)) as number[];
   }
 
   /**
    * Sets `number[]` variable value
    */
   public setInts(variableId: string, value: number[]): void {
-    this.setValueJSON(variableId, VariableValueTypes.IntArray, value);
+    this.setValueInternal(variableId, VariableValueTypes.IntArray, value);
   }
 
   /**
@@ -188,14 +188,14 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
    * Returns invalid Id64String if variable does not exist or does not convert to Id64String.
    */
   public getId64(variableId: string): Id64String {
-    return Id64.fromJSON((this.getValueJSON(variableId, VariableValueTypes.Id64)) as string);
+    return (this.getValueInternal(variableId, VariableValueTypes.Id64)) as Id64String;
   }
 
   /**
    * Sets `Id64String` variable value
    */
   public setId64(variableId: string, value: Id64String): void {
-    this.setValueJSON(variableId, VariableValueTypes.Id64, value);
+    this.setValueInternal(variableId, VariableValueTypes.Id64, value);
   }
 
   /**
@@ -203,14 +203,13 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
    * Returns empty array if variable does not exist or does not convert to Id64String array.
    */
   public getId64s(variableId: string): Id64String[] {
-    const value = (this.getValueJSON(variableId, VariableValueTypes.Id64Array)) as string[];
-    return value.map((v) => Id64.fromJSON(v));
+    return (this.getValueInternal(variableId, VariableValueTypes.Id64Array)) as Id64String[];
   }
 
   /**
    * Sets `Id64String[]` variable value
    */
   public setId64s(variableId: string, value: Id64String[]): void {
-    this.setValueJSON(variableId, VariableValueTypes.Id64Array, value.map((v) => v));
+    this.setValueInternal(variableId, VariableValueTypes.Id64Array, value);
   }
 }

--- a/presentation/backend/src/test/PresentationIpcHandler.test.ts
+++ b/presentation/backend/src/test/PresentationIpcHandler.test.ts
@@ -2,16 +2,18 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import * as moq from "typemoq";
 import * as sinon from "sinon";
-import { NodeKeyJSON, RulesetVariableJSON, SetRulesetVariableParams, UpdateHierarchyStateParams, VariableValueTypes } from "@bentley/presentation-common";
+import * as moq from "typemoq";
+import { IModelDb, IModelJsNative } from "@bentley/imodeljs-backend";
+import {
+  NodeKeyJSON, RulesetVariableJSON, SetRulesetVariableParams, StringRulesetVariable, UpdateHierarchyStateParams, VariableValueTypes,
+} from "@bentley/presentation-common";
+import { createRandomBaseNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
+import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
+import { Presentation } from "../presentation-backend/Presentation";
 import { PresentationIpcHandler } from "../presentation-backend/PresentationIpcHandler";
 import { PresentationManager } from "../presentation-backend/PresentationManager";
 import { RulesetVariablesManager } from "../presentation-backend/RulesetVariablesManager";
-import { Presentation } from "../presentation-backend/Presentation";
-import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
-import { IModelDb, IModelJsNative } from "@bentley/imodeljs-backend";
-import { createRandomBaseNodeKey } from "@bentley/presentation-common/lib/test/_helpers/random";
 
 describe("PresentationIpcHandler", () => {
   const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
@@ -30,7 +32,7 @@ describe("PresentationIpcHandler", () => {
     });
 
     it("sets ruleset variable", async () => {
-      const testVariable = { id: "var-id", type: VariableValueTypes.String, value: "test-val" };
+      const testVariable: StringRulesetVariable = { id: "var-id", type: VariableValueTypes.String, value: "test-val" };
       variablesManagerMock.setup((x) => x.setValue(testVariable.id, testVariable.type, testVariable.value)).verifiable(moq.Times.once());
 
       const ipcHandler = new PresentationIpcHandler();

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -15,10 +15,10 @@ import {
   ArrayTypeDescription, ContentDescriptorRequestOptions, ContentFlags, ContentJSON, ContentRequestOptions, DefaultContentDisplayTypes, Descriptor,
   DescriptorJSON, DiagnosticsOptions, DiagnosticsScopeLogs, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DistinctValuesRequestOptions,
   ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, FieldDescriptor, FieldDescriptorType, FieldJSON, getLocalesDirectory,
-  HierarchyCompareInfo, HierarchyCompareInfoJSON, HierarchyCompareOptions, HierarchyRequestOptions, InstanceKey, ItemJSON, KeySet, KindOfQuantityInfo,
-  LabelDefinition, LabelRequestOptions, NestedContentFieldJSON, NodeJSON, NodeKey, Paged, PageOptions, PresentationError, PresentationUnitSystem,
-  PrimitiveTypeDescription, PropertiesFieldJSON, PropertyInfoJSON, PropertyJSON, RegisteredRuleset, RequestPriority, Ruleset, SelectClassInfoJSON,
-  SelectionInfo, SelectionScope, StandardNodeTypes, StructTypeDescription, VariableValueTypes,
+  HierarchyCompareInfo, HierarchyCompareInfoJSON, HierarchyCompareOptions, HierarchyRequestOptions, InstanceKey, IntRulesetVariable, ItemJSON, KeySet,
+  KindOfQuantityInfo, LabelDefinition, LabelRequestOptions, NestedContentFieldJSON, NodeJSON, NodeKey, Paged, PageOptions, PresentationError,
+  PresentationUnitSystem, PrimitiveTypeDescription, PropertiesFieldJSON, PropertyInfoJSON, PropertyJSON, RegisteredRuleset, RequestPriority, Ruleset,
+  SelectClassInfoJSON, SelectionInfo, SelectionScope, StandardNodeTypes, StructTypeDescription, VariableValueTypes,
 } from "@bentley/presentation-common";
 import {
   createRandomCategory, createRandomDescriptor, createRandomDescriptorJSON, createRandomECClassInfoJSON, createRandomECInstanceKey,
@@ -1154,8 +1154,8 @@ describe("PresentationManager", () => {
     describe("compareHierarchies", () => {
 
       it("[deprecated] addon to compare hierarchies after ruleset change", async () => {
-        const var1 = { id: "var", type: VariableValueTypes.Id64, value: 123 };
-        const var2 = { id: "var", type: VariableValueTypes.Id64, value: 465 };
+        const var1: IntRulesetVariable = { id: "var", type: VariableValueTypes.Int, value: 123 };
+        const var2: IntRulesetVariable = { id: "var", type: VariableValueTypes.Int, value: 465 };
         const nodeKey = createRandomECInstancesNodeKey();
 
         // what the addon receives
@@ -1196,8 +1196,8 @@ describe("PresentationManager", () => {
       });
 
       it("requests addon to compare hierarchies based on ruleset and variables' changes", async () => {
-        const var1 = { id: "var", type: VariableValueTypes.Id64, value: 123 };
-        const var2 = { id: "var", type: VariableValueTypes.Id64, value: 465 };
+        const var1: IntRulesetVariable = { id: "var", type: VariableValueTypes.Int, value: 123 };
+        const var2: IntRulesetVariable = { id: "var", type: VariableValueTypes.Int, value: 465 };
         const nodeKey = createRandomECInstancesNodeKey();
 
         // what the addon receives
@@ -1274,8 +1274,8 @@ describe("PresentationManager", () => {
       });
 
       it("requests addon to compare hierarchies based on ruleset variables' changes", async () => {
-        const var1 = { id: "var", type: VariableValueTypes.Id64, value: 123 };
-        const var2 = { id: "var", type: VariableValueTypes.Id64, value: 465 };
+        const var1: IntRulesetVariable = { id: "var", type: VariableValueTypes.Int, value: 123 };
+        const var2: IntRulesetVariable = { id: "var", type: VariableValueTypes.Int, value: 465 };
 
         // what the addon receives
         const expectedParams = {

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -15,8 +15,8 @@ import {
   DisplayLabelsRpcRequestOptions, DistinctValuesRequestOptions, ExtendedContentRequestOptions, ExtendedContentRpcRequestOptions,
   ExtendedHierarchyRequestOptions, ExtendedHierarchyRpcRequestOptions, FieldDescriptor, FieldDescriptorType, HierarchyCompareInfo,
   HierarchyCompareOptions, HierarchyCompareRpcOptions, HierarchyRequestOptions, HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, KeySetJSON,
-  Node, NodeKey, NodePathElement, Paged, PageOptions, PresentationError, PresentationRpcRequestOptions, PresentationStatus,
-  SelectionScopeRequestOptions, VariableValueTypes,
+  Node, NodeKey, NodePathElement, Paged, PageOptions, PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable,
+  RulesetVariableJSON, SelectionScopeRequestOptions, VariableValueTypes,
 } from "@bentley/presentation-common";
 import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { ResolvablePromise } from "@bentley/presentation-common/lib/test/_helpers/Promises";
@@ -160,6 +160,26 @@ describe("PresentationRpcImpl", () => {
 
         const actualResult = await actualResultPromise;
         expect(actualResult.result).to.eq(999);
+      });
+
+      it("should forward ruleset variables to manager", async () => {
+        const rpcOptions: ExtendedHierarchyRpcRequestOptions = {
+          ...defaultRpcParams,
+          rulesetOrId: testData.rulesetOrId,
+          rulesetVariables: [{ id: "test", type: VariableValueTypes.Int, value: 123 }],
+        };
+        const managerOptions: WithClientRequestContext<ExtendedHierarchyRequestOptions<IModelDb, NodeKey>> = {
+          requestContext: ClientRequestContext.current,
+          imodel: testData.imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          parentKey: undefined,
+          rulesetVariables: rpcOptions.rulesetVariables as RulesetVariable[],
+        };
+        presentationManagerMock.setup((x) => x.getNodesCount(managerOptions))
+          .returns(async () => 999)
+          .verifiable();
+        await impl.getNodesCount(testData.imodelToken, rpcOptions);
+        presentationManagerMock.verifyAll();
       });
 
       it("should forward diagnostics options to manager and return diagnostics with results", async () => {
@@ -585,7 +605,7 @@ describe("PresentationRpcImpl", () => {
 
       it("calls manager", async () => {
         const result = [createRandomNodePathElement(0), createRandomNodePathElement(0)];
-        const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never>> = {
+        const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
         };
@@ -610,7 +630,7 @@ describe("PresentationRpcImpl", () => {
       it("calls manager", async () => {
         const result = [createRandomNodePathElement(0), createRandomNodePathElement(0)];
         const keyArray: InstanceKey[][] = [[createRandomECInstanceKey(), createRandomECInstanceKey()]];
-        const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never>> = {
+        const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
         };
@@ -634,7 +654,7 @@ describe("PresentationRpcImpl", () => {
     describe("loadHierarchy", () => {
 
       it("returns error status", async () => {
-        const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never>> = {
+        const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<never, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
         };
@@ -1261,7 +1281,7 @@ describe("PresentationRpcImpl", () => {
         const descriptor = createRandomDescriptor();
         const fieldName = faker.random.word();
         const maximumValueCount = faker.random.number();
-        const rpcOptions: PresentationRpcRequestOptions<ContentRequestOptions<never>> = {
+        const rpcOptions: PresentationRpcRequestOptions<ContentRequestOptions<never, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
         };
@@ -1305,7 +1325,7 @@ describe("PresentationRpcImpl", () => {
           keys,
           paging: testData.pageOptions,
         };
-        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON>> = {
+        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: managerOptions.rulesetOrId,
           descriptor: descriptor.toJSON(),
@@ -1344,7 +1364,7 @@ describe("PresentationRpcImpl", () => {
           keys,
           paging: { start: 0, size: MAX_ALLOWED_PAGE_SIZE },
         };
-        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON>> = {
+        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: managerOptions.rulesetOrId,
           descriptor: descriptor.toJSON(),
@@ -1383,7 +1403,7 @@ describe("PresentationRpcImpl", () => {
           keys,
           paging: { start: 5, size: MAX_ALLOWED_PAGE_SIZE },
         };
-        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON>> = {
+        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: managerOptions.rulesetOrId,
           descriptor: descriptor.toJSON(),
@@ -1422,7 +1442,7 @@ describe("PresentationRpcImpl", () => {
           keys,
           paging: { size: MAX_ALLOWED_PAGE_SIZE },
         };
-        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON>> = {
+        const rpcOptions: PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>> = {
           ...defaultRpcParams,
           rulesetOrId: managerOptions.rulesetOrId,
           descriptor: descriptor.toJSON(),
@@ -1601,7 +1621,9 @@ describe("PresentationRpcImpl", () => {
         const managerOptions: WithClientRequestContext<HierarchyCompareOptions<IModelDb, NodeKey>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
-          prev: rpcOptions.prev,
+          prev: {
+            rulesetOrId: rpcOptions.prev.rulesetOrId,
+          },
           rulesetOrId: rpcOptions.rulesetOrId,
         };
         presentationManagerMock.setup((x) => x.compareHierarchies(managerOptions))
@@ -1630,7 +1652,10 @@ describe("PresentationRpcImpl", () => {
         const managerOptions: WithClientRequestContext<HierarchyCompareOptions<IModelDb, NodeKey>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
-          prev: rpcOptions.prev,
+          prev: {
+            ...rpcOptions.prev,
+            rulesetVariables: rpcOptions.prev.rulesetVariables?.map(RulesetVariable.fromJSON),
+          },
           rulesetOrId: rpcOptions.rulesetOrId,
           expandedNodeKeys: rpcOptions.expandedNodeKeys!.map(NodeKey.fromJSON),
         };
@@ -1664,7 +1689,9 @@ describe("PresentationRpcImpl", () => {
         const managerOptions: WithClientRequestContext<HierarchyCompareOptions<IModelDb, NodeKey>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
-          prev: rpcOptions.prev,
+          prev: {
+            rulesetOrId: rpcOptions.prev.rulesetOrId,
+          },
           rulesetOrId: rpcOptions.rulesetOrId,
           resultSetSize: 10,
         };
@@ -1695,7 +1722,10 @@ describe("PresentationRpcImpl", () => {
         const managerOptions: WithClientRequestContext<HierarchyCompareOptions<IModelDb, NodeKey>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
-          prev: rpcOptions.prev,
+          prev: {
+            ...rpcOptions.prev,
+            rulesetVariables: rpcOptions.prev.rulesetVariables?.map(RulesetVariable.fromJSON),
+          },
           rulesetOrId: rpcOptions.rulesetOrId,
           expandedNodeKeys: rpcOptions.expandedNodeKeys!.map(NodeKey.fromJSON),
           resultSetSize: 10,
@@ -1726,7 +1756,10 @@ describe("PresentationRpcImpl", () => {
         const managerOptions: WithClientRequestContext<HierarchyCompareOptions<IModelDb, NodeKey>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
-          prev: rpcOptions.prev,
+          prev: {
+            ...rpcOptions.prev,
+            rulesetVariables: rpcOptions.prev.rulesetVariables?.map(RulesetVariable.fromJSON),
+          },
           rulesetOrId: rpcOptions.rulesetOrId,
           expandedNodeKeys: rpcOptions.expandedNodeKeys!.map(NodeKey.fromJSON),
           resultSetSize: MAX_ALLOWED_PAGE_SIZE,

--- a/presentation/backend/src/test/RulesetVariablesManager.test.ts
+++ b/presentation/backend/src/test/RulesetVariablesManager.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import * as faker from "faker";
-import { Id64String } from "@bentley/bentleyjs-core";
+import { Id64String, OrderedId64Iterable } from "@bentley/bentleyjs-core";
 import { VariableValueTypes } from "@bentley/presentation-common";
 import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { createRandomId } from "@bentley/presentation-common/lib/test/_helpers/random";
@@ -41,7 +41,7 @@ describe("RulesetVariablesManager", () => {
     it("calls addon's setRulesetVariableValue with Id64[]", async () => {
       const value = [createRandomId()];
       manager.setValue(variableId, VariableValueTypes.Id64Array, value);
-      addonMock.verify((x) => x.setRulesetVariableValue(rulesetId, variableId, VariableValueTypes.Id64Array, value.map((v) => v)), moq.Times.once());
+      addonMock.verify((x) => x.setRulesetVariableValue(rulesetId, variableId, VariableValueTypes.Id64Array, value), moq.Times.once());
     });
 
     it("calls addon's setRulesetVariableValue with number", async () => {
@@ -88,7 +88,7 @@ describe("RulesetVariablesManager", () => {
     it("calls addon's getRulesetVariableValue with Id64[]", async () => {
       const value = [createRandomId()];
       addonMock.setup((x) => x.getRulesetVariableValue(rulesetId, variableId, VariableValueTypes.Id64Array))
-        .returns(() => ({ result: value.map((v) => v) })).verifiable(moq.Times.once());
+        .returns(() => ({ result: value })).verifiable(moq.Times.once());
       const result = manager.getValue(variableId, VariableValueTypes.Id64Array);
       addonMock.verifyAll();
       expect(Array.isArray(result)).to.be.true;
@@ -274,7 +274,7 @@ describe("RulesetVariablesManager", () => {
       const valueArray = [createRandomId(), createRandomId(), createRandomId()];
       addonMock
         .setup((x) => x.getRulesetVariableValue(rulesetId, variableId, VariableValueTypes.Id64Array))
-        .returns(() => ({ result: valueArray.map((v) => v) }))
+        .returns(() => ({ result: valueArray }))
         .verifiable();
       const result = manager.getId64s(variableId);
       expect(result).to.deep.equal(valueArray);
@@ -288,7 +288,7 @@ describe("RulesetVariablesManager", () => {
     it("sets Id64 array variable value", async () => {
       const valueArray = [createRandomId(), createRandomId(), createRandomId()];
       addonMock
-        .setup((x) => x.setRulesetVariableValue(rulesetId, variableId, VariableValueTypes.Id64Array, valueArray.map((v) => v)))
+        .setup((x) => x.setRulesetVariableValue(rulesetId, variableId, VariableValueTypes.Id64Array, OrderedId64Iterable.sortArray(valueArray)))
         .verifiable();
       manager.setId64s(variableId, valueArray);
       addonMock.verifyAll();

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -70,12 +70,12 @@ export interface RequestOptions<TIModel> {
  *
  * @public
  */
-export interface RequestOptionsWithRuleset<TIModel> extends RequestOptions<TIModel> {
+export interface RequestOptionsWithRuleset<TIModel, TRulesetVariable = RulesetVariable> extends RequestOptions<TIModel> {
   /** Ruleset or id of the ruleset to use when requesting data */
   rulesetOrId: Ruleset | string;
 
   /** Ruleset variables to use when requesting data */
-  rulesetVariables?: RulesetVariable[];
+  rulesetVariables?: TRulesetVariable[];
 }
 
 /**
@@ -83,21 +83,21 @@ export interface RequestOptionsWithRuleset<TIModel> extends RequestOptions<TIMod
  * @public
  * @deprecated Use [[ExtendedHierarchyRequestOptions]]
  */
-export interface HierarchyRequestOptions<TIModel> extends RequestOptionsWithRuleset<TIModel> { // eslint-disable-line @typescript-eslint/no-empty-interface
+export interface HierarchyRequestOptions<TIModel, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> { // eslint-disable-line @typescript-eslint/no-empty-interface
 }
 
 /**
  * Request type for hierarchy requests
  * @public
  */
-export interface ExtendedHierarchyRequestOptions<TIModel, TNodeKey> extends RequestOptionsWithRuleset<TIModel> {
+export interface ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
   /** Key of the parent node to get children for */
   parentKey?: TNodeKey;
 }
 /** @internal */
 // eslint-disable-next-line deprecation/deprecation
-export const isExtendedHierarchyRequestOptions = <TIModel, TNodeKey>(opts: HierarchyRequestOptions<TIModel> | ExtendedHierarchyRequestOptions<TIModel, TNodeKey>): opts is ExtendedHierarchyRequestOptions<TIModel, TNodeKey> => {
-  return !!(opts as ExtendedHierarchyRequestOptions<TIModel, TNodeKey>).parentKey;
+export const isExtendedHierarchyRequestOptions = <TIModel, TNodeKey, TRulesetVariable>(opts: HierarchyRequestOptions<TIModel> | ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable>): opts is ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable> => {
+  return !!(opts as ExtendedHierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable>).parentKey;
 };
 
 /**
@@ -105,14 +105,14 @@ export const isExtendedHierarchyRequestOptions = <TIModel, TNodeKey>(opts: Hiera
  * @public
  * @deprecated Use [[ContentDescriptorRequestOptions]] or [[ExtendedContentRequestOptions]]
  */
-export interface ContentRequestOptions<TIModel> extends RequestOptionsWithRuleset<TIModel> { // eslint-disable-line @typescript-eslint/no-empty-interface
+export interface ContentRequestOptions<TIModel, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> { // eslint-disable-line @typescript-eslint/no-empty-interface
 }
 
 /**
  * Request type for content descriptor requests
  * @public
  */
-export interface ContentDescriptorRequestOptions<TIModel, TKeySet> extends RequestOptionsWithRuleset<TIModel> {
+export interface ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
   /**
    * Content display type.
    * @see [[DefaultContentDisplayTypes]]
@@ -125,15 +125,15 @@ export interface ContentDescriptorRequestOptions<TIModel, TKeySet> extends Reque
 }
 /** @internal */
 // eslint-disable-next-line deprecation/deprecation
-export const isContentDescriptorRequestOptions = <TIModel, TKeySet>(opts: ContentRequestOptions<TIModel> | ContentDescriptorRequestOptions<TIModel, TKeySet>): opts is ContentDescriptorRequestOptions<TIModel, TKeySet> => {
-  return !!(opts as ContentDescriptorRequestOptions<TIModel, TKeySet>).keys;
+export const isContentDescriptorRequestOptions = <TIModel, TKeySet, TRulesetVariable>(opts: ContentRequestOptions<TIModel> | ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable>): opts is ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable> => {
+  return !!(opts as ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable>).keys;
 };
 
 /**
  * Request type for content requests
  * @public
  */
-export interface ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet> extends RequestOptionsWithRuleset<TIModel> {
+export interface ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
   /** Content descriptor or overrides for customizing the returned content */
   descriptor: TDescriptor | DescriptorOverrides;
   /** Input keys for getting the content */
@@ -141,16 +141,16 @@ export interface ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet> ex
 }
 /** @internal */
 // eslint-disable-next-line deprecation/deprecation
-export const isExtendedContentRequestOptions = <TIModel, TDescriptor, TKeySet>(opts: ContentRequestOptions<TIModel> | ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet>): opts is ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet> => {
-  return !!(opts as ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet>).descriptor
-    && !!(opts as ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet>).keys;
+export const isExtendedContentRequestOptions = <TIModel, TDescriptor, TKeySet, TRulesetVariable>(opts: ContentRequestOptions<TIModel> | ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable>): opts is ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable> => {
+  return !!(opts as ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable>).descriptor
+    && !!(opts as ExtendedContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable>).keys;
 };
 
 /**
  * Request type for distinct values' requests
  * @public
  */
-export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet> extends Paged<RequestOptionsWithRuleset<TIModel>> {
+export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable = RulesetVariable> extends Paged<RequestOptionsWithRuleset<TIModel, TRulesetVariable>> {
   /** Content descriptor for content we're requesting distinct values for or overrides for customizing the returned content */
   descriptor: TDescriptor | DescriptorOverrides;
   /** Input keys for getting the content */
@@ -205,16 +205,16 @@ export interface SelectionScopeRequestOptions<TIModel> extends RequestOptions<TI
  * @public
  * @deprecated Use [[HierarchyCompareOptions]]
  */
-export type PresentationDataCompareOptions<TIModel, TNodeKey> = HierarchyCompareOptions<TIModel, TNodeKey>;
+export type PresentationDataCompareOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> = HierarchyCompareOptions<TIModel, TNodeKey, TRulesetVariable>;
 
 /**
  * Data structure for comparing a hierarchy after ruleset or ruleset variable changes.
  * @public
  */
-export interface HierarchyCompareOptions<TIModel, TNodeKey> extends RequestOptionsWithRuleset<TIModel> {
+export interface HierarchyCompareOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
   prev: {
     rulesetOrId?: Ruleset | string;
-    rulesetVariables?: RulesetVariable[];
+    rulesetVariables?: TRulesetVariable[];
   };
   expandedNodeKeys?: TNodeKey[];
   continuationToken?: {

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -25,6 +25,7 @@ import {
   ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, HierarchyCompareOptions, HierarchyRequestOptions, LabelRequestOptions, Paged,
   SelectionScopeRequestOptions,
 } from "./PresentationManagerOptions";
+import { RulesetVariableJSON } from "./RulesetVariables";
 import { SelectionScope } from "./selection/SelectionScope";
 import { HierarchyCompareInfoJSON, PartialHierarchyModificationJSON } from "./Update";
 import { Omit, PagedResponse } from "./Utils";
@@ -60,38 +61,38 @@ export type PresentationRpcResponse<TResult = undefined> = Promise<{
  * @public
  * @deprecated Use [[ExtendedHierarchyRpcRequestOptions]]
  */
-export type HierarchyRpcRequestOptions = PresentationRpcRequestOptions<HierarchyRequestOptions<never>>; // eslint-disable-line deprecation/deprecation
+export type HierarchyRpcRequestOptions = PresentationRpcRequestOptions<HierarchyRequestOptions<never, RulesetVariableJSON>>; // eslint-disable-line deprecation/deprecation
 
 /**
  * Data structure for hierarchy request options.
  * @public
  */
-export type ExtendedHierarchyRpcRequestOptions = PresentationRpcRequestOptions<ExtendedHierarchyRequestOptions<never, NodeKeyJSON>>;
+export type ExtendedHierarchyRpcRequestOptions = PresentationRpcRequestOptions<ExtendedHierarchyRequestOptions<never, NodeKeyJSON, RulesetVariableJSON>>;
 
 /**
  * Data structure for content request options.
  * @public
  * @deprecated Use [[ContentDescriptorRpcRequestOptions]] or [[ExtendedContentRpcRequestOptions]]
  */
-export type ContentRpcRequestOptions = PresentationRpcRequestOptions<ContentRequestOptions<never>>; // eslint-disable-line deprecation/deprecation
+export type ContentRpcRequestOptions = PresentationRpcRequestOptions<ContentRequestOptions<never, RulesetVariableJSON>>; // eslint-disable-line deprecation/deprecation
 
 /**
  * Data structure for content descriptor RPC request options.
  * @public
  */
-export type ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions<ContentDescriptorRequestOptions<never, KeySetJSON>>;
+export type ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions<ContentDescriptorRequestOptions<never, KeySetJSON, RulesetVariableJSON>>;
 
 /**
  * Data structure for content RPC request options.
  * @public
  */
-export type ExtendedContentRpcRequestOptions = PresentationRpcRequestOptions<ExtendedContentRequestOptions<never, DescriptorJSON, KeySetJSON>>;
+export type ExtendedContentRpcRequestOptions = PresentationRpcRequestOptions<ExtendedContentRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>;
 
 /**
  * Data structure for distinct values' request options.
  * @public
  */
-export type DistinctValuesRpcRequestOptions = PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON>>;
+export type DistinctValuesRpcRequestOptions = PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>;
 
 /**
  * Data structure for label request options.
@@ -122,7 +123,7 @@ export type SelectionScopeRpcRequestOptions = PresentationRpcRequestOptions<Sele
  * Data structure for comparing presentation data after ruleset or ruleset variable changes.
  * @public
  */
-export type HierarchyCompareRpcOptions = PresentationRpcRequestOptions<HierarchyCompareOptions<never, NodeKeyJSON>>;
+export type HierarchyCompareRpcOptions = PresentationRpcRequestOptions<HierarchyCompareOptions<never, NodeKeyJSON, RulesetVariableJSON>>;
 
 /**
  * Interface used for communication between Presentation backend and frontend.
@@ -133,7 +134,7 @@ export class PresentationRpcInterface extends RpcInterface {
   public static readonly interfaceName = "PresentationRpcInterface"; // eslint-disable-line @typescript-eslint/naming-convention
 
   /** The semantic version of the interface. */
-  public static interfaceVersion = "2.9.0";
+  public static interfaceVersion = "2.10.0";
 
   /*===========================================================================================
     NOTE: Any add/remove/change to the methods below requires an update of the interface version.

--- a/presentation/common/src/presentation-common/RpcRequestsHandler.ts
+++ b/presentation/common/src/presentation-common/RpcRequestsHandler.ts
@@ -24,6 +24,7 @@ import {
   ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, HierarchyCompareOptions, Paged, RequestOptions, SelectionScopeRequestOptions,
 } from "./PresentationManagerOptions";
 import { PresentationRpcInterface, PresentationRpcRequestOptions, PresentationRpcResponse } from "./PresentationRpcInterface";
+import { RulesetVariableJSON } from "./RulesetVariables";
 import { SelectionScope } from "./selection/SelectionScope";
 import { HierarchyCompareInfoJSON, PartialHierarchyModificationJSON } from "./Update";
 import { PagedResponse } from "./Utils";
@@ -124,43 +125,43 @@ export class RpcRequestsHandler implements IDisposable {
     return this.requestRepeatedly(doRequest, diagnosticsHandler);
   }
 
-  public async getNodesCount(options: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>): Promise<number> {
-    return this.request<number, ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>>(
+  public async getNodesCount(options: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<number> {
+    return this.request<number, ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>(
       this.rpcClient.getNodesCount.bind(this.rpcClient), options); // eslint-disable-line deprecation/deprecation
   }
-  public async getPagedNodes(options: Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>>): Promise<PagedResponse<NodeJSON>> {
-    return this.request<PagedResponse<NodeJSON>, Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>>>(
+  public async getPagedNodes(options: Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>): Promise<PagedResponse<NodeJSON>> {
+    return this.request<PagedResponse<NodeJSON>, Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>>(
       this.rpcClient.getPagedNodes.bind(this.rpcClient), options);
   }
 
-  public async getNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never>, paths: InstanceKeyJSON[][], markedIndex: number): Promise<NodePathElementJSON[]> {
-    return this.request<NodePathElementJSON[], ExtendedHierarchyRequestOptions<IModelRpcProps, never>>(
+  public async getNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON>, paths: InstanceKeyJSON[][], markedIndex: number): Promise<NodePathElementJSON[]> {
+    return this.request<NodePathElementJSON[], ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON>>(
       this.rpcClient.getNodePaths.bind(this.rpcClient), options, paths, markedIndex);
   }
-  public async getFilteredNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never>, filterText: string): Promise<NodePathElementJSON[]> {
-    return this.request<NodePathElementJSON[], ExtendedHierarchyRequestOptions<IModelRpcProps, never>>(
+  public async getFilteredNodePaths(options: ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON>, filterText: string): Promise<NodePathElementJSON[]> {
+    return this.request<NodePathElementJSON[], ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON>>(
       this.rpcClient.getFilteredNodePaths.bind(this.rpcClient), options, filterText);
   }
 
-  public async getContentDescriptor(options: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON>): Promise<DescriptorJSON | undefined> {
-    return this.request<DescriptorJSON | undefined, ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON>>(
+  public async getContentDescriptor(options: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>): Promise<DescriptorJSON | undefined> {
+    return this.request<DescriptorJSON | undefined, ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>>(
       this.rpcClient.getContentDescriptor.bind(this.rpcClient), options); // eslint-disable-line deprecation/deprecation
   }
-  public async getContentSetSize(options: ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>): Promise<number> {
-    return this.request<number, ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>(
+  public async getContentSetSize(options: ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>): Promise<number> {
+    return this.request<number, ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>(
       this.rpcClient.getContentSetSize.bind(this.rpcClient), options); // eslint-disable-line deprecation/deprecation
   }
-  public async getPagedContent(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>) {
-    return this.request<{ descriptor: DescriptorJSON, contentSet: PagedResponse<ItemJSON> } | undefined, Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>>(
+  public async getPagedContent(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>) {
+    return this.request<{ descriptor: DescriptorJSON, contentSet: PagedResponse<ItemJSON> } | undefined, Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>>(
       this.rpcClient.getPagedContent.bind(this.rpcClient), options);
   }
-  public async getPagedContentSet(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>) {
-    return this.request<PagedResponse<ItemJSON>, Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>>(
+  public async getPagedContentSet(options: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>) {
+    return this.request<PagedResponse<ItemJSON>, Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>>(
       this.rpcClient.getPagedContentSet.bind(this.rpcClient), options);
   }
 
-  public async getPagedDistinctValues(options: DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>): Promise<PagedResponse<DisplayValueGroupJSON>> {
-    return this.request<PagedResponse<DisplayValueGroupJSON>, DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>>(
+  public async getPagedDistinctValues(options: DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>): Promise<PagedResponse<DisplayValueGroupJSON>> {
+    return this.request<PagedResponse<DisplayValueGroupJSON>, DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>>(
       this.rpcClient.getPagedDistinctValues.bind(this.rpcClient), options);
   }
 
@@ -181,12 +182,12 @@ export class RpcRequestsHandler implements IDisposable {
     return this.request<KeySetJSON, SelectionScopeRequestOptions<IModelRpcProps>>(
       this.rpcClient.computeSelection.bind(this.rpcClient), options, ids, scopeId);
   }
-  public async compareHierarchies(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON>): Promise<PartialHierarchyModificationJSON[]> {
-    return this.request<PartialHierarchyModificationJSON[], HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON>>(
+  public async compareHierarchies(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<PartialHierarchyModificationJSON[]> {
+    return this.request<PartialHierarchyModificationJSON[], HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>(
       this.rpcClient.compareHierarchies.bind(this.rpcClient), options); // eslint-disable-line deprecation/deprecation
   }
-  public async compareHierarchiesPaged(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON>): Promise<HierarchyCompareInfoJSON> {
-    return this.request<HierarchyCompareInfoJSON, HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON>>(
+  public async compareHierarchiesPaged(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<HierarchyCompareInfoJSON> {
+    return this.request<HierarchyCompareInfoJSON, HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>(
       this.rpcClient.compareHierarchiesPaged.bind(this.rpcClient), options);
   }
 }

--- a/presentation/common/src/presentation-common/RulesetVariables.ts
+++ b/presentation/common/src/presentation-common/RulesetVariables.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { Id64String } from "@bentley/bentleyjs-core";
+import { CompressedId64Set, Id64String } from "@bentley/bentleyjs-core";
 
 /**
  * Possible variable value types
@@ -36,30 +36,154 @@ export enum VariableValueTypes {
  * Union of all supported variable value types
  * @public
  */
-export type VariableValue = boolean | string | number | number[] | Id64String[];
+export type VariableValue = boolean | string | number | number[] | Id64String | Id64String[];
 
 /**
  * JSON representation of [[VariableValue]]
  * @public
  */
-export type VariableValueJSON = boolean | string | string[] | number | number[];
+export type VariableValueJSON = boolean | string | number | number[] | Id64String | CompressedId64Set;
 
 /**
- * Data structure for representing ruleset variable.
+ * Base data structure for representing ruleset variables.
  * @public
  */
-export interface RulesetVariable {
+export interface RulesetVariableBase {
   id: string;
   type: VariableValueTypes;
   value: VariableValue;
 }
+/**
+ * Data structure for representing boolean ruleset variables.
+ * @public
+ */
+export interface BooleanRulesetVariable extends RulesetVariableBase {
+  type: VariableValueTypes.Bool;
+  value: boolean;
+}
+/**
+ * Data structure for representing string ruleset variables.
+ * @public
+ */
+export interface StringRulesetVariable extends RulesetVariableBase {
+  type: VariableValueTypes.String;
+  value: string;
+}
+/**
+ * Data structure for representing int ruleset variables.
+ * @public
+ */
+export interface IntRulesetVariable extends RulesetVariableBase {
+  type: VariableValueTypes.Int;
+  value: number;
+}
+/**
+ * Data structure for representing int array ruleset variables.
+ * @public
+ */
+export interface IntsRulesetVariable extends RulesetVariableBase {
+  type: VariableValueTypes.IntArray;
+  value: number[];
+}
+/**
+ * Data structure for representing ID ruleset variables.
+ * @public
+ */
+export interface Id64RulesetVariable extends RulesetVariableBase {
+  type: VariableValueTypes.Id64;
+  value: Id64String;
+}
+/**
+ * Data structure for representing ID array ruleset variables.
+ * @public
+ */
+export interface Id64sRulesetVariable extends RulesetVariableBase {
+  type: VariableValueTypes.Id64Array;
+  value: Id64String[];
+}
+/**
+ * Data structure for representing ruleset variables.
+ * @public
+ */
+export type RulesetVariable = BooleanRulesetVariable | StringRulesetVariable | IntRulesetVariable | IntsRulesetVariable | Id64RulesetVariable | Id64sRulesetVariable;
 
+/**
+ * JSON representation of [[RulesetVariableBase]].
+ * @public
+ */
+export interface RulesetVariableBaseJSON {
+  id: string;
+  type: VariableValueTypes;
+  value: VariableValueJSON;
+}
+/**
+ * JSON representation of [[BooleanRulesetVariable]].
+ * @public
+ */
+export interface BooleanRulesetVariableJSON extends RulesetVariableBaseJSON {
+  type: VariableValueTypes.Bool;
+  value: boolean;
+}
+/**
+ * JSON representation of [[StringRulesetVariable]].
+ * @public
+ */
+export interface StringRulesetVariableJSON extends RulesetVariableBaseJSON {
+  type: VariableValueTypes.String;
+  value: string;
+}
+/**
+ * JSON representation of [[IntRulesetVariable]].
+ * @public
+ */
+export interface IntRulesetVariableJSON extends RulesetVariableBaseJSON {
+  type: VariableValueTypes.Int;
+  value: number;
+}
+/**
+ * JSON representation of [[IntsRulesetVariable]].
+ * @public
+ */
+export interface IntsRulesetVariableJSON extends RulesetVariableBaseJSON {
+  type: VariableValueTypes.IntArray;
+  value: number[];
+}
+/**
+ * JSON representation of [[Id64RulesetVariable]].
+ * @public
+ */
+export interface Id64RulesetVariableJSON extends RulesetVariableBaseJSON {
+  type: VariableValueTypes.Id64;
+  value: Id64String;
+}
+/**
+ * JSON representation of [[Id64sRulesetVariable]].
+ * @public
+ */
+export interface Id64sRulesetVariableJSON extends RulesetVariableBaseJSON {
+  type: VariableValueTypes.Id64Array;
+  value: CompressedId64Set;
+}
 /**
  * JSON representation of [[RulesetVariable]].
  * @public
  */
-export interface RulesetVariableJSON {
-  id: string;
-  type: VariableValueTypes;
-  value: VariableValueJSON;
+export type RulesetVariableJSON = BooleanRulesetVariableJSON | StringRulesetVariableJSON | IntRulesetVariableJSON | IntsRulesetVariableJSON | Id64RulesetVariableJSON | Id64sRulesetVariableJSON;
+
+/** @public */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export namespace RulesetVariable {
+  /** Serialize given RulesetVariable to JSON */
+  export function toJSON(variable: RulesetVariable): RulesetVariableJSON {
+    if (variable.type === VariableValueTypes.Id64Array)
+      return { ...variable, value: CompressedId64Set.compressArray(variable.value) };
+    return variable;
+  }
+
+  /** Deserialize [[RulesetVariable]] from JSON. */
+  export function fromJSON(json: RulesetVariableJSON): RulesetVariable {
+    if (json.type === VariableValueTypes.Id64Array)
+      return { ...json, value: CompressedId64Set.decompressArray(json.value) };
+    return json;
+  }
 }

--- a/presentation/common/src/presentation-common/RulesetVariables.ts
+++ b/presentation/common/src/presentation-common/RulesetVariables.ts
@@ -42,7 +42,7 @@ export type VariableValue = boolean | string | number | number[] | Id64String | 
  * JSON representation of [[VariableValue]]
  * @public
  */
-export type VariableValueJSON = boolean | string | number | number[] | Id64String | CompressedId64Set;
+export type VariableValueJSON = boolean | string | number | number[] | Id64String | Id64String[] | CompressedId64Set;
 
 /**
  * Base data structure for representing ruleset variables.
@@ -162,7 +162,7 @@ export interface Id64RulesetVariableJSON extends RulesetVariableBaseJSON {
  */
 export interface Id64sRulesetVariableJSON extends RulesetVariableBaseJSON {
   type: VariableValueTypes.Id64Array;
-  value: CompressedId64Set;
+  value: Id64String[] | CompressedId64Set;
 }
 /**
  * JSON representation of [[RulesetVariable]].
@@ -182,8 +182,11 @@ export namespace RulesetVariable {
 
   /** Deserialize [[RulesetVariable]] from JSON. */
   export function fromJSON(json: RulesetVariableJSON): RulesetVariable {
-    if (json.type === VariableValueTypes.Id64Array)
-      return { ...json, value: CompressedId64Set.decompressArray(json.value) };
+    if (json.type === VariableValueTypes.Id64Array) {
+      if (typeof json.value === "string")
+        return { ...json, value: CompressedId64Set.decompressArray(json.value) };
+      return json as any; // for some reason TS doesn't understand that `json.value` is always an array here
+    }
     return json;
   }
 }

--- a/presentation/common/src/presentation-common/RulesetVariables.ts
+++ b/presentation/common/src/presentation-common/RulesetVariables.ts
@@ -173,7 +173,10 @@ export type RulesetVariableJSON = BooleanRulesetVariableJSON | StringRulesetVari
 /** @public */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export namespace RulesetVariable {
-  /** Serialize given RulesetVariable to JSON */
+  /**
+   * Serialize given RulesetVariable to JSON.
+   * Note: In case of [[Id64sRulesetVariable]], this method expects IDs are sorted. See [[OrderedId64Iterable.sortArray]].
+   */
   export function toJSON(variable: RulesetVariable): RulesetVariableJSON {
     if (variable.type === VariableValueTypes.Id64Array)
       return { ...variable, value: CompressedId64Set.compressArray(variable.value) };

--- a/presentation/common/src/test/PresentationRpcInterface.test.ts
+++ b/presentation/common/src/test/PresentationRpcInterface.test.ts
@@ -130,7 +130,7 @@ describe("PresentationRpcInterface", () => {
     });
 
     it("forwards getFilteredNodePaths call", async () => {
-      const options: HierarchyRpcRequestOptions = {
+      const options: ExtendedHierarchyRpcRequestOptions = {
         rulesetOrId: faker.random.word(),
       };
       await rpcInterface.getFilteredNodePaths(token, options, "filter");
@@ -138,7 +138,7 @@ describe("PresentationRpcInterface", () => {
     });
 
     it("forwards getNodePaths call", async () => {
-      const options: HierarchyRpcRequestOptions = {
+      const options: ExtendedHierarchyRpcRequestOptions = {
         rulesetOrId: faker.random.word(),
       };
       const keys = [[createRandomECInstanceKey(), createRandomECInstanceKey()]];

--- a/presentation/common/src/test/RpcRequestsHandler.test.ts
+++ b/presentation/common/src/test/RpcRequestsHandler.test.ts
@@ -10,7 +10,7 @@ import * as moq from "typemoq";
 import { Id64String } from "@bentley/bentleyjs-core";
 import { IModelRpcProps, RpcInterface, RpcInterfaceDefinition, RpcManager } from "@bentley/imodeljs-common";
 import {
-  DescriptorJSON, DistinctValuesRpcRequestOptions, HierarchyRequestOptions, KeySet, KeySetJSON, Paged, PresentationError, PresentationRpcInterface,
+  DescriptorJSON, DistinctValuesRpcRequestOptions, KeySet, KeySetJSON, Paged, PresentationError, PresentationRpcInterface,
   PresentationRpcRequestOptions, PresentationRpcResponse, PresentationStatus, RpcRequestsHandler, SelectionInfo, SelectionScopeRequestOptions,
 } from "../presentation-common";
 import { FieldDescriptorType } from "../presentation-common/content/Fields";
@@ -26,6 +26,7 @@ import {
   ContentDescriptorRpcRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions, ExtendedContentRpcRequestOptions,
   ExtendedHierarchyRpcRequestOptions, HierarchyCompareRpcOptions,
 } from "../presentation-common/PresentationRpcInterface";
+import { RulesetVariableJSON } from "../presentation-common/RulesetVariables";
 import { HierarchyCompareInfoJSON, PartialHierarchyModificationJSON } from "../presentation-common/Update";
 import {
   createRandomDescriptorJSON, createRandomECInstanceKeyJSON, createRandomECInstancesNodeJSON, createRandomECInstancesNodeKeyJSON,
@@ -192,7 +193,7 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards getNodesCount call for root nodes", async () => {
-      const handlerOptions: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON> = {
+      const handlerOptions: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
       };
@@ -209,12 +210,12 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards getNodesCount call for child nodes", async () => {
-      const handlerOptions: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON> = {
+      const handlerOptions: ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         parentKey: createRandomECInstancesNodeKeyJSON(),
       };
-      const rpcOptions: PresentationRpcRequestOptions<ExtendedHierarchyRequestOptions<any, NodeKeyJSON>> = {
+      const rpcOptions: ExtendedHierarchyRpcRequestOptions = {
         clientId,
         rulesetOrId: handlerOptions.rulesetOrId,
         parentKey: handlerOptions.parentKey,
@@ -228,13 +229,13 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards getPagedNodes call", async () => {
-      const handlerOptions: Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON>> = {
+      const handlerOptions: Paged<ExtendedHierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         paging: { start: 1, size: 2 },
         parentKey: createRandomECInstancesNodeKeyJSON(),
       };
-      const rpcOptions: PresentationRpcRequestOptions<Paged<ExtendedHierarchyRequestOptions<any, NodeKeyJSON>>> = {
+      const rpcOptions: Paged<ExtendedHierarchyRpcRequestOptions> = {
         clientId,
         rulesetOrId: handlerOptions.rulesetOrId,
         paging: { start: 1, size: 2 },
@@ -249,11 +250,11 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards getFilteredNodePaths call", async () => {
-      const handlerOptions: HierarchyRequestOptions<IModelRpcProps> = {
+      const handlerOptions: ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
       };
-      const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<any>> = {
+      const rpcOptions: ExtendedHierarchyRpcRequestOptions = {
         clientId,
         rulesetOrId: handlerOptions.rulesetOrId,
       };
@@ -267,11 +268,11 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards getNodePaths call", async () => {
-      const handlerOptions: HierarchyRequestOptions<IModelRpcProps> = {
+      const handlerOptions: ExtendedHierarchyRequestOptions<IModelRpcProps, never, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
       };
-      const rpcOptions: PresentationRpcRequestOptions<HierarchyRequestOptions<any>> = {
+      const rpcOptions: ExtendedHierarchyRpcRequestOptions = {
         clientId,
         rulesetOrId: handlerOptions.rulesetOrId,
       };
@@ -289,7 +290,7 @@ describe("RpcRequestsHandler", () => {
       const displayType = faker.random.word();
       const keys = new KeySet().toJSON();
       const selectionInfo: SelectionInfo = { providerName: faker.random.word() };
-      const handlerOptions: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON> = {
+      const handlerOptions: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         displayType,
@@ -313,7 +314,7 @@ describe("RpcRequestsHandler", () => {
       const descriptor = createRandomDescriptorJSON();
       const keys = new KeySet().toJSON();
       const result = faker.random.number();
-      const handlerOptions: ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON> = {
+      const handlerOptions: ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         descriptor,
@@ -340,7 +341,7 @@ describe("RpcRequestsHandler", () => {
           items: new Array<ItemJSON>(),
         },
       };
-      const handlerOptions: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>> = {
+      const handlerOptions: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         descriptor,
@@ -366,7 +367,7 @@ describe("RpcRequestsHandler", () => {
         total: 123,
         items: new Array<ItemJSON>(),
       };
-      const handlerOptions: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON>> = {
+      const handlerOptions: Paged<ExtendedContentRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON>> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         descriptor,
@@ -386,7 +387,7 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards getPagedDistinctValues call", async () => {
-      const handlerOptions: DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON> = {
+      const handlerOptions: DistinctValuesRequestOptions<IModelRpcProps, DescriptorJSON, KeySetJSON, RulesetVariableJSON> = {
         imodel: token,
         rulesetOrId: faker.random.word(),
         descriptor: createRandomDescriptorJSON(),
@@ -485,7 +486,7 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("[deprecated] forwards compareHierarchies call", async () => {
-      const handlerOptions: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON> = {
+      const handlerOptions: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON> = {
         imodel: token,
         prev: {
           rulesetOrId: "test1",
@@ -508,7 +509,7 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards compareHierarchiesPaged call", async () => {
-      const handlerOptions: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON> = {
+      const handlerOptions: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON> = {
         imodel: token,
         prev: {
           rulesetOrId: "test1",

--- a/presentation/common/src/test/RulesetVariable.test.ts
+++ b/presentation/common/src/test/RulesetVariable.test.ts
@@ -86,7 +86,7 @@ describe("RulesetVariable", () => {
       });
     });
 
-    it("returns non Id64[] variables as is", () => {
+    it("returns non CompressedId64Set variables as is", () => {
       const boolVariable: BooleanRulesetVariableJSON = {
         type: VariableValueTypes.Bool,
         id: "test",
@@ -114,6 +114,13 @@ describe("RulesetVariable", () => {
         value: "0x123",
       };
       expect(RulesetVariable.fromJSON(id64Variable)).to.eq(id64Variable);
+
+      const id64ArrayVariable: Id64sRulesetVariableJSON = {
+        type: VariableValueTypes.Id64Array,
+        id: "test",
+        value: ["0x123", "0x456"],
+      };
+      expect(RulesetVariable.fromJSON(id64ArrayVariable)).to.eq(id64ArrayVariable);
 
       const stringVariable: StringRulesetVariableJSON = {
         type: VariableValueTypes.String,

--- a/presentation/common/src/test/RulesetVariable.test.ts
+++ b/presentation/common/src/test/RulesetVariable.test.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { CompressedId64Set, OrderedId64Iterable } from "@bentley/bentleyjs-core";
+import {
+  BooleanRulesetVariable, BooleanRulesetVariableJSON, Id64RulesetVariable, Id64RulesetVariableJSON, Id64sRulesetVariable, Id64sRulesetVariableJSON,
+  IntRulesetVariable, IntRulesetVariableJSON, IntsRulesetVariable, IntsRulesetVariableJSON, RulesetVariable, StringRulesetVariable,
+  StringRulesetVariableJSON, VariableValueTypes,
+} from "../presentation-common/RulesetVariables";
+import { createRandomId } from "./_helpers/random";
+
+describe("RulesetVariable", () => {
+
+  describe("toJSON", () => {
+
+    it("serializes Id64[] to CompressedId64Set", () => {
+      const ids = OrderedId64Iterable.sortArray([createRandomId(), createRandomId()]);
+      const variable: Id64sRulesetVariable = {
+        type: VariableValueTypes.Id64Array,
+        id: "test",
+        value: ids,
+      };
+      const json = RulesetVariable.toJSON(variable);
+      expect(json).to.deep.eq({
+        type: VariableValueTypes.Id64Array,
+        id: "test",
+        value: CompressedId64Set.compressIds(ids),
+      });
+    });
+
+    it("returns non Id64[] variables as is", () => {
+      const boolVariable: BooleanRulesetVariable = {
+        type: VariableValueTypes.Bool,
+        id: "test",
+        value: true,
+      };
+      expect(RulesetVariable.toJSON(boolVariable)).to.eq(boolVariable);
+
+      const intVariable: IntRulesetVariable = {
+        type: VariableValueTypes.Int,
+        id: "test",
+        value: 123,
+      };
+      expect(RulesetVariable.toJSON(intVariable)).to.eq(intVariable);
+
+      const intArrayVariable: IntsRulesetVariable = {
+        type: VariableValueTypes.IntArray,
+        id: "test",
+        value: [123, 456],
+      };
+      expect(RulesetVariable.toJSON(intArrayVariable)).to.eq(intArrayVariable);
+
+      const id64Variable: Id64RulesetVariable = {
+        type: VariableValueTypes.Id64,
+        id: "test",
+        value: "0x123",
+      };
+      expect(RulesetVariable.toJSON(id64Variable)).to.eq(id64Variable);
+
+      const stringVariable: StringRulesetVariable = {
+        type: VariableValueTypes.String,
+        id: "test",
+        value: "123",
+      };
+      expect(RulesetVariable.toJSON(stringVariable)).to.eq(stringVariable);
+    });
+
+  });
+
+  describe("fromJSON", () => {
+
+    it("deserializes CompressedId64Set to Id64[]", () => {
+      const ids = OrderedId64Iterable.sortArray([createRandomId(), createRandomId()]);
+      const json: Id64sRulesetVariableJSON = {
+        type: VariableValueTypes.Id64Array,
+        id: "test",
+        value: CompressedId64Set.compressIds(ids),
+      };
+      const variable = RulesetVariable.fromJSON(json);
+      expect(variable).to.deep.eq({
+        type: VariableValueTypes.Id64Array,
+        id: "test",
+        value: ids,
+      });
+    });
+
+    it("returns non Id64[] variables as is", () => {
+      const boolVariable: BooleanRulesetVariableJSON = {
+        type: VariableValueTypes.Bool,
+        id: "test",
+        value: true,
+      };
+      expect(RulesetVariable.fromJSON(boolVariable)).to.eq(boolVariable);
+
+      const intVariable: IntRulesetVariableJSON = {
+        type: VariableValueTypes.Int,
+        id: "test",
+        value: 123,
+      };
+      expect(RulesetVariable.fromJSON(intVariable)).to.eq(intVariable);
+
+      const intArrayVariable: IntsRulesetVariableJSON = {
+        type: VariableValueTypes.IntArray,
+        id: "test",
+        value: [123, 456],
+      };
+      expect(RulesetVariable.fromJSON(intArrayVariable)).to.eq(intArrayVariable);
+
+      const id64Variable: Id64RulesetVariableJSON = {
+        type: VariableValueTypes.Id64,
+        id: "test",
+        value: "0x123",
+      };
+      expect(RulesetVariable.fromJSON(id64Variable)).to.eq(id64Variable);
+
+      const stringVariable: StringRulesetVariableJSON = {
+        type: VariableValueTypes.String,
+        id: "test",
+        value: "123",
+      };
+      expect(RulesetVariable.fromJSON(stringVariable)).to.eq(stringVariable);
+    });
+
+  });
+
+});

--- a/presentation/components/src/presentation-components/common/ContentDataProvider.ts
+++ b/presentation/components/src/presentation-components/common/ContentDataProvider.ts
@@ -11,7 +11,7 @@ import { Logger } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
 import {
   Content, DEFAULT_KEYS_BATCH_SIZE, Descriptor, DescriptorOverrides, DiagnosticsOptionsWithHandler, Field, KeySet, PageOptions, RegisteredRuleset,
-  RequestOptionsWithRuleset, Ruleset, SelectionInfo,
+  RequestOptionsWithRuleset, Ruleset, RulesetVariable, SelectionInfo,
 } from "@bentley/presentation-common";
 import { IModelContentChangeEventArgs, Presentation } from "@bentley/presentation-frontend";
 import { PropertyRecord } from "@bentley/ui-abstract";
@@ -246,7 +246,7 @@ export class ContentDataProvider implements IContentDataProvider {
     }
   }
 
-  private createRequestOptions(): RequestOptionsWithRuleset<IModelConnection> {
+  private createRequestOptions(): RequestOptionsWithRuleset<IModelConnection, RulesetVariable> {
     return {
       imodel: this._imodel,
       rulesetOrId: this._rulesetRegistration.rulesetId,

--- a/presentation/components/src/presentation-components/tree/DataProvider.ts
+++ b/presentation/components/src/presentation-components/tree/DataProvider.ts
@@ -70,7 +70,7 @@ export interface PresentationTreeDataProviderProps extends DiagnosticsProps {
 export interface PresentationTreeDataProviderDataSourceEntryPoints {
   getNodesCount: (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>) => Promise<number>;
   getNodesAndCount: (requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>) => Promise<{ nodes: Node[], count: number }>;
-  getFilteredNodePaths: (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>, filterText: string) => Promise<NodePathElement[]>;
+  getFilteredNodePaths: (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never>, filterText: string) => Promise<NodePathElement[]>;
 }
 
 /**
@@ -95,7 +95,7 @@ export class PresentationTreeDataProvider implements IPresentationTreeDataProvid
     this._dataSource = {
       getNodesCount: async (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>) => Presentation.presentation.getNodesCount(requestOptions),
       getNodesAndCount: async (requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>) => Presentation.presentation.getNodesAndCount(requestOptions),
-      getFilteredNodePaths: async (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>, filterText: string) => Presentation.presentation.getFilteredNodePaths(requestOptions, filterText),
+      getFilteredNodePaths: async (requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never>, filterText: string) => Presentation.presentation.getFilteredNodePaths(requestOptions, filterText),
       ...props.dataSourceOverrides,
     };
     this._disposeVariablesChangeListener = Presentation.presentation.vars(this._rulesetRegistration.rulesetId).onVariableChanged.addListener(() => {
@@ -125,7 +125,7 @@ export class PresentationTreeDataProvider implements IPresentationTreeDataProvid
   public set pagingSize(value: number | undefined) { this._pagingSize = value; }
 
   /** Called to get extended options for node requests */
-  private createRequestOptions(parentKey: NodeKey | undefined): ExtendedHierarchyRequestOptions<IModelConnection, NodeKey> {
+  private createRequestOptions<TNodeKey = NodeKey>(parentKey: TNodeKey | undefined): ExtendedHierarchyRequestOptions<IModelConnection, TNodeKey> {
     return {
       imodel: this._imodel,
       rulesetOrId: this._rulesetRegistration.rulesetId,
@@ -183,7 +183,7 @@ export class PresentationTreeDataProvider implements IPresentationTreeDataProvid
    * @param filter Filter.
    */
   public getFilteredNodePaths = async (filter: string): Promise<NodePathElement[]> => {
-    return this._dataSource.getFilteredNodePaths(this.createRequestOptions(undefined), filter);
+    return this._dataSource.getFilteredNodePaths(this.createRequestOptions<never>(undefined), filter);
   };
 
   /**
@@ -191,7 +191,7 @@ export class PresentationTreeDataProvider implements IPresentationTreeDataProvid
    * @alpha @deprecated Will be removed on 3.0
    */
   // istanbul ignore next
-  public async loadHierarchy() {}
+  public async loadHierarchy() { }
 }
 
 class MemoizationHelpers {

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -9,7 +9,7 @@
 import * as immer from "immer";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  HierarchyUpdateRecord, PageOptions, PartialHierarchyModification, RegisteredRuleset, Ruleset, UPDATE_FULL, VariableValue,
+  HierarchyUpdateRecord, PageOptions, PartialHierarchyModification, RegisteredRuleset, Ruleset, RulesetVariable, UPDATE_FULL, VariableValue,
 } from "@bentley/presentation-common";
 import { IModelHierarchyChangeEventArgs, Presentation } from "@bentley/presentation-frontend";
 import {
@@ -183,8 +183,8 @@ function useModelSourceUpdateOnRulesetModification(props: ModelSourceUpdateProps
 function useModelSourceUpdateOnRulesetVariablesChange(props: ModelSourceUpdateProps) {
   const onRulesetVariableChanged = useCallback(async (variableId: string, prevValue: VariableValue) => {
     // note: we should probably debounce these events while accumulating changed variables in case multiple vars are changed
-    const prevVariables = (await Presentation.presentation.vars(props.dataProvider.rulesetId).getAllVariables())
-      .map((v) => (v.id === variableId) ? { ...v, value: prevValue } : v);
+    const prevVariables = Presentation.presentation.vars(props.dataProvider.rulesetId).getAllVariables()
+      .map((v): RulesetVariable => (v.id === variableId) ? { ...v, value: prevValue } as RulesetVariable : v);
     const compareResult = await Presentation.presentation.compareHierarchies({
       imodel: props.dataProvider.imodel,
       prev: {

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -9,7 +9,8 @@ import * as moq from "typemoq";
 import { BeEvent, IDisposable } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
 import {
-  LabelDefinition, LabelGroupingNodeKey, Node, PartialHierarchyModification, RegisteredRuleset, StandardNodeTypes, VariableValueTypes,
+  LabelDefinition, LabelGroupingNodeKey, Node, PartialHierarchyModification, RegisteredRuleset, RulesetVariable, StandardNodeTypes,
+  VariableValueTypes,
 } from "@bentley/presentation-common";
 import { Presentation, PresentationManager, RulesetManager, RulesetVariablesManager } from "@bentley/presentation-frontend";
 import { PrimitiveValue, PropertyRecord } from "@bentley/ui-abstract";
@@ -211,14 +212,22 @@ describe("usePresentationNodeLoader", () => {
       );
       const oldNodeLoader = result.current.nodeLoader;
 
-      const variables = [{ id: "var-id", type: VariableValueTypes.String, value: "curr" }, { id: "other-var", type: VariableValueTypes.Int, value: 123 }];
+      const variables: RulesetVariable[] = [{
+        id: "var-id",
+        type: VariableValueTypes.String,
+        value: "curr",
+      }, {
+        id: "other-var",
+        type: VariableValueTypes.Int,
+        value: 123,
+      }];
 
       presentationManagerMock
         .setup(async (x) => x.compareHierarchies({
           imodel: imodelMock.object,
           prev: {
             rulesetVariables: [
-              { ...variables[0], value: "prev" },
+              { ...variables[0], value: "prev" } as RulesetVariable,
               variables[1],
             ],
           },
@@ -227,7 +236,7 @@ describe("usePresentationNodeLoader", () => {
         }))
         .returns(async () => [hierarchyChange])
         .verifiable();
-      rulesetVariablesManagerMock.setup(async (x) => x.getAllVariables()).returns(async () => variables);
+      rulesetVariablesManagerMock.setup((x) => x.getAllVariables()).returns(() => variables);
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       act(() => { onRulesetVariableChanged.raiseEvent("var-id", "prev", "curr"); });

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -206,7 +206,7 @@ export class PresentationManager implements IDisposable {
 
     try {
       while (true) {
-        const result = (await this.rpcRequestsHandler.compareHierarchiesPaged(this.toRpcTokenOptions(options)));
+        const result = (await this.rpcRequestsHandler.compareHierarchiesPaged({ ...this.toRpcTokenOptions(options), prev: { ...options.prev, rulesetVariables: options.prev.rulesetVariables?.map(RulesetVariable.toJSON) } }));
         modifications.push(...result.changes.map(PartialHierarchyModification.fromJSON));
         if (!result.continuationToken)
           break;
@@ -268,19 +268,22 @@ export class PresentationManager implements IDisposable {
     return this._rulesetVars.get(rulesetId)!;
   }
 
-  private toRpcTokenOptions<TOptions extends { imodel: IModelConnection, locale?: string, unitSystem?: PresentationUnitSystem }>(requestOptions: TOptions) {
+  private toRpcTokenOptions<TOptions extends { imodel: IModelConnection, locale?: string, unitSystem?: PresentationUnitSystem, rulesetVariables?: RulesetVariable[] }>(requestOptions: TOptions) {
     // 1. put default `locale` and `unitSystem`
     // 2. put all `requestOptions` members (if `locale` or `unitSystem` are set, they'll override the defaults put at #1)
     // 3. put `imodel` of type `IModelRpcProps` which overwrites the `imodel` from `requestOptions` put at #2
-    const managerOptions: Pick<TOptions, "locale" | "unitSystem"> = {};
+    const defaultOptions: Pick<TOptions, "locale" | "unitSystem"> = {};
     if (this.activeLocale)
-      managerOptions.locale = this.activeLocale;
+      defaultOptions.locale = this.activeLocale;
     if (this.activeUnitSystem)
-      managerOptions.unitSystem = this.activeUnitSystem;
+      defaultOptions.unitSystem = this.activeUnitSystem;
+
+    const { imodel, rulesetVariables, ...rpcRequestOptions } = requestOptions;
     return {
-      ...managerOptions,
-      ...requestOptions,
-      ...{ imodel: requestOptions.imodel.getRpcProps() },
+      ...defaultOptions,
+      ...rpcRequestOptions,
+      ...(rulesetVariables ? { rulesetVariables: rulesetVariables.map(RulesetVariable.toJSON) } : {}),
+      imodel: imodel.getRpcProps(),
     };
   }
 
@@ -298,7 +301,7 @@ export class PresentationManager implements IDisposable {
     if (!this._ipcRequestsHandler) {
       // only need to add variables from variables manager if there's no IPC
       // handler - if there is one, the variables are already known by the backend
-      variables.push(...(await this.vars(rulesetId).getAllVariables()));
+      variables.push(...this.vars(rulesetId).getAllVariables());
     }
 
     return { ...options, rulesetOrId: foundRulesetOrId, rulesetVariables: variables };
@@ -309,11 +312,11 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ExtendedHierarchyRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodes(requestOptions: Paged<HierarchyRequestOptions<IModelConnection>>, parentKey: NodeKey | undefined): Promise<Node[]>; // eslint-disable-line @typescript-eslint/unified-signatures
+  public async getNodes(requestOptions: Paged<HierarchyRequestOptions<IModelConnection, RulesetVariable>>, parentKey: NodeKey | undefined): Promise<Node[]>; // eslint-disable-line @typescript-eslint/unified-signatures
   /** Retrieves nodes */
-  public async getNodes(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>): Promise<Node[]>;
+  public async getNodes(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>>): Promise<Node[]>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodes(requestOptions: Paged<HierarchyRequestOptions<IModelConnection> | ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>, parentKey?: NodeKey): Promise<Node[]> {
+  public async getNodes(requestOptions: Paged<HierarchyRequestOptions<IModelConnection, RulesetVariable> | ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>>, parentKey?: NodeKey): Promise<Node[]> {
     await this.onConnection(requestOptions.imodel);
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
     const rpcOptions = this.toRpcTokenOptions({ ...options, parentKey: optionalNodeKeyToJson(isExtendedHierarchyRequestOptions(options) ? options.parentKey : parentKey) });
@@ -326,11 +329,11 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ExtendedHierarchyRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodesCount(requestOptions: HierarchyRequestOptions<IModelConnection>, parentKey: NodeKey | undefined): Promise<number>; // eslint-disable-line @typescript-eslint/unified-signatures
+  public async getNodesCount(requestOptions: HierarchyRequestOptions<IModelConnection, RulesetVariable>, parentKey: NodeKey | undefined): Promise<number>; // eslint-disable-line @typescript-eslint/unified-signatures
   /** Retrieves nodes count. */
-  public async getNodesCount(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>): Promise<number>;
+  public async getNodesCount(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>): Promise<number>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodesCount(requestOptions: HierarchyRequestOptions<IModelConnection> | ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>, parentKey?: NodeKey): Promise<number> {
+  public async getNodesCount(requestOptions: HierarchyRequestOptions<IModelConnection, RulesetVariable> | ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>, parentKey?: NodeKey): Promise<number> {
     await this.onConnection(requestOptions.imodel);
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
     const rpcOptions = this.toRpcTokenOptions({ ...options, parentKey: optionalNodeKeyToJson(isExtendedHierarchyRequestOptions(options) ? options.parentKey : parentKey) });
@@ -342,11 +345,11 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ExtendedHierarchyRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodesAndCount(requestOptions: Paged<HierarchyRequestOptions<IModelConnection>>, parentKey: NodeKey | undefined): Promise<{ count: number, nodes: Node[] }>; // eslint-disable-line @typescript-eslint/unified-signatures
+  public async getNodesAndCount(requestOptions: Paged<HierarchyRequestOptions<IModelConnection, RulesetVariable>>, parentKey: NodeKey | undefined): Promise<{ count: number, nodes: Node[] }>; // eslint-disable-line @typescript-eslint/unified-signatures
   /** Retrieves total nodes count and a single page of nodes. */
-  public async getNodesAndCount(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>): Promise<{ count: number, nodes: Node[] }>;
+  public async getNodesAndCount(requestOptions: Paged<ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>>): Promise<{ count: number, nodes: Node[] }>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodesAndCount(requestOptions: Paged<HierarchyRequestOptions<IModelConnection> | ExtendedHierarchyRequestOptions<IModelConnection, NodeKey>>, parentKey?: NodeKey): Promise<{ count: number, nodes: Node[] }> {
+  public async getNodesAndCount(requestOptions: Paged<HierarchyRequestOptions<IModelConnection, RulesetVariable> | ExtendedHierarchyRequestOptions<IModelConnection, NodeKey, RulesetVariable>>, parentKey?: NodeKey): Promise<{ count: number, nodes: Node[] }> {
     await this.onConnection(requestOptions.imodel);
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
     const rpcOptions = this.toRpcTokenOptions({ ...options, parentKey: optionalNodeKeyToJson(isExtendedHierarchyRequestOptions(options) ? options.parentKey : parentKey) });
@@ -365,7 +368,7 @@ export class PresentationManager implements IDisposable {
    * @return A promise object that returns either an array of paths on success or an error string on error.
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getNodePaths(requestOptions: HierarchyRequestOptions<IModelConnection>, paths: InstanceKey[][], markedIndex: number): Promise<NodePathElement[]> {
+  public async getNodePaths(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never, RulesetVariable>, paths: InstanceKey[][], markedIndex: number): Promise<NodePathElement[]> {
     await this.onConnection(requestOptions.imodel);
 
     const pathsJson = paths.map((p) => p.map(InstanceKey.toJSON));
@@ -381,7 +384,7 @@ export class PresentationManager implements IDisposable {
    * @return A promise object that returns either an array of paths on success or an error string on error.
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getFilteredNodePaths(requestOptions: HierarchyRequestOptions<IModelConnection>, filterText: string): Promise<NodePathElement[]> {
+  public async getFilteredNodePaths(requestOptions: ExtendedHierarchyRequestOptions<IModelConnection, never, RulesetVariable>, filterText: string): Promise<NodePathElement[]> {
     await this.onConnection(requestOptions.imodel);
 
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
@@ -404,10 +407,10 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ContentDescriptorRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getContentDescriptor(requestOptions: ContentRequestOptions<IModelConnection>, displayType: string, keys: KeySet, selection: SelectionInfo | undefined): Promise<Descriptor | undefined>;
-  public async getContentDescriptor(requestOptions: ContentDescriptorRequestOptions<IModelConnection, KeySet>): Promise<Descriptor | undefined>;
+  public async getContentDescriptor(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable>, displayType: string, keys: KeySet, selection: SelectionInfo | undefined): Promise<Descriptor | undefined>;
+  public async getContentDescriptor(requestOptions: ContentDescriptorRequestOptions<IModelConnection, KeySet, RulesetVariable>): Promise<Descriptor | undefined>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getContentDescriptor(requestOptions: ContentRequestOptions<IModelConnection> | ContentDescriptorRequestOptions<IModelConnection, KeySet>, displayType?: string, keys?: KeySet, selection?: SelectionInfo): Promise<Descriptor | undefined> {
+  public async getContentDescriptor(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable> | ContentDescriptorRequestOptions<IModelConnection, KeySet, RulesetVariable>, displayType?: string, keys?: KeySet, selection?: SelectionInfo): Promise<Descriptor | undefined> {
     if (!isContentDescriptorRequestOptions(requestOptions))
       return this.getContentDescriptor({ ...requestOptions, displayType: displayType!, keys: keys!, selection });
 
@@ -426,10 +429,10 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ExtendedContentRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<number>;
-  public async getContentSetSize(requestOptions: ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>): Promise<number>;
+  public async getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<number>;
+  public async getContentSetSize(requestOptions: ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>): Promise<number>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection> | ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>, descriptorOrOverrides?: Descriptor | DescriptorOverrides, keys?: KeySet): Promise<number> {
+  public async getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable> | ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>, descriptorOrOverrides?: Descriptor | DescriptorOverrides, keys?: KeySet): Promise<number> {
     if (!isExtendedContentRequestOptions(requestOptions))
       return this.getContentSetSize({ ...requestOptions, descriptor: descriptorOrOverrides!, keys: keys! });
 
@@ -448,10 +451,10 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ExtendedContentRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getContent(requestOptions: Paged<ContentRequestOptions<IModelConnection>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<Content | undefined>;
-  public async getContent(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>>): Promise<Content | undefined>;
+  public async getContent(requestOptions: Paged<ContentRequestOptions<IModelConnection, RulesetVariable>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<Content | undefined>;
+  public async getContent(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>>): Promise<Content | undefined>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getContent(requestOptions: Paged<ContentRequestOptions<IModelConnection> | ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>>, argsDescriptor?: Descriptor | DescriptorOverrides, argsKeys?: KeySet): Promise<Content | undefined> {
+  public async getContent(requestOptions: Paged<ContentRequestOptions<IModelConnection, RulesetVariable> | ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>>, argsDescriptor?: Descriptor | DescriptorOverrides, argsKeys?: KeySet): Promise<Content | undefined> {
     if (!isExtendedContentRequestOptions(requestOptions))
       return this.getContent({ ...requestOptions, descriptor: argsDescriptor!, keys: argsKeys! });
     return (await this.getContentAndSize(requestOptions))?.content;
@@ -462,10 +465,10 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use an overload with [[ExtendedContentRequestOptions]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getContentAndSize(requestOptions: Paged<ContentRequestOptions<IModelConnection>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<{ content: Content, size: number } | undefined>;
-  public async getContentAndSize(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>>): Promise<{ content: Content, size: number } | undefined>;
+  public async getContentAndSize(requestOptions: Paged<ContentRequestOptions<IModelConnection, RulesetVariable>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<{ content: Content, size: number } | undefined>;
+  public async getContentAndSize(requestOptions: Paged<ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>>): Promise<{ content: Content, size: number } | undefined>;
   // eslint-disable-next-line deprecation/deprecation
-  public async getContentAndSize(requestOptions: Paged<ContentRequestOptions<IModelConnection> | ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet>>, argsDescriptor?: Descriptor | DescriptorOverrides, argsKeys?: KeySet): Promise<{ content: Content, size: number } | undefined> {
+  public async getContentAndSize(requestOptions: Paged<ContentRequestOptions<IModelConnection, RulesetVariable> | ExtendedContentRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>>, argsDescriptor?: Descriptor | DescriptorOverrides, argsKeys?: KeySet): Promise<{ content: Content, size: number } | undefined> {
     if (!isExtendedContentRequestOptions(requestOptions))
       return this.getContentAndSize({ ...requestOptions, descriptor: argsDescriptor!, keys: argsKeys! });
 
@@ -508,7 +511,7 @@ export class PresentationManager implements IDisposable {
    * @deprecated Use [[getPagedDistinctValues]]
    */
   // eslint-disable-next-line deprecation/deprecation
-  public async getDistinctValues(requestOptions: ContentRequestOptions<IModelConnection>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet, fieldName: string, maximumValueCount: number = 0): Promise<string[]> {
+  public async getDistinctValues(requestOptions: ContentRequestOptions<IModelConnection, RulesetVariable>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet, fieldName: string, maximumValueCount: number = 0): Promise<string[]> {
     const values = await this.getPagedDistinctValues({
       ...requestOptions,
       descriptor: descriptorOrOverrides,
@@ -530,7 +533,7 @@ export class PresentationManager implements IDisposable {
    * @param requestOptions Options for the request
    * @public
    */
-  public async getPagedDistinctValues(requestOptions: DistinctValuesRequestOptions<IModelConnection, Descriptor, KeySet>): Promise<PagedResponse<DisplayValueGroup>> {
+  public async getPagedDistinctValues(requestOptions: DistinctValuesRequestOptions<IModelConnection, Descriptor, KeySet, RulesetVariable>): Promise<PagedResponse<DisplayValueGroup>> {
     await this.onConnection(requestOptions.imodel);
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
     const rpcOptions = {

--- a/presentation/frontend/src/test/RulesetVariablesManager.test.ts
+++ b/presentation/frontend/src/test/RulesetVariablesManager.test.ts
@@ -6,13 +6,13 @@
 import { expect } from "chai";
 import * as faker from "faker";
 import sinon from "sinon";
-import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { Id64 } from "@bentley/bentleyjs-core";
 import { IpcApp } from "@bentley/imodeljs-frontend";
 import { RulesetVariable, VariableValueTypes } from "@bentley/presentation-common";
+import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { createRandomId } from "@bentley/presentation-common/lib/test/_helpers/random";
-import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager";
 import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
+import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager";
 
 describe("RulesetVariablesManager", () => {
 
@@ -39,7 +39,7 @@ describe("RulesetVariablesManager", () => {
       };
       ipcHandlerMock.setup(async (x) => x.setRulesetVariable(moq.It.isObjectWith({ rulesetId, variable: testVariable }))).verifiable(moq.Times.once());
 
-      await vars.setString(testVariable.id, testVariable.value as string);
+      await vars.setString(testVariable.id, testVariable.value);
       ipcHandlerMock.verifyAll();
     });
 
@@ -48,13 +48,13 @@ describe("RulesetVariablesManager", () => {
   describe("getAllVariables", () => {
 
     it("return empty array if there's no variables", async () => {
-      expect(await vars.getAllVariables()).to.deep.eq([]);
+      expect(vars.getAllVariables()).to.deep.eq([]);
     });
 
     it("returns variables", async () => {
       const variables = [{ id: variableId, type: VariableValueTypes.String, value: faker.random.word() }];
       await vars.setString(variables[0].id, variables[0].value);
-      const allVariables = await vars.getAllVariables();
+      const allVariables = vars.getAllVariables();
       expect(allVariables).to.deep.eq(variables);
     });
   });


### PR DESCRIPTION
We may be sending a lot of these IDs to the backend, so need to make sure the payload is as little as possible. Send them as a `CompressedId64Set`.

The PR doesn't directly require addon changes, but the newly added full stack test crashes the backend without this: https://bentleycs.visualstudio.com/iModelTechnologies/_git/imodel02/pullrequest/168205.