### PR TITLE
Use the ecef column vectors to calculate the ecef transform if presen…

### DIFF
--- a/core/frontend/src/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/tile/OrbitGtTileTree.ts
@@ -373,7 +373,7 @@ export namespace OrbitGtTileTree {
       const pointCloudCenterToEcef = pointCloudToEcef.multiplyTransformTransform(addCloudCenter);
       ecefTransform.setFrom(pointCloudCenterToEcef);
 
-      let ecefToDb = iModel.backgroundMapLocation.getMapEcefToDb(0);
+      let ecefToDb = iModel.ecefLocation ? iModel.backgroundMapLocation.getMapEcefToDb(0) : Transform.createIdentity();
       // In initial publishing version the iModel ecef Transform was used to locate the reality model.
       // This would work well only for tilesets published from that iModel but for iModels the ecef transform is calculated
       // at the center of the project extents and the reality model location may differ greatly, and the curvature of the earth


### PR DESCRIPTION
…t so that non-rigid transforms are handled. (#1364)

* Remove BackgroundMapLocation

* Changes

* extract-api

* Make getMapEcefToDb internal.  Remove BackgroundMapLocation init

* Rework altitude implementation for background maps

* Fix merge errors

* Fix lint error

* Geolocated test

* Fix lint error

* Cleanup.   Calculate ecef transform in constructor.

Co-authored-by: Ray.Bentley <rbbentley@users.noreply.github.com>