### PR TITLE
Fix BentleyMochaReporter to ban `.only` in PR builds again

### DIFF
--- a/common/changes/@bentley/build-tools/fix-dotonly-ban_2021-06-18-15-15.json
+++ b/common/changes/@bentley/build-tools/fix-dotonly-ban_2021-06-18-15-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/build-tools",
+  "email": "33036725+wgoehrig@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-backend/fix-dotonly-ban_2021-06-18-15-58.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-dotonly-ban_2021-06-18-15-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "33036725+wgoehrig@users.noreply.github.com"
+}

--- a/core/backend/src/test/standalone/IModel.test.ts
+++ b/core/backend/src/test/standalone/IModel.test.ts
@@ -2018,7 +2018,7 @@ describe("iModel", () => {
     process.env.BLOCKCACHE_DIR = "/foo/";
     const ctx = ClientRequestContext.current as AuthorizedClientRequestContext;
     const attachMock = sinon.stub(V2CheckpointManager, "attach").callsFake(async () => ({ filePath: "BAD", expiryTimestamp: Date.now() }));
-    await imodel1.reattachDaemon(ctx)
+    await imodel1.reattachDaemon(ctx);
     assert.isTrue(attachMock.notCalled);
   });
 

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -21,7 +21,7 @@ function withStdErr(callback: () => void) {
   console.log = originalConsoleLog;
 }
 
-declare var mocha: any;
+declare const mocha: any;
 const isCI = process.env.CI || process.env.TF_BUILD;
 
 // Force rush test to fail CI builds if describe.only or it.only is used.


### PR DESCRIPTION
Updating mocha to 8.3.2 (#1190) broke our mechanism for failing builds when someone pushes a commit that uses `.only` in a test.

I could probably come up with a cleaner implementation for this by moving it out of our reporter file entirely and configuring all tests to require another file, but keeping this in the reporter is awfully convenient given the multitude of test configurations we have today...