### PR TITLE
UI: Visibility widget improvements

### DIFF
--- a/common/api/ui-framework.api.md
+++ b/common/api/ui-framework.api.md
@@ -62,6 +62,7 @@ import { HorizontalAnchor } from '@bentley/ui-ninezone';
 import { I18N } from '@bentley/imodeljs-i18n';
 import { IconProps } from '@bentley/ui-core';
 import { IconSpec } from '@bentley/ui-core';
+import { Id64Array } from '@bentley/bentleyjs-core';
 import { Id64String } from '@bentley/bentleyjs-core';
 import { IDisposable } from '@bentley/bentleyjs-core';
 import { IFilteredPresentationTreeDataProvider } from '@bentley/presentation-components';
@@ -3990,6 +3991,8 @@ export interface ModelsTreeProps {
     enableHierarchyAutoUpdate?: boolean;
     // @deprecated
     enablePreloading?: boolean;
+    // @alpha
+    filteredElementIds?: Id64Array;
     // @alpha
     filterInfo?: VisibilityTreeFilterInfo;
     iModel: IModelConnection;

--- a/common/changes/@bentley/ui-framework/ui-visibility-widget-improvements_2021-06-10-08-24.json
+++ b/common/changes/@bentley/ui-framework/ui-visibility-widget-improvements_2021-06-10-08-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Models Tree: Add a way to filter the hierarchy by element IDs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/ui/framework/src/test/imodel-components/models-tree/ModelsTree.test.tsx
+++ b/ui/framework/src/test/imodel-components/models-tree/ModelsTree.test.tsx
@@ -14,7 +14,7 @@ import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { createRandomId } from "@bentley/presentation-common/lib/test/_helpers/random";
 import { IPresentationTreeDataProvider } from "@bentley/presentation-components";
 import { mockPresentationManager } from "@bentley/presentation-components/lib/test/_helpers/UiComponents";
-import { Presentation, PresentationManager, SelectionChangeEvent, SelectionManager } from "@bentley/presentation-frontend";
+import { Presentation, PresentationManager, RulesetVariablesManager, SelectionChangeEvent, SelectionManager } from "@bentley/presentation-frontend";
 import {
   HierarchyBuilder, HierarchyCacheMode, initialize as initializePresentationTesting, terminate as terminatePresentationTesting,
 } from "@bentley/presentation-testing";
@@ -48,6 +48,7 @@ describe("ModelsTree", () => {
     const imodelMock = moq.Mock.ofType<IModelConnection>();
     const selectionManagerMock = moq.Mock.ofType<SelectionManager>();
     let presentationManagerMock: moq.IMock<PresentationManager>;
+    let rulesetVariablesManagerMock: moq.IMock<RulesetVariablesManager>;
     let dataProvider: IPresentationTreeDataProvider;
 
     beforeEach(() => {
@@ -71,7 +72,9 @@ describe("ModelsTree", () => {
       selectionManagerMock.setup((x) => x.getSelection(imodelMock.object, moq.It.isAny())).returns(() => new KeySet());
       Presentation.setSelectionManager(selectionManagerMock.object);
 
-      presentationManagerMock = mockPresentationManager().presentationManager;
+      const mocks = mockPresentationManager();
+      presentationManagerMock = mocks.presentationManager;
+      rulesetVariablesManagerMock = mocks.rulesetVariablesManager;
       Presentation.setPresentationManager(presentationManagerMock.object);
     });
 
@@ -365,6 +368,12 @@ describe("ModelsTree", () => {
           await waitForElement(() => result.getByText("filtered-node"));
 
           expect(spy).to.be.calledOnce;
+        });
+
+        it("filters nodes by element IDs", async () => {
+          const elementIds = ["0x123", "0x456"];
+          render(<ModelsTree iModel={imodelMock.object} dataProvider={dataProvider} modelsVisibilityHandler={visibilityHandlerMock.object} filteredElementIds={elementIds} />);
+          rulesetVariablesManagerMock.verify(async (x) => x.setId64s("filtered-element-ids", elementIds), moq.Times.once());
         });
 
       });

--- a/ui/framework/src/ui-framework/imodel-components/category-tree/Categories.json
+++ b/ui/framework/src/ui-framework/imodel-components/category-tree/Categories.json
@@ -21,14 +21,12 @@
               "arePolymorphic": true,
               "relatedInstances": [
                 {
-                  "relationship": {
-                    "schemaName": "BisCore",
-                    "className": "ModelContainsElements"
-                  },
-                  "requiredDirection": "Backward",
-                  "class": {
-                    "schemaName": "BisCore",
-                    "className": "Model"
+                  "relationshipPath": {
+                    "relationship": {
+                      "schemaName": "BisCore",
+                      "className": "ModelContainsElements"
+                    },
+                    "direction": "Backward"
                   },
                   "isRequired": true,
                   "alias": "model"
@@ -56,14 +54,12 @@
               "arePolymorphic": true,
               "relatedInstances": [
                 {
-                  "relationship": {
-                    "schemaName": "BisCore",
-                    "className": "ModelContainsElements"
-                  },
-                  "requiredDirection": "Backward",
-                  "class": {
-                    "schemaName": "BisCore",
-                    "className": "Model"
+                  "relationshipPath": {
+                    "relationship": {
+                      "schemaName": "BisCore",
+                      "className": "ModelContainsElements"
+                    },
+                    "direction": "Backward"
                   },
                   "isRequired": true,
                   "alias": "model"
@@ -83,19 +79,15 @@
       "specifications": [
         {
           "specType": "RelatedInstanceNodes",
-          "relationships": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "CategoryOwnsSubCategories"
-            ]
-          },
-          "relatedClasses": {
-            "schemaName": "BisCore",
-            "classNames": [
-              "SubCategory"
-            ]
-          },
-          "requiredDirection": "Forward",
+          "relationshipPaths": [
+            {
+              "relationship": {
+                "schemaName": "BisCore",
+                "className": "CategoryOwnsSubCategories"
+              },
+              "direction": "Forward"
+            }
+          ],
           "groupByClass": false,
           "groupByLabel": false
         }

--- a/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.GroupedByClass.json
+++ b/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.GroupedByClass.json
@@ -121,7 +121,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
-          "hasChildren": "Always",
+          "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
         },
@@ -153,7 +153,6 @@
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
           "hideNodesInHierarchy": true,
-          "hasChildren": "Always",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -183,7 +182,6 @@
             }
           ],
           "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
-          "hasChildren": "Always",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -231,7 +229,7 @@
             ]
           ],
           "suppressSimilarAncestorsCheck": true,
-          "hasChildren": "Always",
+          "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -265,7 +263,7 @@
               }
             }
           ],
-          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
+          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL ANDALSO (NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId))",
           "groupByClass": true,
           "groupByLabel": false
         }
@@ -299,6 +297,7 @@
               }
             }
           ],
+          "instanceFilter": "NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId)",
           "groupByClass": true,
           "groupByLabel": false
         }

--- a/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.json
+++ b/ui/framework/src/ui-framework/imodel-components/models-tree/Hierarchy.json
@@ -121,7 +121,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
-          "hasChildren": "Always",
+          "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
         },
@@ -153,7 +153,6 @@
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
           "hideNodesInHierarchy": true,
-          "hasChildren": "Always",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -183,7 +182,6 @@
             }
           ],
           "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
-          "hasChildren": "Always",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -231,7 +229,7 @@
             ]
           ],
           "suppressSimilarAncestorsCheck": true,
-          "hasChildren": "Always",
+          "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -265,7 +263,7 @@
               }
             }
           ],
-          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
+          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL ANDALSO (NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId))",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -299,6 +297,7 @@
               }
             }
           ],
+          "instanceFilter": "NOT HasVariable(\"filtered-element-ids\") OR GetVariableIntValues(\"filtered-element-ids\").AnyMatch(id => id = this.ECInstanceId)",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -341,22 +340,22 @@
     },
     {
       "ruleType": "ImageIdOverride",
-      "condition": "ThisNode.IsOfClass(\"Subject\", \"BisCore\")",
+      "condition": "ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass(\"Subject\", \"BisCore\")",
       "imageIdExpression": "IIF(this.Parent.Id = NULL, \"icon-imodel-hollow-2\", \"icon-folder\")"
     },
     {
       "ruleType": "ImageIdOverride",
-      "condition": "ThisNode.IsOfClass(\"Model\", \"BisCore\")",
+      "condition": "ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass(\"Model\", \"BisCore\")",
       "imageIdExpression": "\"icon-model\""
     },
     {
       "ruleType": "ImageIdOverride",
-      "condition": "ThisNode.IsOfClass(\"Category\", \"BisCore\")",
+      "condition": "ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass(\"Category\", \"BisCore\")",
       "imageIdExpression": "\"icon-layers\""
     },
     {
       "ruleType": "ImageIdOverride",
-      "condition": "ThisNode.IsOfClass(\"Element\", \"BisCore\")",
+      "condition": "ThisNode.IsInstanceNode ANDALSO ThisNode.IsOfClass(\"Element\", \"BisCore\")",
       "imageIdExpression": "\"icon-item\""
     },
     {


### PR DESCRIPTION
Add a way to filter Models Tree by element IDs. ui-test-app demonstrates this by adding a key-in to filter the hierarchy by elements visible in the active viewport.