### PR TITLE
add nativeDb.restartTxnSession, take 2

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -2635,7 +2635,7 @@ export abstract class IModelDb extends IModel {
     requestSnap(requestContext: ClientRequestContext, sessionId: string, props: SnapRequestProps): Promise<SnapResponseProps>;
     restartQuery(token: string, ecsql: string, bindings?: any[] | object, limitRows?: number, quota?: QueryQuota, priority?: QueryPriority): AsyncIterableIterator<any>;
     // @internal (undocumented)
-    reverseTxns(numOperations: number, allowCrossSessions?: boolean): IModelStatus;
+    reverseTxns(numOperations: number): IModelStatus;
     saveChanges(description?: string): void;
     saveFileProperty(prop: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): DbResult;
     // (undocumented)
@@ -2957,7 +2957,7 @@ export class IModelHubBackend {
     // (undocumented)
     static getRequestContext(arg: {
         requestContext?: AuthorizedClientRequestContext;
-    }): Promise<AuthorizedBackendRequestContext | AuthorizedClientRequestContext>;
+    }): Promise<AuthorizedClientRequestContext | AuthorizedBackendRequestContext>;
     // (undocumented)
     static get iModelClient(): IModelClient;
     // (undocumented)
@@ -4576,14 +4576,14 @@ export class TxnManager {
     // @internal
     constructor(_iModel: BriefcaseDb | StandaloneDb);
     beginMultiTxnOperation(): DbResult;
-    cancelTo(txnId: TxnIdString, allowCrossSessions?: boolean): IModelStatus;
-    checkUndoPossible(allowCrossSessions?: boolean): boolean;
+    cancelTo(txnId: TxnIdString): IModelStatus;
+    checkUndoPossible(): boolean;
     endMultiTxnOperation(): DbResult;
     getCurrentTxnId(): TxnIdString;
     getMultiTxnOperationDepth(): number;
     getRedoString(): string;
     getTxnDescription(txnId: TxnIdString): string;
-    getUndoString(allowCrossSessions?: boolean): string;
+    getUndoString(): string;
     get hasFatalError(): boolean;
     get hasLocalChanges(): boolean;
     get hasPendingTxns(): boolean;
@@ -4631,15 +4631,16 @@ export class TxnManager {
     readonly onModelsChanged: BeEvent<(changes: TxnChangedEntities) => void>;
     // @internal (undocumented)
     protected _onRootChanged(props: RelationshipProps): void;
-    queryFirstTxnId(allowCrossSessions?: boolean): TxnIdString;
+    queryFirstTxnId(): TxnIdString;
     queryNextTxnId(txnId: TxnIdString): TxnIdString;
     queryPreviousTxnId(txnId: TxnIdString): TxnIdString;
     reinstateTxn(): IModelStatus;
     reportError(error: ValidationError): void;
+    restartSession(): void;
     reverseAll(): IModelStatus;
     reverseSingleTxn(): IModelStatus;
-    reverseTo(txnId: TxnIdString, allowCrossSessions?: boolean): IModelStatus;
-    reverseTxns(numOperations: number, allowCrossSessions?: boolean): IModelStatus;
+    reverseTo(txnId: TxnIdString): IModelStatus;
+    reverseTxns(numOperations: number): IModelStatus;
     readonly validationErrors: ValidationError[];
 }
 

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4385,7 +4385,7 @@ export interface IpcAppFunctions {
     cancelTileContentRequests: (tokenProps: IModelRpcProps, _contentIds: TileTreeContentIds[]) => Promise<void>;
     closeIModel: (key: string) => Promise<void>;
     getRedoString: (key: string) => Promise<string>;
-    getUndoString: (key: string, allowCrossSessions?: boolean) => Promise<string>;
+    getUndoString: (key: string) => Promise<string>;
     hasPendingTxns: (key: string) => Promise<boolean>;
     // (undocumented)
     isGraphicalEditingSupported: (key: string) => Promise<boolean>;
@@ -4402,7 +4402,7 @@ export interface IpcAppFunctions {
     // (undocumented)
     reverseAllTxn: (key: string) => Promise<IModelStatus>;
     // (undocumented)
-    reverseTxns: (key: string, numOperations: number, allowCrossSessions?: boolean) => Promise<IModelStatus>;
+    reverseTxns: (key: string, numOperations: number) => Promise<IModelStatus>;
     saveChanges: (key: string, description?: string) => Promise<void>;
     // (undocumented)
     toggleGraphicalEditingScope: (key: string, _startSession: boolean) => Promise<boolean>;

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -1665,7 +1665,7 @@ export class BriefcaseTxns extends BriefcaseNotificationHandler implements TxnNo
     // @internal (undocumented)
     dispose(): void;
     getRedoString(): Promise<string>;
-    getUndoString(allowCrossSessions?: boolean): Promise<string>;
+    getUndoString(): Promise<string>;
     hasPendingTxns(): Promise<boolean>;
     isRedoPossible(): Promise<boolean>;
     isUndoPossible(): Promise<boolean>;
@@ -1714,7 +1714,7 @@ export class BriefcaseTxns extends BriefcaseNotificationHandler implements TxnNo
     reinstateTxn(): Promise<IModelStatus>;
     reverseAll(): Promise<IModelStatus>;
     reverseSingleTxn(): Promise<IModelStatus>;
-    reverseTxns(numOperations: number, allowCrossSessions?: boolean): Promise<IModelStatus>;
+    reverseTxns(numOperations: number): Promise<IModelStatus>;
 }
 
 // @internal (undocumented)

--- a/common/changes/@bentley/imodeljs-backend/restart-undo2_2021-06-04-18-36.json
+++ b/common/changes/@bentley/imodeljs-backend/restart-undo2_2021-06-04-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "added TxnManager.restartSession",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/restart-undo2_2021-06-04-18-36.json
+++ b/common/changes/@bentley/imodeljs-common/restart-undo2_2021-06-04-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/restart-undo2_2021-06-04-18-36.json
+++ b/common/changes/@bentley/imodeljs-frontend/restart-undo2_2021-06-04-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -718,8 +718,8 @@ export abstract class IModelDb extends IModel {
   }
 
   /** @internal */
-  public reverseTxns(numOperations: number, allowCrossSessions?: boolean): IModelStatus {
-    return this.nativeDb.reverseTxns(numOperations, allowCrossSessions);
+  public reverseTxns(numOperations: number): IModelStatus {
+    return this.nativeDb.reverseTxns(numOperations);
   }
   /** @internal */
   public reinstateTxn(): IModelStatus {

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -207,8 +207,8 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
   public async isRedoPossible(key: string): Promise<boolean> {
     return IModelDb.findByKey(key).nativeDb.isRedoPossible();
   }
-  public async getUndoString(key: string, allowCrossSessions?: boolean): Promise<string> {
-    return IModelDb.findByKey(key).nativeDb.getUndoString(allowCrossSessions);
+  public async getUndoString(key: string): Promise<string> {
+    return IModelDb.findByKey(key).nativeDb.getUndoString();
   }
   public async getRedoString(key: string): Promise<string> {
     return IModelDb.findByKey(key).nativeDb.getUndoString();
@@ -237,8 +237,8 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
     return IModelDb.findByKey(key).nativeDb.isGeometricModelTrackingSupported();
   }
 
-  public async reverseTxns(key: string, numOperations: number, allowCrossSessions?: boolean): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reverseTxns(numOperations, allowCrossSessions);
+  public async reverseTxns(key: string, numOperations: number): Promise<IModelStatus> {
+    return IModelDb.findByKey(key).nativeDb.reverseTxns(numOperations);
   }
   public async reverseAllTxn(key: string): Promise<IModelStatus> {
     return IModelDb.findByKey(key).nativeDb.reverseAll();

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -268,6 +268,17 @@ export class TxnManager {
    */
   public readonly onAfterUndoRedo = new BeEvent<(isUndo: boolean) => void>();
 
+  /**
+   * Restart the current TxnManager session. This causes all Txns in the current session to no longer be undoable (as if the file was closed
+   * and reopened.)
+   * @note This can be quite disconcerting to the user expecting to be able to undo previously made changes. It should only be used
+   * under extreme circumstances where damage to the file or session could happen if the currently committed are reversed. Use sparingly and with care.
+   * Probably a good idea to alert the user it happened.
+   */
+  public restartSession() {
+    this._nativeDb.restartTxnSession();
+  }
+
   /** Determine whether undo is possible
    * @@deprecated - use [[isUndoPossible]]
    */

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -269,9 +269,9 @@ export class TxnManager {
   public readonly onAfterUndoRedo = new BeEvent<(isUndo: boolean) => void>();
 
   /** Determine whether undo is possible, optionally permitting undoing txns from previous sessions.
-   * @param allowCrossSessions if true, allow undoing from previous sessions.
+   * @@deprecated - use [[isUndoPossible]]
    */
-  public checkUndoPossible(allowCrossSessions?: boolean) { return this._nativeDb.isUndoPossible(allowCrossSessions); }
+  public checkUndoPossible() { return this._nativeDb.isUndoPossible(); }
 
   /** Determine if there are currently any reversible (undoable) changes from this editing session. */
   public get isUndoPossible(): boolean { return this._nativeDb.isUndoPossible(); }
@@ -281,9 +281,8 @@ export class TxnManager {
 
   /** Get the description of the operation that would be reversed by calling reverseTxns(1).
    * This is useful for showing the operation that would be undone, for example in a menu.
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    */
-  public getUndoString(allowCrossSessions?: boolean): string { return this._nativeDb.getUndoString(allowCrossSessions); }
+  public getUndoString(): string { return this._nativeDb.getUndoString(); }
 
   /** Get a description of the operation that would be reinstated by calling reinstateTxn.
    * This is useful for showing the operation that would be redone, in a pull-down menu for example.
@@ -307,14 +306,13 @@ export class TxnManager {
   /** Reverse (undo) the most recent operation(s) to this IModelDb.
    * @param numOperations the number of operations to reverse. If this is greater than 1, the entire set of operations will
    *  be reinstated together when/if ReinstateTxn is called.
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    * @note If there are any outstanding uncommitted changes, they are reversed.
    * @note The term "operation" is used rather than Txn, since multiple Txns can be grouped together via [[beginMultiTxnOperation]]. So,
    * even if numOperations is 1, multiple Txns may be reversed if they were grouped together when they were made.
    * @note If numOperations is too large only the operations are reversible are reversed.
    */
-  public reverseTxns(numOperations: number, allowCrossSessions?: boolean): IModelStatus {
-    return this._iModel.reverseTxns(numOperations, allowCrossSessions);
+  public reverseTxns(numOperations: number): IModelStatus {
+    return this._iModel.reverseTxns(numOperations);
   }
 
   /** Reverse the most recent operation. */
@@ -325,18 +323,16 @@ export class TxnManager {
 
   /** Reverse all changes back to a previously saved TxnId.
    * @param txnId a TxnId obtained from a previous call to GetCurrentTxnId.
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    * @returns Success if the transactions were reversed, error status otherwise.
    * @see  [[getCurrentTxnId]] [[cancelTo]]
    */
-  public reverseTo(txnId: TxnIdString, allowCrossSessions?: boolean): IModelStatus { return this._nativeDb.reverseTo(txnId, allowCrossSessions); }
+  public reverseTo(txnId: TxnIdString): IModelStatus { return this._nativeDb.reverseTo(txnId); }
 
   /** Reverse and then cancel (make non-reinstatable) all changes back to a previous TxnId.
    * @param txnId a TxnId obtained from a previous call to [[getCurrentTxnId]]
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    * @returns Success if the transactions were reversed and cleared, error status otherwise.
    */
-  public cancelTo(txnId: TxnIdString, allowCrossSessions?: boolean): IModelStatus { return this._nativeDb.cancelTo(txnId, allowCrossSessions); }
+  public cancelTo(txnId: TxnIdString): IModelStatus { return this._nativeDb.cancelTo(txnId); }
 
   /** Reinstate the most recently reversed transaction. Since at any time multiple transactions can be reversed, it
    * may take multiple calls to this method to reinstate all reversed operations.
@@ -346,9 +342,8 @@ export class TxnManager {
   public reinstateTxn(): IModelStatus { return this._iModel.reinstateTxn(); }
 
   /** Get the Id of the first transaction, if any.
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    */
-  public queryFirstTxnId(allowCrossSessions?: boolean): TxnIdString { return this._nativeDb.queryFirstTxnId(allowCrossSessions); }
+  public queryFirstTxnId(): TxnIdString { return this._nativeDb.queryFirstTxnId(); }
 
   /** Get the successor of the specified TxnId */
   public queryNextTxnId(txnId: TxnIdString): TxnIdString { return this._nativeDb.queryNextTxnId(txnId); }

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -268,7 +268,7 @@ export class TxnManager {
    */
   public readonly onAfterUndoRedo = new BeEvent<(isUndo: boolean) => void>();
 
-  /** Determine whether undo is possible, optionally permitting undoing txns from previous sessions.
+  /** Determine whether undo is possible
    * @@deprecated - use [[isUndoPossible]]
    */
   public checkUndoPossible() { return this._nativeDb.isUndoPossible(); }

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -256,7 +256,7 @@ describe("TxnManager", () => {
     assert.isTrue(txns.isUndoPossible);
 
     // test restarting the session, which should truncate undo history
-    imodel.nativeDb.restartTxnSession();
+    txns.restartSession();
 
     assert.isFalse(txns.isUndoPossible);
     assert.equal("", txns.getUndoString());

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -77,7 +77,7 @@ describe("TxnManager", () => {
 
     assert.isDefined(imodel.getMetaData("TestBim:TestPhysicalObject"), "TestPhysicalObject is present");
 
-    let txns = imodel.txns;
+    const txns = imodel.txns;
     assert.isFalse(txns.hasPendingTxns);
 
     const change1Msg = "change 1";
@@ -254,32 +254,16 @@ describe("TxnManager", () => {
     expect(lastMod3).not.to.equal(lastMod2);
 
     assert.isTrue(txns.isUndoPossible);
-    assert.isTrue(txns.checkUndoPossible(true));
-    assert.isTrue(txns.checkUndoPossible(false));
-    assert.isTrue(txns.checkUndoPossible());
 
-    // test the ability to undo/redo from previous sessions
-    imodel.close();
-    imodel = StandaloneDb.openFile(testFileName, OpenMode.ReadWrite);
-    txns = imodel.txns;
+    // test restarting the session, which should truncate undo history
+    imodel.nativeDb.restartTxnSession();
 
     assert.isFalse(txns.isUndoPossible);
-    assert.isTrue(txns.checkUndoPossible(true));
-    assert.isFalse(txns.checkUndoPossible(false));
-    assert.isFalse(txns.checkUndoPossible());
-    assert.equal(deleteTxnMsg, txns.getUndoString(true));
     assert.equal("", txns.getUndoString());
 
-    assert.equal(IModelStatus.Success, txns.reverseTxns(1, true), "reverse from previous session");
-    assert.equal(saveUpdateMsg, txns.getUndoString(true));
-    assert.equal(deleteTxnMsg, txns.getRedoString());
-    assert.equal(IModelStatus.Success, txns.reinstateTxn());
-    assert.equal(IModelStatus.Success, txns.cancelTo(txns.queryFirstTxnId(true), true), "cancel all committed txns");
-    assert.isFalse(txns.checkUndoPossible(true));
     assert.isFalse(txns.isRedoPossible);
-    assert.isFalse(txns.isUndoPossible);
     assert.isFalse(txns.hasUnsavedChanges);
-    assert.isFalse(txns.hasPendingTxns);
+    assert.isTrue(txns.hasPendingTxns); // these are from the previous session
     cleanup.forEach((drop) => drop());
   });
 

--- a/core/common/src/BriefcaseTypes.ts
+++ b/core/common/src/BriefcaseTypes.ts
@@ -137,7 +137,11 @@ export interface RequestNewBriefcaseProps {
    */
   fileName?: string;
 
-  /** The BriefcaseId of the newly downloaded briefcase. If undefined, a new BriefcaseId will be acquired from iModelHub before the download, and is returned in this member.
+  /**
+   * The BriefcaseId for the new briefcase. If undefined, a new BriefcaseId will be acquired from iModelHub before the download, and is returned in this member.
+   * @note To download a briefcase that can accept but not create new changesets (sometimes referred to as "pull only" briefcases), set this value to [[BriefcaseIdValue.Unassigned]].
+   * After downloading, you can merely delete unassigned briefcase files when they are no longer needed. Assigned BriefcaseIds should be released (via [BriefcaseManager.releaseBriefcase]($backend) )
+   * when you are done with them.
    * @note this member is both an input and an output.
    *
    */

--- a/core/common/src/IpcAppProps.ts
+++ b/core/common/src/IpcAppProps.ts
@@ -130,7 +130,7 @@ export interface IpcAppFunctions {
   /** see BriefcaseTxns.isRedoPossible */
   isRedoPossible: (key: string) => Promise<boolean>;
   /** see BriefcaseTxns.getUndoString */
-  getUndoString: (key: string, allowCrossSessions?: boolean) => Promise<string>;
+  getUndoString: (key: string) => Promise<string>;
   /** see BriefcaseTxns.getRedoString */
   getRedoString: (key: string) => Promise<string>;
 
@@ -149,7 +149,7 @@ export interface IpcAppFunctions {
   toggleGraphicalEditingScope: (key: string, _startSession: boolean) => Promise<boolean>;
   isGraphicalEditingSupported: (key: string) => Promise<boolean>;
 
-  reverseTxns: (key: string, numOperations: number, allowCrossSessions?: boolean) => Promise<IModelStatus>;
+  reverseTxns: (key: string, numOperations: number) => Promise<IModelStatus>;
   reverseAllTxn: (key: string) => Promise<IModelStatus>;
   reinstateTxn: (key: string) => Promise<IModelStatus>;
 

--- a/core/frontend/src/BriefcaseTxns.ts
+++ b/core/frontend/src/BriefcaseTxns.ts
@@ -143,10 +143,9 @@ export class BriefcaseTxns extends BriefcaseNotificationHandler implements TxnNo
 
   /** Get the description of the operation that would be reversed by calling [[reverseTxns]]`(1)`.
    * This is useful for showing the operation that would be undone, for example in a menu.
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    */
-  public async getUndoString(allowCrossSessions?: boolean): Promise<string> {
-    return IpcApp.callIpcHost("getUndoString", this._iModel.key, allowCrossSessions);
+  public async getUndoString(): Promise<string> {
+    return IpcApp.callIpcHost("getUndoString", this._iModel.key);
   }
 
   /** Get a description of the operation that would be reinstated by calling [[reinstateTxn]].
@@ -165,17 +164,16 @@ export class BriefcaseTxns extends BriefcaseNotificationHandler implements TxnNo
     return this.reverseTxns(1);
   }
 
-  /** Reverse (undo) the most recent operation(s) to the briefcase.
+  /** Reverse (undo) the most recent operation(s) to the briefcase in the current session.
    * @param numOperations the number of operations to reverse. If this is greater than 1, the entire set of operations will
    *  be reinstated together when/if [[reinstateTxn]] is called.
-   * @param allowCrossSessions if true, allow undo from previous sessions.
    * @note If there are any outstanding uncommitted changes, they are reversed.
    * @note The term "operation" is used rather than Txn, since multiple Txns can be grouped together via [TxnManager.beginMultiTxnOperation]($backend). So,
    * even if numOperations is 1, multiple Txns may be reversed if they were grouped together when they were made.
    * @note If numOperations is too large only the number of reversible operations are reversed.
    */
-  public async reverseTxns(numOperations: number, allowCrossSessions?: boolean): Promise<IModelStatus> {
-    return IpcApp.callIpcHost("reverseTxns", this._iModel.key, numOperations, allowCrossSessions);
+  public async reverseTxns(numOperations: number): Promise<IModelStatus> {
+    return IpcApp.callIpcHost("reverseTxns", this._iModel.key, numOperations);
   }
 
   /** Reverse (undo) all changes back to the beginning of the session.


### PR DESCRIPTION
Allows applications to clear undo history in case their changes should not be undoable (@bbastings will use it when setting geolocation).

**BREAKING CHANGE**: removed "allowCrossSession" optional argument to undo methods. There was no real use case for it and I'm confident no one is using it (and I don't see any way to deprecate an optional argument in TS).

relies on [this](https://bentleycs.visualstudio.com/iModelTechnologies/_git/imodel02/pullrequest/168978) iModel02 PR