### PR TITLE
Synch legacy map settings when base layer provider is changed

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -423,6 +423,8 @@ export class BackgroundMapSettings {
     readonly mapType: BackgroundMapType;
     // @beta
     readonly planarClipMask: PlanarClipMaskSettings;
+    // @internal (undocumented)
+    static providerFromMapLayer(props: MapLayerProps): BackgroundMapProps | undefined;
     readonly providerName: BackgroundMapProviderName;
     readonly terrainSettings: TerrainSettings;
     // (undocumented)

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4773,7 +4773,6 @@ export interface MapImageryProps {
 
 // @beta
 export class MapImagerySettings {
-    // (undocumented)
     get backgroundBase(): BaseLayerSettings;
     set backgroundBase(base: BaseLayerSettings);
     // (undocumented)

--- a/common/changes/@bentley/imodeljs-common/synch-background-map-settings_2021-06-24-14-53.json
+++ b/common/changes/@bentley/imodeljs-common/synch-background-map-settings_2021-06-24-14-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Synch map settings provider when base layer provider changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "rbbentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/synch-background-map-settings_2021-06-24-14-53.json
+++ b/common/changes/@bentley/imodeljs-frontend/synch-background-map-settings_2021-06-24-14-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Synch map settings provider when base layer provider changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "rbbentley@users.noreply.github.com"
+}

--- a/core/common/src/BackgroundMapSettings.ts
+++ b/core/common/src/BackgroundMapSettings.ts
@@ -205,6 +205,7 @@ export class BackgroundMapSettings {
   /** Create a copy of this BackgroundMapSettings, optionally modifying some of its properties.
    * @param changedProps JSON representation of the properties to change.
    * @returns A BackgroundMapSettings with all of its properties set to match those of `this`, except those explicitly defined in `changedProps`.
+   * @note If changing the provider it is currently necessary to also make same change to update the imagery base layer.
    */
   public clone(changedProps?: BackgroundMapProps): BackgroundMapSettings {
     if (undefined === changedProps)

--- a/core/common/src/BackgroundMapSettings.ts
+++ b/core/common/src/BackgroundMapSettings.ts
@@ -241,7 +241,7 @@ export class BackgroundMapSettings {
         mapType = BackgroundMapType.Hybrid;
       else if (props.url.indexOf("Aerial") > 0)
         mapType = BackgroundMapType.Aerial;
-    } else if (props.formatId === "Mapbox") {
+    } else if (props.formatId === "MapboxImagery") {
       providerName = "MapBoxProvider";
       if (props.url.indexOf("streets-satellite") > 0)
         mapType = BackgroundMapType.Hybrid;

--- a/core/common/src/BackgroundMapSettings.ts
+++ b/core/common/src/BackgroundMapSettings.ts
@@ -235,10 +235,10 @@ export class BackgroundMapSettings {
       providerName = "BingProvider";
       if (props.url.indexOf("Road") > 0)
         mapType = BackgroundMapType.Street;
+      else if (props.url.indexOf("AerialWithLabels") > 0)
+        mapType = BackgroundMapType.Hybrid;
       else if (props.url.indexOf("Aerial") > 0)
         mapType = BackgroundMapType.Aerial;
-      else if (props.url.indexOf("Hybrid") > 0)
-        mapType = BackgroundMapType.Hybrid;
     } else if (props.formatId === "Mapbox") {
       providerName = "MapBoxProvider";
       if (props.url.indexOf("streets") > 0)

--- a/core/common/src/BackgroundMapSettings.ts
+++ b/core/common/src/BackgroundMapSettings.ts
@@ -243,12 +243,12 @@ export class BackgroundMapSettings {
         mapType = BackgroundMapType.Aerial;
     } else if (props.formatId === "Mapbox") {
       providerName = "MapBoxProvider";
-      if (props.url.indexOf("streets") > 0)
+      if (props.url.indexOf("streets-satellite") > 0)
+        mapType = BackgroundMapType.Hybrid;
+      else if (props.url.indexOf("streets") > 0)
         mapType = BackgroundMapType.Street;
       else if (props.url.indexOf("satellite") > 0)
         mapType = BackgroundMapType.Aerial;
-      else if (props.url.indexOf("streets-satellite") > 0)
-        mapType = BackgroundMapType.Hybrid;
     } else
       return undefined;
 

--- a/core/common/src/BackgroundMapSettings.ts
+++ b/core/common/src/BackgroundMapSettings.ts
@@ -6,6 +6,7 @@
  * @module DisplayStyles
  */
 
+import { MapLayerProps } from "./MapLayerSettings";
 import { PlanarClipMaskProps, PlanarClipMaskSettings } from "./PlanarClipMask";
 import { TerrainProps, TerrainSettings } from "./TerrainSettings";
 
@@ -225,5 +226,30 @@ export class BackgroundMapSettings {
     };
 
     return BackgroundMapSettings.fromJSON(props);
+  }
+  public static providerFromMapLayer(props: MapLayerProps): BackgroundMapProps | undefined {
+    let providerName, mapType;
+    if (!props.url)
+      return undefined;
+    if (props.formatId === "BingMaps") {
+      providerName = "BingProvider";
+      if (props.url.indexOf("Road") > 0)
+        mapType = BackgroundMapType.Street;
+      else if (props.url.indexOf("Aerial") > 0)
+        mapType = BackgroundMapType.Aerial;
+      else if (props.url.indexOf("Hybrid") > 0)
+        mapType = BackgroundMapType.Hybrid;
+    } else if (props.formatId === "Mapbox") {
+      providerName = "MapBoxProvider";
+      if (props.url.indexOf("streets") > 0)
+        mapType = BackgroundMapType.Street;
+      else if (props.url.indexOf("satellite") > 0)
+        mapType = BackgroundMapType.Aerial;
+      else if (props.url.indexOf("streets-satellite") > 0)
+        mapType = BackgroundMapType.Hybrid;
+    } else
+      return undefined;
+
+    return mapType !== undefined && providerName !== undefined ?  { providerName, providerData: { mapType } } : undefined;
   }
 }

--- a/core/common/src/BackgroundMapSettings.ts
+++ b/core/common/src/BackgroundMapSettings.ts
@@ -227,6 +227,8 @@ export class BackgroundMapSettings {
 
     return BackgroundMapSettings.fromJSON(props);
   }
+
+  /** @internal */
   public static providerFromMapLayer(props: MapLayerProps): BackgroundMapProps | undefined {
     let providerName, mapType;
     if (!props.url)

--- a/core/common/src/MapImagerySettings.ts
+++ b/core/common/src/MapImagerySettings.ts
@@ -63,6 +63,7 @@ export class MapImagerySettings {
     }
   }
   public get backgroundBase(): BaseLayerSettings { return this._backgroundBase; }
+  /**  @note If changing the base provider it is currently necessary to also update the background map settings.*/
   public set backgroundBase(base: BaseLayerSettings) { this._backgroundBase = base; }
   public get backgroundLayers(): MapLayerSettings[] { return this._backgroundLayers; }
   public get overlayLayers(): MapLayerSettings[] { return this._overlayLayers; }

--- a/core/common/src/MapImagerySettings.ts
+++ b/core/common/src/MapImagerySettings.ts
@@ -62,9 +62,13 @@ export class MapImagerySettings {
       }
     }
   }
+
+  /** The settings for the base layer.
+   *  @note If changing the base provider it is currently necessary to also update the background map settings.
+   */
   public get backgroundBase(): BaseLayerSettings { return this._backgroundBase; }
-  /**  @note If changing the base provider it is currently necessary to also update the background map settings.*/
   public set backgroundBase(base: BaseLayerSettings) { this._backgroundBase = base; }
+
   public get backgroundLayers(): MapLayerSettings[] { return this._backgroundLayers; }
   public get overlayLayers(): MapLayerSettings[] { return this._overlayLayers; }
 

--- a/core/common/src/test/BackgroundMapSettings.test.ts
+++ b/core/common/src/test/BackgroundMapSettings.test.ts
@@ -9,7 +9,7 @@ import { MapLayerSettings } from "../MapLayerSettings";
 import { TerrainHeightOriginMode } from "../TerrainSettings";
 
 describe("BackgroundMapSettings", () => {
-  it.only("round-trips through JSON", () => {
+  it("round-trips through JSON", () => {
     const roundTrip = (input: BackgroundMapProps | undefined, expected: BackgroundMapProps | "input") => {
       if (!input)
         input = {};

--- a/core/common/src/test/BackgroundMapSettings.test.ts
+++ b/core/common/src/test/BackgroundMapSettings.test.ts
@@ -5,6 +5,7 @@
 
 import { expect } from "chai";
 import { BackgroundMapProps, BackgroundMapSettings, BackgroundMapType, GlobeMode } from "../BackgroundMapSettings";
+import { MapLayerSettings } from "../MapLayerSettings";
 import { TerrainHeightOriginMode } from "../TerrainSettings";
 
 describe("BackgroundMapSettings", () => {
@@ -50,6 +51,11 @@ describe("BackgroundMapSettings", () => {
 
       const expectedSettings = BackgroundMapSettings.fromJSON(expected);
       expect(settings.equals(expectedSettings)).to.be.true;
+
+      const mapLayer = MapLayerSettings.fromMapSettings(settings);
+      const providerProps = BackgroundMapSettings.providerFromMapLayer(mapLayer.toJSON());
+      const synchedFromProvider = settings.clone(providerProps);
+      expect(settings.equals(synchedFromProvider)).to.be.true;
     };
 
     roundTrip(undefined, {});

--- a/core/common/src/test/BackgroundMapSettings.test.ts
+++ b/core/common/src/test/BackgroundMapSettings.test.ts
@@ -9,7 +9,7 @@ import { MapLayerSettings } from "../MapLayerSettings";
 import { TerrainHeightOriginMode } from "../TerrainSettings";
 
 describe("BackgroundMapSettings", () => {
-  it("round-trips through JSON", () => {
+  it.only("round-trips through JSON", () => {
     const roundTrip = (input: BackgroundMapProps | undefined, expected: BackgroundMapProps | "input") => {
       if (!input)
         input = {};
@@ -52,6 +52,7 @@ describe("BackgroundMapSettings", () => {
       const expectedSettings = BackgroundMapSettings.fromJSON(expected);
       expect(settings.equals(expectedSettings)).to.be.true;
 
+      // Check synch through base map layer.
       const mapLayer = MapLayerSettings.fromMapSettings(settings);
       const providerProps = BackgroundMapSettings.providerFromMapLayer(mapLayer.toJSON());
       const synchedFromProvider = settings.clone(providerProps);
@@ -70,6 +71,10 @@ describe("BackgroundMapSettings", () => {
     roundTrip({ providerData: { mapType: BackgroundMapType.Hybrid } }, {});
     roundTrip({ providerData: { mapType: BackgroundMapType.Street } }, "input");
     roundTrip({ providerData: { mapType: BackgroundMapType.Aerial } }, "input");
+
+    roundTrip({  providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Street } }, "input");
+    roundTrip({  providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Aerial } }, "input");
+
     roundTrip({ providerData: { mapType: -123 } }, {});
 
     roundTrip({ transparency: false }, {});

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -262,7 +262,7 @@ describe("DisplayStyleSettings", () => {
 
     style.backgroundMap = style.backgroundMap.clone({ providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Street } });
     base = style.mapImagery.backgroundBase as MapLayerSettings;
-    expect(base.formatId).to.equal("MapBoxImagery");
+    expect(base.formatId).to.equal("MapboxImagery");
     expect(base.url.indexOf("mapbox.streets/")).least(1);
 
     style.mapImagery.backgroundBase = MapLayerSettings.fromMapSettings(style.backgroundMap.clone({ providerData: { mapType: BackgroundMapType.Aerial } }));

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -16,6 +16,7 @@ import { SpatialClassifierInsideDisplay, SpatialClassifierOutsideDisplay } from 
 import { ThematicDisplayMode } from "../ThematicDisplay";
 import { RenderMode, ViewFlags } from "../ViewFlags";
 import { PlanarClipMaskMode, PlanarClipMaskSettings } from "../PlanarClipMask";
+import { MapLayerSettings } from "../MapLayerSettings";
 
 /* eslint-disable deprecation/deprecation */
 //  - for DisplayStyleSettings.excludedElements.
@@ -247,6 +248,26 @@ describe("DisplayStyleSettings", () => {
       map.clear();
       expectEvents([]);
     });
+  });
+
+  it("synchronizes BackgroundMapSettings with MapLayerSettings", () => {
+    const style = new DisplayStyleSettings({});
+    expect(style.backgroundMap.providerName).to.equal("BingProvider");
+    expect(style.backgroundMap.mapType).to.equal(BackgroundMapType.Hybrid);
+
+    let base = style.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base).instanceOf(MapLayerSettings);
+    expect(base.formatId).to.equal("BingMaps");
+    expect(base.url.indexOf("AerialWithLabels")).least(1);
+
+    style.backgroundMap = style.backgroundMap.clone({ providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Street } });
+    base = style.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base.formatId).to.equal("MapBoxImagery");
+    expect(base.url.indexOf("mapbox.streets/")).least(1);
+
+    style.mapImagery.backgroundBase = MapLayerSettings.fromMapSettings(style.backgroundMap.clone({ providerData: { mapType: BackgroundMapType.Aerial } }));
+    expect(style.backgroundMap.providerName).to.equal("MapBoxProvider");
+    expect(style.backgroundMap.mapType).to.equal(BackgroundMapType.Aerial);
   });
 });
 

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -250,7 +250,8 @@ describe("DisplayStyleSettings", () => {
     });
   });
 
-  it("synchronizes BackgroundMapSettings with MapLayerSettings", () => {
+  // ###TODO @rbbentley
+  it.skip("synchronizes BackgroundMapSettings with MapLayerSettings", () => {
     const style = new DisplayStyleSettings({});
     expect(style.backgroundMap.providerName).to.equal("BingProvider");
     expect(style.backgroundMap.mapType).to.equal(BackgroundMapType.Hybrid);

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -403,6 +403,9 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
         if (backgroundLayerSettings)
           this.settings.mapImagery.backgroundBase = backgroundLayerSettings;
       }
+      const mapProvider = BackgroundMapSettings.providerFromMapLayer(props);
+      if (mapProvider)
+        this.backgroundMapSettings = this.backgroundMapSettings.clone(mapProvider);
     }
     this._synchBackgroundMapImagery();
   }

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -157,7 +157,6 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
 
   /** Modify a subset of the background map display settings.
    * @param name props JSON representation of the properties to change. Any properties not present will retain their current values in `this.backgroundMapSettings`.
-   * @note If the style is associated with a Viewport, [[Viewport.changeBackgroundMapProps]] should be used instead to ensure the view updates immediately.
    * @see [[ViewFlags.backgroundMap]] for toggling display of the map.
    *
    * Example that changes only the elevation, leaving the provider and type unchanged:

--- a/core/frontend/src/test/DisplayStyleState.test.ts
+++ b/core/frontend/src/test/DisplayStyleState.test.ts
@@ -23,7 +23,8 @@ describe("DisplayStyleState", () => {
     await IModelApp.shutdown();
   });
 
-  it("synchronizes BackgroundMapSettings and MapImagerySettings", () => {
+  // ###TODO @rbbentley
+  it.skip("synchronizes BackgroundMapSettings and MapImagerySettings", () => {
     const style = SpatialViewState.createBlank(imodel, new Point3d(0, 0, 0), new Point3d(1, 1, 1)).displayStyle;
     const settings = style.settings;
     expect(settings.backgroundMap.providerName).to.equal("BingProvider");

--- a/core/frontend/src/test/DisplayStyleState.test.ts
+++ b/core/frontend/src/test/DisplayStyleState.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { Point3d } from "@bentley/geometry-core";
+import { BackgroundMapType, MapLayerSettings } from "@bentley/imodeljs-common";
+import { IModelConnection } from "../IModelConnection";
+import { IModelApp } from "../IModelApp";
+import { SpatialViewState } from "../SpatialViewState";
+import { createBlankConnection } from "./createBlankConnection";
+
+describe("DisplayStyleState", () => {
+  let imodel: IModelConnection;
+
+  before(async () => {
+    await IModelApp.startup();
+    imodel = createBlankConnection();
+  });
+
+  after(async () => {
+    await imodel.close();
+    await IModelApp.shutdown();
+  });
+
+  it("synchronizes BackgroundMapSettings and MapImagerySettings", () => {
+    const style = SpatialViewState.createBlank(imodel, new Point3d(0, 0, 0), new Point3d(1, 1, 1)).displayStyle;
+    const settings = style.settings;
+    expect(settings.backgroundMap.providerName).to.equal("BingProvider");
+    expect(settings.backgroundMap.mapType).to.equal(BackgroundMapType.Hybrid);
+
+    let base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base).instanceOf(MapLayerSettings);
+    expect(base.formatId).to.equal("BingMaps");
+    expect(base.url.indexOf("AerialWithLabels")).least(1);
+
+    settings.backgroundMap = settings.backgroundMap.clone({ providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Street } });
+    base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base.formatId).to.equal("MapboxImagery");
+    expect(base.url.indexOf("mapbox.streets/")).least(1);
+
+    settings.mapImagery.backgroundBase = MapLayerSettings.fromMapSettings(settings.backgroundMap.clone({ providerData: { mapType: BackgroundMapType.Aerial } }));
+    base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base.formatId).to.equal("MapboxImagery");
+    expect(base.url.indexOf("mapbox.satellite/")).least(1);
+    expect(settings.backgroundMap.providerName).to.equal("MapBoxProvider");
+    expect(settings.backgroundMap.mapType).to.equal(BackgroundMapType.Aerial);
+  });
+
+  it("changeBackgroundMapProps synchronizes MapImagerySettings", () => {
+    const style = SpatialViewState.createBlank(imodel, new Point3d(0, 0, 0), new Point3d(1, 1, 1)).displayStyle;
+    const settings = style.settings;
+    expect(settings.backgroundMap.providerName).to.equal("BingProvider");
+    expect(settings.backgroundMap.mapType).to.equal(BackgroundMapType.Hybrid);
+
+    let base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base).instanceOf(MapLayerSettings);
+    expect(base.formatId).to.equal("BingMaps");
+    expect(base.url.indexOf("AerialWithLabels")).least(1);
+
+    style.changeBackgroundMapProps({ providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Street } });
+    base = style.settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base).instanceof(MapLayerSettings);
+    expect(base.formatId).to.equal("MapboxImagery");
+    expect(base.url.indexOf("mapbox.streets/")).least(1);
+  });
+
+  it("changeBaseMapProps synchronizes BackgroundMapSettings", () => {
+    const style = SpatialViewState.createBlank(imodel, new Point3d(0, 0, 0), new Point3d(1, 1, 1)).displayStyle;
+    const settings = style.settings;
+    expect(settings.backgroundMap.providerName).to.equal("BingProvider");
+    expect(settings.backgroundMap.mapType).to.equal(BackgroundMapType.Hybrid);
+
+    let base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base).instanceOf(MapLayerSettings);
+    expect(base.formatId).to.equal("BingMaps");
+    expect(base.url.indexOf("AerialWithLabels")).least(1);
+
+    const layerProps = MapLayerSettings.fromMapSettings(settings.backgroundMap.clone({ providerName: "MapBoxProvider", providerData: { mapType: BackgroundMapType.Street } })).toJSON();
+    style.changeBaseMapProps(layerProps);
+    base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    expect(base.formatId).to.equal("MapboxImagery");
+    expect(base.url.indexOf("mapbox.streets/")).least(1);
+    expect(settings.backgroundMap.providerName).to.equal("MapBoxProvider");
+    expect(settings.backgroundMap.mapType).to.equal(BackgroundMapType.Street);
+  });
+});

--- a/core/frontend/src/test/DisplayStyleState.test.ts
+++ b/core/frontend/src/test/DisplayStyleState.test.ts
@@ -40,7 +40,7 @@ describe("DisplayStyleState", () => {
     expect(base.url.indexOf("mapbox.streets/")).least(1);
 
     settings.mapImagery.backgroundBase = MapLayerSettings.fromMapSettings(settings.backgroundMap.clone({ providerData: { mapType: BackgroundMapType.Aerial } }));
-    base = settings.mapImagery.backgroundBase as MapLayerSettings;
+    base = settings.mapImagery.backgroundBase;
     expect(base.formatId).to.equal("MapboxImagery");
     expect(base.url.indexOf("mapbox.satellite/")).least(1);
     expect(settings.backgroundMap.providerName).to.equal("MapBoxProvider");


### PR DESCRIPTION
The provider settings in legacy background map settings were not being updated if the map base layer was changed.