### PR TITLE
Update tile trees when script changes.

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -10400,7 +10400,8 @@ export class Tiles {
     purgeTileTrees(modelIds: Id64Array | undefined): Promise<void>;
     // @internal
     reset(): void;
-    }
+    updateForScheduleScript(scriptSourceElementId: Id64String): Promise<void>;
+}
 
 // @public
 export abstract class TileTree {
@@ -10517,6 +10518,11 @@ export abstract class TileTreeReference {
 
 // @public
 export interface TileTreeSupplier {
+    // @internal
+    addModelsAnimatedByScript?: (modelIds: Set<Id64String_2>, scriptSourceId: Id64String_2, trees: Iterable<{
+        id: any;
+        owner: TileTreeOwner;
+    }>) => void;
     compareTileTreeIds(lhs: any, rhs: any): number;
     createTileTree(id: any, iModel: IModelConnection): Promise<TileTree | undefined>;
     readonly isEcefDependent?: true;

--- a/common/changes/@bentley/imodeljs-backend/animated-tile-tree-checksum_2021-06-24-18-27.json
+++ b/common/changes/@bentley/imodeljs-backend/animated-tile-tree-checksum_2021-06-24-18-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/animated-tile-tree-checksum_2021-06-24-18-27.json
+++ b/common/changes/@bentley/imodeljs-frontend/animated-tile-tree-checksum_2021-06-24-18-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Add Tiles.updateForScheduleScript to refresh tiles after modifying schedule script.\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/backend/src/test/standalone/TileTree.test.ts
+++ b/core/backend/src/test/standalone/TileTree.test.ts
@@ -242,7 +242,7 @@ describe("tile tree", () => {
     options.useProjectExtents = false;
 
     const context = new BackendRequestContext();
-    const loadTree = () => db.tiles.requestTileTreeProps(context, iModelTileTreeIdToString(modelId, treeId, options));
+    const loadTree = async () => db.tiles.requestTileTreeProps(context, iModelTileTreeIdToString(modelId, treeId, options));
 
     let tree = await loadTree();
     expect(tree.contentIdQualifier).to.be.undefined;

--- a/core/frontend/src/tile/ClassifierTileTree.ts
+++ b/core/frontend/src/tile/ClassifierTileTree.ts
@@ -38,6 +38,7 @@ class ClassifierTreeSupplier implements TileTreeSupplier {
     loadTree: async () => undefined,
     iModel: undefined as unknown as IModelConnection,
   };
+
   public compareTileTreeIds(lhs: ClassifierTreeId, rhs: ClassifierTreeId): number {
     return compareIds(lhs, rhs);
   }
@@ -64,6 +65,12 @@ class ClassifierTreeSupplier implements TileTreeSupplier {
 
   public getOwner(id: ClassifierTreeId, iModel: IModelConnection): TileTreeOwner {
     return Id64.isValid(id.modelId) ? iModel.tiles.getTileTreeOwner(id, this) : this._nonexistentTreeOwner;
+  }
+
+  public addModelsAnimatedByScript(modelIds: Set<Id64String>, scriptSourceId: Id64String, trees: Iterable<{ id: ClassifierTreeId, owner: TileTreeOwner }>): void {
+    for (const tree of trees)
+      if (tree.id.animationId === scriptSourceId)
+        modelIds.add(tree.id.modelId);
   }
 }
 

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -93,6 +93,12 @@ class PrimaryTreeSupplier implements TileTreeSupplier {
   public getOwner(id: PrimaryTreeId, iModel: IModelConnection): TileTreeOwner {
     return iModel.tiles.getTileTreeOwner(id, this);
   }
+
+  public addModelsAnimatedByScript(modelIds: Set<Id64String>, scriptSourceId: Id64String, trees: Iterable<{ id: PrimaryTreeId, owner: TileTreeOwner }>): void {
+    for (const tree of trees)
+      if (tree.id.treeId.animationId === scriptSourceId)
+        modelIds.add(tree.id.modelId);
+  }
 }
 
 const primaryTreeSupplier = new PrimaryTreeSupplier();

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  assert, BeDuration, BeEvent, BeTimePoint, Id64Array, Id64String, ProcessDetector,
+  assert, BeDuration, BeEvent, BeTimePoint, Id64Array, ProcessDetector,
 } from "@bentley/bentleyjs-core";
 import {
   CloudStorageTileCache, defaultTileOptions, ElementGraphicsRequestProps, getMaximumMajorTileFormatVersion, IModelTileRpcInterface,

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  assert, BeDuration, BeEvent, BeTimePoint, Id64Array, ProcessDetector,
+  assert, BeDuration, BeEvent, BeTimePoint, Id64Array, Id64String, ProcessDetector,
 } from "@bentley/bentleyjs-core";
 import {
   CloudStorageTileCache, defaultTileOptions, ElementGraphicsRequestProps, getMaximumMajorTileFormatVersion, IModelTileRpcInterface,

--- a/core/frontend/src/tile/TileTreeSupplier.ts
+++ b/core/frontend/src/tile/TileTreeSupplier.ts
@@ -6,7 +6,7 @@
  * @module Tiles
  */
 
-import {Id64String} from "../../../bentley/lib/Id";
+import {Id64String} from "@bentley/bentleyjs-core";
 import { IModelConnection } from "../IModelConnection";
 import { TileTree, TileTreeOwner } from "./internal";
 

--- a/core/frontend/src/tile/TileTreeSupplier.ts
+++ b/core/frontend/src/tile/TileTreeSupplier.ts
@@ -6,8 +6,9 @@
  * @module Tiles
  */
 
+import {Id64String} from "../../../bentley/lib/Id";
 import { IModelConnection } from "../IModelConnection";
-import { TileTree } from "./internal";
+import { TileTree, TileTreeOwner } from "./internal";
 
 /** Interface adopted by an object which can supply a [[TileTree]] for rendering.
  * A supplier can supply any number of tile trees; the only requirement is that each tile tree has a unique identifier within the context of the supplier and a single IModelConnection.
@@ -30,4 +31,10 @@ export interface TileTreeSupplier {
    * the updated ECEF location whenever they are next requested.
    */
   readonly isEcefDependent?: true;
+
+  /** Given the set of trees belonging to this supplier, add the modelIds associated with any trees that are animated by
+   * the schedule script hosted by the specified RenderTimeline or DisplayStyle element.
+   * @internal
+   */
+  addModelsAnimatedByScript?: (modelIds: Set<Id64String>, scriptSourceId: Id64String, trees: Iterable<{ id: any, owner: TileTreeOwner }>) => void;
 }


### PR DESCRIPTION
The contents of animated tiles depend upon the contents of the schedule script that animates them, but that is not captured in the tiles' cache keys.
Add a hash of the schedule script contents to the tile tree's contentIdQualifier.
Provide `Tiles.updateForScheduleScript` that an app's frontend can use to update tiles after it modifies the schedule script.
I don't think it's currently worth trying to detect changes to scripts and automatically update tile trees - the app ought to know when the script changes.
[Bug](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/623840).
[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/173904).