### PR TITLE
Make display-performance-test-app wait for all external textures to load

### DIFF
--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -12,7 +12,7 @@ import {
   DisplayStyle3dState, DisplayStyleState, EntityState, FeatureSymbology, GLTimerResult, GLTimerResultCallback, IModelApp, IModelConnection,
   PerformanceMetrics, Pixel, RenderSystem, ScreenViewport, SnapshotConnection, Target, TileAdmin, ViewRect, ViewState,
 } from "@bentley/imodeljs-frontend";
-import { System } from "@bentley/imodeljs-frontend/lib/webgl";
+import { ExternalTextureLoader, System } from "@bentley/imodeljs-frontend/lib/webgl";
 import { HyperModeling } from "@bentley/hypermodeling-frontend";
 import DisplayPerfRpcInterface from "../common/DisplayPerfRpcInterface";
 import {
@@ -470,6 +470,11 @@ export class TestRunner {
       if (haveNewTiles)
         IModelApp.tileAdmin.process();
 
+      await BeDuration.wait(100);
+    }
+
+    const extTexLoader = ExternalTextureLoader.instance;
+    while (extTexLoader.numActiveRequests > 0 || extTexLoader.numPendingRequests > 0) {
       await BeDuration.wait(100);
     }
 


### PR DESCRIPTION
This PR makes display-performance-test-app wait for all external textures to finish loading before taking image captures.