### PR TITLE
fix method name typo

### DIFF
--- a/core/frontend/src/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/tile/OrbitGtTileTree.ts
@@ -226,7 +226,7 @@ export class OrbitGtTileTree extends TileTree {
     this.rootTile = new OrbitGtRootTile(this._tileParams, this);
   }
 
-  public async getEcefTranform(): Promise<Transform | undefined> {
+  public async getEcefTransform(): Promise<Transform | undefined> {
     return this._ecefTransform;
   }
 


### PR DESCRIPTION
Managed to include the typo in the method name... OCP can workaround for now but good if this is fixed until later versions. @RBBentley 