### PR TITLE
Accomodated the inability to reverse Changesets when creating change summaries. 

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -653,7 +653,7 @@ export interface ChangesetFileProps extends ChangesetProps {
 // @internal
 export type ChangesetId = string;
 
-// @internal (undocumented)
+// @beta (undocumented)
 export type ChangesetIndex = number;
 
 // @internal (undocumented)
@@ -687,7 +687,7 @@ export interface ChangesetProps {
     userCreated: string;
 }
 
-// @internal
+// @beta
 export interface ChangesetRange {
     end?: ChangesetIndex;
     first: ChangesetIndex;
@@ -718,7 +718,7 @@ export interface ChangeSummary {
     id: Id64String;
 }
 
-// @beta (undocumented)
+// @beta @deprecated (undocumented)
 export class ChangeSummaryExtractContext {
     constructor(iModel: IModelDb);
     // (undocumented)
@@ -727,7 +727,7 @@ export class ChangeSummaryExtractContext {
     get iModelId(): GuidString;
 }
 
-// @beta
+// @beta @deprecated
 export interface ChangeSummaryExtractOptions {
     currentVersionOnly?: boolean;
     startVersion?: IModelVersion;
@@ -744,10 +744,12 @@ export class ChangeSummaryManager {
             className: string;
         };
     }, changedValueState: ChangedValueState, changedPropertyNames?: string[]): string;
-    // @deprecated
+    static createChangeSummaries(args: CreateChangeSummaryArgs): Promise<Id64String[]>;
+    static createChangeSummary(requestContext: AuthorizedClientRequestContext, iModel: BriefcaseDb): Promise<Id64String>;
     static detachChangeCache(iModel: IModelDb): void;
-    // @internal (undocumented)
-    static downloadChangesets(requestContext: AuthorizedClientRequestContext, ctx: ChangeSummaryExtractContext, firstId: ChangesetId, endId: ChangesetId): Promise<ChangesetFileProps[]>;
+    // @internal
+    static downloadChangesets(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, firstId: ChangesetId, lastId: ChangesetId): Promise<ChangesetFileProps[]>;
+    // @deprecated
     static extractChangeSummaries(requestContext: AuthorizedClientRequestContext, iModel: BriefcaseDb, options?: ChangeSummaryExtractOptions): Promise<Id64String[]>;
     static getChangedPropertyValueNames(iModel: IModelDb, instanceChangeId: Id64String): string[];
     static isChangeCacheAttached(iModel: IModelDb): boolean;
@@ -1175,6 +1177,14 @@ export interface CrashReportingConfigNameValuePair {
     name: string;
     // (undocumented)
     value: string;
+}
+
+// @beta
+export interface CreateChangeSummaryArgs {
+    contextId: GuidString;
+    iModelId: GuidString;
+    range: ChangesetRange;
+    requestContext?: AuthorizedClientRequestContext;
 }
 
 // @public
@@ -2980,7 +2990,7 @@ export class IModelHubBackend {
     // (undocumented)
     static getRequestContext(arg: {
         requestContext?: AuthorizedClientRequestContext;
-    }): Promise<AuthorizedBackendRequestContext | AuthorizedClientRequestContext>;
+    }): Promise<AuthorizedClientRequestContext | AuthorizedBackendRequestContext>;
     // (undocumented)
     static get iModelClient(): IModelClient;
     // (undocumented)

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -4291,14 +4291,14 @@ export interface IModelTileTreeProps extends TileTreeProps {
 export class IModelVersion {
     static asOfChangeSet(changeSetId: string): IModelVersion;
     // @deprecated
-    evaluateChangeSet(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, imodelClient: IModelClient): Promise<GuidString>;
+    evaluateChangeSet(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, imodelClient: IModelClient): Promise<string>;
     static first(): IModelVersion;
     static fromJSON(json: IModelVersionProps): IModelVersion;
     // @deprecated
     static fromJson(jsonObj: any): IModelVersion;
     getAsOfChangeSet(): GuidString | undefined;
     // @internal @deprecated
-    static getChangeSetFromNamedVersion(requestContext: AuthorizedClientRequestContext, imodelClient: IModelClient, iModelId: GuidString, versionName: string): Promise<GuidString>;
+    static getChangeSetFromNamedVersion(requestContext: AuthorizedClientRequestContext, imodelClient: IModelClient, iModelId: GuidString, versionName: string): Promise<string>;
     // @internal @deprecated
     static getLatestChangeSetId(requestContext: AuthorizedClientRequestContext, imodelClient: IModelClient, iModelId: GuidString): Promise<GuidString>;
     getName(): string | undefined;

--- a/common/api/summary/imodeljs-backend.exports.csv
+++ b/common/api/summary/imodeljs-backend.exports.csv
@@ -42,16 +42,18 @@ internal;ChangedElementsDb
 internal;ChangesetArg 
 internal;ChangesetFileProps 
 internal;ChangesetId = string
-internal;ChangesetIndex = number
+beta;ChangesetIndex = number
 internal;ChangesetIndexArg 
 internal;ChangesetIndexOrId =
 internal;ChangesetProps
-internal;ChangesetRange
+beta;ChangesetRange
 internal;ChangesetRangeArg 
 public;ChangesetType
 beta;ChangeSummary
 beta;ChangeSummaryExtractContext
+deprecated;ChangeSummaryExtractContext
 beta;ChangeSummaryExtractOptions
+deprecated;ChangeSummaryExtractOptions
 beta;ChangeSummaryManager
 public;ChannelRootAspect 
 internal;CheckPointArg = DownloadRequest
@@ -75,6 +77,7 @@ internal;StateCache
 alpha;ConcurrencyControlChannel = ConcurrencyControl.Channel
 alpha;CrashReportingConfig
 alpha;CrashReportingConfigNameValuePair
+beta;CreateChangeSummaryArgs
 public;DefinitionContainer 
 public;class DefinitionElement 
 public;DefinitionGroup 

--- a/common/changes/@bentley/imodeljs-backend/change-summary-fixes_2021-06-24-19-13.json
+++ b/common/changes/@bentley/imodeljs-backend/change-summary-fixes_2021-06-24-19-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Accomodated the inability to reverse Changesets when creating change summaries. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/change-summary-fixes_2021-06-24-19-13.json
+++ b/common/changes/@bentley/imodeljs-common/change-summary-fixes_2021-06-24-19-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Accomodated the inability to reverse Changesets when creating change summaries. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/core/backend/src/BackendHubAccess.ts
+++ b/core/backend/src/BackendHubAccess.ts
@@ -22,7 +22,7 @@ export type LocalDirName = string;
  */
 export type ChangesetId = string;
 
-/** @internal */
+/** @beta */
 export type ChangesetIndex = number;
 
 /** supply either changeset index, id, or both
@@ -73,7 +73,7 @@ export interface ChangesetFileProps extends ChangesetProps {
 
 /**
  * A range of changesets
- * @internal
+ * @beta
  */
 export interface ChangesetRange {
   /** index of the first changeset */

--- a/core/backend/src/ChangeSummaryManager.ts
+++ b/core/backend/src/ChangeSummaryManager.ts
@@ -6,11 +6,11 @@
  * @module iModels
  */
 
-import * as path from "path";
 import { assert, DbResult, GuidString, Id64String, IModelStatus, Logger, PerfLogger, using } from "@bentley/bentleyjs-core";
 import { ChangedValueState, ChangeOpCode, IModelError, IModelVersion } from "@bentley/imodeljs-common";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
-import { ChangesetFileProps, ChangesetId } from "./BackendHubAccess";
+import * as path from "path";
+import { ChangesetFileProps, ChangesetId, ChangesetRange } from "./BackendHubAccess";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { BriefcaseManager } from "./BriefcaseManager";
 import { ECDb, ECDbOpenMode } from "./ECDb";
@@ -52,6 +52,7 @@ export interface InstanceChange {
 
 /** Options for [ChangeSummaryManager.extractChangeSummaries]($backend).
  * @beta
+ * @deprecated
  */
 export interface ChangeSummaryExtractOptions {
   /** If specified, change summaries are extracted from the start version to the current version as of which the iModel
@@ -64,11 +65,35 @@ export interface ChangeSummaryExtractOptions {
   currentVersionOnly?: boolean;
 }
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated
+*/
 export class ChangeSummaryExtractContext {
   public constructor(public readonly iModel: IModelDb) { }
 
   public get iModelId(): GuidString { return this.iModel.iModelId; }
+}
+
+/** Options for [ChangeSummaryManager.createChangeSummaries]($backend).
+ * @beta
+ */
+export interface CreateChangeSummaryArgs {
+  /** Id of the context that contains the iModel */
+  contextId: GuidString;
+
+  /** Id of the iModel */
+  iModelId: GuidString;
+
+  /**
+   * Range of change sets
+   * - the Change Summary for the first and last versions are also included
+   * - if unspecified, all change sets until the latest version are processed
+   */
+  range: ChangesetRange;
+
+  /** Context for the request */
+  requestContext?: AuthorizedClientRequestContext;
 }
 
 /** Class to extract Change Summaries for a briefcase.
@@ -117,9 +142,9 @@ export class ChangeSummaryManager {
   }
 
   /** Detaches the *Change Cache file* from the specified iModel.
+   * - note that this method will cause any pending (currently running or queued) queries to fail
    * @param iModel iModel to detach the *Change Cache file* to
    * @throws [IModelError]($common) in case of errors, e.g. if no *Change Cache file* was attached before.
-   * @deprecated This method is not required to be called anymore. The attach change cache will stay around until connection is closed.
    */
   public static detachChangeCache(iModel: IModelDb): void {
     if (!iModel || !iModel.isOpen)
@@ -141,52 +166,47 @@ export class ChangeSummaryManager {
    * @param options Extraction options
    * @return the Ids of the extracted change summaries.
    * @throws [IModelError]($common) if the iModel is standalone
+   * @deprecated Use ChangeSummaryManager.createChangeSummaries instead
    */
-  public static async extractChangeSummaries(requestContext: AuthorizedClientRequestContext, iModel: BriefcaseDb, options?: ChangeSummaryExtractOptions): Promise<Id64String[]> {
+  public static async extractChangeSummaries(requestContext: AuthorizedClientRequestContext, iModel: BriefcaseDb, options?: ChangeSummaryExtractOptions): Promise<Id64String[]> { // eslint-disable-line deprecation/deprecation
     requestContext.enter();
     if (!iModel?.isOpen)
       throw new IModelError(IModelStatus.BadRequest, "Briefcase must be open");
 
-    const ctx = new ChangeSummaryExtractContext(iModel);
-
+    const iModelId = iModel.iModelId;
     const endChangeSetId = iModel.changeSetId;
     assert(endChangeSetId.length !== 0);
 
     let startChangeSetId = "";
     if (options) {
       if (options.startVersion) {
-        startChangeSetId = (await IModelHost.hubAccess.getChangesetFromVersion({ version: options.startVersion, requestContext, iModelId: ctx.iModelId })).id;
+        startChangeSetId = (await IModelHost.hubAccess.getChangesetFromVersion({ version: options.startVersion, requestContext, iModelId })).id;
         requestContext.enter();
       } else if (options.currentVersionOnly) {
         startChangeSetId = endChangeSetId;
       }
     }
 
-    Logger.logInfo(loggerCategory, "Started Change Summary extraction...", () => ({ iModelId: ctx.iModelId, startChangeSetId, endChangeSetId }));
-    const totalPerf = new PerfLogger(`ChangeSummaryManager.extractChangeSummaries [ChangeSets: ${startChangeSetId} through ${endChangeSetId}, iModel: ${ctx.iModelId}]`);
+    Logger.logInfo(loggerCategory, "Started Change Summary extraction...", () => ({ iModelId, startChangeSetId, endChangeSetId }));
+    const totalPerf = new PerfLogger(`ChangeSummaryManager.extractChangeSummaries [ChangeSets: ${startChangeSetId} through ${endChangeSetId}, iModel: ${iModelId}]`);
 
     // download necessary changesets if they were not downloaded before and retrieve infos about those changesets
     let perfLogger = new PerfLogger("ChangeSummaryManager.extractChangeSummaries>Retrieve ChangeSetInfos and download ChangeSets from Hub");
-    const changeSetInfos = await ChangeSummaryManager.downloadChangesets(requestContext, ctx, startChangeSetId, endChangeSetId);
+    const changeSetInfos = await ChangeSummaryManager.downloadChangesets(requestContext, iModelId, startChangeSetId, endChangeSetId);
     requestContext.enter();
     perfLogger.dispose();
-    Logger.logTrace(loggerCategory, "Retrieved changesets to extract from from cache or from hub.", () => ({ iModelId: ctx.iModelId, startChangeSetId, endChangeSetId, changeSets: changeSetInfos }));
+    Logger.logTrace(loggerCategory, "Retrieved changesets to extract from from cache or from hub.", () => ({ iModelId, startChangeSetId, endChangeSetId, changeSets: changeSetInfos }));
 
-    // Detach change cache as it's being written to during the extraction
-    const isChangeCacheAttached = this.isChangeCacheAttached(iModel);
-    if (isChangeCacheAttached) {
-      throw new IModelError(DbResult.BE_SQLITE_ERROR, "There is an attached change cache file. Re-open the connection to detach it.");
+    // Ensure change cache is detached as it's being written to during the extraction
+    if (this.isChangeCacheAttached(iModel)) {
+      throw new IModelError(DbResult.BE_SQLITE_ERROR, "Change cache must be detached before extraction");
     }
 
     perfLogger = new PerfLogger("ChangeSummaryManager.extractChangeSummaries>Open or create local Change Cache file");
-    const changesFile: ECDb = ChangeSummaryManager.openOrCreateChangesFile(iModel);
+    const changesFile = ChangeSummaryManager.openOrCreateChangesFile(iModel);
+    assert(changesFile.nativeDb !== undefined, "Should not happen as an exception should have been thrown in that case");
     perfLogger.dispose();
-    Logger.logTrace(loggerCategory, "Opened or created Changes Cachefile.", () => ({ iModelId: ctx.iModelId, startChangeSetId, endChangeSetId }));
-
-    if (!changesFile || !changesFile.nativeDb) {
-      assert(false, "Should not happen as an exception should have been thrown in that case");
-      throw new IModelError(IModelStatus.BadArg, "Failed to create Change Cache file.");
-    }
+    Logger.logTrace(loggerCategory, "Opened or created Changes Cachefile.", () => ({ iModelId, startChangeSetId, endChangeSetId }));
 
     try {
       // extract summaries from end changeset through start changeset, so that we only have to go back in history
@@ -196,11 +216,11 @@ export class ChangeSummaryManager {
       for (let i = endChangeSetIx; i >= 0; i--) {
         const currentChangeSetInfo = changeSetInfos[i];
         const currentChangeSetId = currentChangeSetInfo.id;
-        Logger.logInfo(loggerCategory, `Started Change Summary extraction for changeset #${i + 1}...`, () => ({ iModelId: ctx.iModelId, changeSetId: currentChangeSetId }));
+        Logger.logInfo(loggerCategory, `Started Change Summary extraction for changeset #${i + 1}...`, () => ({ iModelId, changeSetId: currentChangeSetId }));
 
         const existingSummaryId: Id64String | undefined = ChangeSummaryManager.isSummaryAlreadyExtracted(changesFile, currentChangeSetId);
         if (!!existingSummaryId) {
-          Logger.logInfo(loggerCategory, `Change Summary for changeset #${i + 1} already exists. It is not extracted again.`, () => ({ iModelId: ctx.iModelId, changeSetId: currentChangeSetId }));
+          Logger.logInfo(loggerCategory, `Change Summary for changeset #${i + 1} already exists. It is not extracted again.`, () => ({ iModelId, changeSetId: currentChangeSetId }));
           summaries.push(existingSummaryId);
           continue;
         }
@@ -211,7 +231,7 @@ export class ChangeSummaryManager {
           await iModel.reverseChanges(requestContext, IModelVersion.asOfChangeSet(currentChangeSetId)); // eslint-disable-line deprecation/deprecation
           requestContext.enter();
           perfLogger.dispose();
-          Logger.logTrace(loggerCategory, `Moved iModel to changeset #${i + 1} to extract summary from.`, () => ({ iModelId: ctx.iModelId, changeSetId: currentChangeSetId }));
+          Logger.logTrace(loggerCategory, `Moved iModel to changeset #${i + 1} to extract summary from.`, () => ({ iModelId, changeSetId: currentChangeSetId }));
         }
 
         const changeSetFilePath = currentChangeSetInfo.pathname;
@@ -224,16 +244,16 @@ export class ChangeSummaryManager {
         if (stat.error && stat.error.status !== DbResult.BE_SQLITE_OK)
           throw new IModelError(stat.error.status, stat.error.message);
 
-        Logger.logTrace(loggerCategory, `Actual Change summary extraction done for changeset #${i + 1}.`, () => ({ iModelId: ctx.iModelId, changeSetId: currentChangeSetId }));
+        Logger.logTrace(loggerCategory, `Actual Change summary extraction done for changeset #${i + 1}.`, () => ({ iModelId, changeSetId: currentChangeSetId }));
 
         perfLogger = new PerfLogger("ChangeSummaryManager.extractChangeSummaries>Add ChangeSet info to ChangeSummary");
         const changeSummaryId = stat.result!;
         summaries.push(changeSummaryId);
         ChangeSummaryManager.addExtendedInfos(changesFile, changeSummaryId, currentChangeSetId, currentChangeSetInfo.parentId, currentChangeSetInfo.description, currentChangeSetInfo.pushDate, currentChangeSetInfo.userCreated);
         perfLogger.dispose();
-        Logger.logTrace(loggerCategory, `Added extended infos to Change Summary for changeset #${i + 1}.`, () => ({ iModelId: ctx.iModelId, changeSetId: currentChangeSetId }));
+        Logger.logTrace(loggerCategory, `Added extended infos to Change Summary for changeset #${i + 1}.`, () => ({ iModelId, changeSetId: currentChangeSetId }));
 
-        Logger.logInfo(loggerCategory, `Finished Change Summary extraction for changeset #${i + 1}.`, () => ({ iModelId: ctx.iModelId, changeSetId: currentChangeSetId }));
+        Logger.logInfo(loggerCategory, `Finished Change Summary extraction for changeset #${i + 1}.`, () => ({ iModelId, changeSetId: currentChangeSetId }));
       }
 
       changesFile.saveChanges();
@@ -241,27 +261,25 @@ export class ChangeSummaryManager {
     } finally {
       changesFile.dispose();
 
-      // Reattach change cache if it was attached before the extraction
-      if (isChangeCacheAttached)
-        ChangeSummaryManager.attachChangeCache(iModel);
-
       perfLogger = new PerfLogger("ChangeSummaryManager.extractChangeSummaries>Move iModel to original changeset");
       if (iModel.changeSetId !== endChangeSetId)
         await iModel.reinstateChanges(requestContext, IModelVersion.asOfChangeSet(endChangeSetId));// eslint-disable-line deprecation/deprecation
       requestContext.enter();
       perfLogger.dispose();
-      Logger.logTrace(loggerCategory, "Moved iModel to initial changeset (the end changeset).", () => ({ iModelId: ctx.iModelId, startChangeSetId, endChangeSetId }));
+      Logger.logTrace(loggerCategory, "Moved iModel to initial changeset (the end changeset).", () => ({ iModelId, startChangeSetId, endChangeSetId }));
 
       totalPerf.dispose();
-      Logger.logInfo(loggerCategory, "Finished Change Summary extraction.", () => ({ iModelId: ctx.iModelId, startChangeSetId, endChangeSetId }));
+      Logger.logInfo(loggerCategory, "Finished Change Summary extraction.", () => ({ iModelId, startChangeSetId, endChangeSetId }));
     }
   }
 
-  /** @internal */
-  public static async downloadChangesets(requestContext: AuthorizedClientRequestContext, ctx: ChangeSummaryExtractContext, firstId: ChangesetId, endId: ChangesetId): Promise<ChangesetFileProps[]> {
-    const iModelId = ctx.iModelId;
+  /**
+   * Download a range of change sets including the first and last
+   * @internal
+  */
+  public static async downloadChangesets(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, firstId: ChangesetId, lastId: ChangesetId): Promise<ChangesetFileProps[]> {
     const first = (await IModelHost.hubAccess.queryChangeset({ iModelId, changeset: { id: firstId }, requestContext })).index;
-    const end = (await IModelHost.hubAccess.queryChangeset({ iModelId, changeset: { id: endId }, requestContext })).index;
+    const end = (await IModelHost.hubAccess.queryChangeset({ iModelId, changeset: { id: lastId }, requestContext })).index;
     const changeSetInfos = await IModelHost.hubAccess.downloadChangesets({ requestContext, iModelId, range: { first, end }, targetDir: BriefcaseManager.getChangeSetsPath(iModelId) });
     return changeSetInfos;
   }
@@ -399,8 +417,8 @@ export class ChangeSummaryManager {
 
     // query instance changes
     const instanceChange: InstanceChange = iModel.withPreparedStatement(`SELECT ic.Summary.Id summaryId, s.Name changedInstanceSchemaName, c.Name changedInstanceClassName, ic.ChangedInstance.Id changedInstanceId,
-      ic.OpCode, ic.IsIndirect FROM ecchange.change.InstanceChange ic JOIN main.meta.ECClassDef c ON c.ECInstanceId = ic.ChangedInstance.ClassId
-      JOIN main.meta.ECSchemaDef s ON c.Schema.Id = s.ECInstanceId WHERE ic.ECInstanceId =? `, (stmt: ECSqlStatement) => {
+       ic.OpCode, ic.IsIndirect FROM ecchange.change.InstanceChange ic JOIN main.meta.ECClassDef c ON c.ECInstanceId = ic.ChangedInstance.ClassId
+       JOIN main.meta.ECSchemaDef s ON c.Schema.Id = s.ECInstanceId WHERE ic.ECInstanceId =? `, (stmt: ECSqlStatement) => {
       stmt.bindId(1, instanceChangeId);
       if (stmt.step() !== DbResult.BE_SQLITE_ROW)
         throw new IModelError(IModelStatus.BadArg, `No InstanceChange found for id ${instanceChangeId}.`);
@@ -495,4 +513,101 @@ export class ChangeSummaryManager {
     ecsql += ` FROM main.${instanceChangeInfo.changedInstance.className}.Changes(${instanceChangeInfo.summaryId},${changedValueState}) WHERE ECInstanceId=${instanceChangeInfo.changedInstance.id}`;
     return ecsql;
   }
+
+  /**
+   * Creates a change summary for the last applied change set to the iModel
+   * @param requestContext The client request context
+   * @param iModel iModel to extract change summaries for. The iModel must not be a standalone iModel, and must have at least one change set applied to it.
+   * @returns The id of the extracted change summary.
+   * @beta
+   */
+  public static async createChangeSummary(requestContext: AuthorizedClientRequestContext, iModel: BriefcaseDb): Promise<Id64String> {
+    requestContext.enter();
+    if (!iModel?.isOpen)
+      throw new IModelError(IModelStatus.BadRequest, "Briefcase must be open");
+    const changesetId = iModel.changeSetId;
+    if (!changesetId)
+      throw new IModelError(IModelStatus.BadRequest, "No change set was applied to the iModel");
+    if (this.isChangeCacheAttached(iModel))
+      throw new IModelError(IModelStatus.BadRequest, "Change cache must be detached before extraction");
+
+    const iModelId = iModel.iModelId;
+    const changesetsFolder: string = BriefcaseManager.getChangeSetsPath(iModelId);
+    const changeset = await IModelHost.hubAccess.downloadChangeset({ requestContext, iModelId, changeset: { id: iModel.changeSetId }, targetDir: changesetsFolder });
+    requestContext.enter();
+
+    if (!IModelJsFs.existsSync(changeset.pathname))
+      throw new IModelError(IModelStatus.FileNotFound, `Failed to download change set: ${changeset.pathname}`);
+
+    let changesFile: ECDb | undefined;
+    try {
+      changesFile = ChangeSummaryManager.openOrCreateChangesFile(iModel);
+      assert(changesFile.nativeDb !== undefined, "Invalid changesFile - should've caused an exception");
+
+      let changeSummaryId = ChangeSummaryManager.isSummaryAlreadyExtracted(changesFile, changesetId);
+      if (changeSummaryId !== undefined) {
+        Logger.logInfo(loggerCategory, `Change Summary for changeset already exists. It is not extracted again.`, () => ({ iModelId, changeSetId: changesetId }));
+        return changeSummaryId;
+      }
+
+      const stat = iModel.nativeDb.extractChangeSummary(changesFile.nativeDb, changeset.pathname);
+      if (stat.error && stat.error.status !== DbResult.BE_SQLITE_OK)
+        throw new IModelError(stat.error.status, stat.error.message);
+
+      changeSummaryId = stat.result!;
+      ChangeSummaryManager.addExtendedInfos(changesFile, changeSummaryId, changesetId, changeset.parentId, changeset.description, changeset.pushDate, changeset.userCreated);
+
+      changesFile.saveChanges();
+      return changeSummaryId;
+    } finally {
+      if (changesFile !== undefined)
+        changesFile.dispose();
+      IModelJsFs.unlinkSync(changeset.pathname);
+    }
+  }
+
+  /**
+   * Creates change summaries for the specified iModel and a specified range of versions
+   * @note This may be an expensive operation - downloads the first version and starts applying the change sets, extracting summaries one by one
+   * @param args Arguments including the range of versions for which Change Summaries are to be created, and other necessary input for creation
+   */
+  public static async createChangeSummaries(args: CreateChangeSummaryArgs): Promise<Id64String[]> {
+    const requestContext = args.requestContext ?? await IModelHost.getAuthorizedContext();
+    const { iModelId, contextId, range } = args;
+    range.end = range.end ?? (await IModelHost.hubAccess.getChangesetFromVersion({ requestContext, iModelId, version: IModelVersion.latest() })).index;
+    if (range.first > range.end)
+      throw new IModelError(IModelStatus.BadArg, "Invalid range of changesets", undefined, undefined, () => ({ iModelId, ...range }));
+
+    const changesets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId, range });
+
+    // Setup a temporary briefcase to help with extracting change summaries
+    const briefcasePath = BriefcaseManager.getBriefcaseBasePath(iModelId);
+    const fileName: string = path.join(briefcasePath, `ChangeSummaryBriefcase.bim`);
+    if (IModelJsFs.existsSync(fileName))
+      IModelJsFs.removeSync(fileName);
+
+    let iModel: BriefcaseDb | undefined;
+    try {
+      // Download a version that has the first change set applied
+      const props = await BriefcaseManager.downloadBriefcase(requestContext, { contextId, iModelId, asOf: { afterChangeSetId: changesets[0].id }, briefcaseId: 0, fileName });
+      iModel = await BriefcaseDb.open(requestContext, { fileName: props.fileName });
+
+      const summaryIds = new Array<Id64String>();
+      for (let index = 0; index < changesets.length; index++) {
+        // Apply a change set if necessary
+        if (index > 0)
+          await iModel.pullAndMergeChanges(requestContext, IModelVersion.asOfChangeSet(changesets[index].id));
+
+        // Create a change summary for the last change set that was applied
+        const summaryId = await this.createChangeSummary(requestContext, iModel);
+        summaryIds.push(summaryId);
+      }
+      return summaryIds;
+    } finally {
+      if (iModel !== undefined)
+        iModel.close();
+      IModelJsFs.removeSync(fileName);
+    }
+  }
+
 }

--- a/core/backend/src/ChangedElementsDb.ts
+++ b/core/backend/src/ChangedElementsDb.ts
@@ -10,7 +10,7 @@ import { DbResult, IDisposable, IModelStatus, OpenMode } from "@bentley/bentleyj
 import { ChangeData, ChangedElements, ChangedModels, IModelError } from "@bentley/imodeljs-common";
 import { IModelJsNative } from "@bentley/imodeljs-native";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
-import { ChangeSummaryExtractContext, ChangeSummaryManager } from "./ChangeSummaryManager";
+import { ChangeSummaryManager } from "./ChangeSummaryManager";
 import { ECDbOpenMode } from "./ECDb";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
@@ -101,9 +101,7 @@ export class ChangedElementsDb implements IDisposable {
    */
   public async processChangesets(requestContext: AuthorizedClientRequestContext, briefcase: IModelDb, options: ProcessChangesetOptions): Promise<DbResult> {
     requestContext.enter();
-    const changeSummaryContext = new ChangeSummaryExtractContext(briefcase);
-
-    const changesets = await ChangeSummaryManager.downloadChangesets(requestContext, changeSummaryContext, options.startChangesetId, options.endChangesetId);
+    const changesets = await ChangeSummaryManager.downloadChangesets(requestContext, briefcase.iModelId, options.startChangesetId, options.endChangesetId);
     requestContext.enter();
     // ChangeSets need to be processed from newest to oldest
     changesets.reverse();
@@ -130,8 +128,7 @@ export class ChangedElementsDb implements IDisposable {
    */
   public async processChangesetsAndRoll(requestContext: AuthorizedClientRequestContext, briefcase: IModelDb, options: ProcessChangesetOptions): Promise<DbResult> {
     requestContext.enter();
-    const changeSummaryContext = new ChangeSummaryExtractContext(briefcase);
-    const changesets = await ChangeSummaryManager.downloadChangesets(requestContext, changeSummaryContext, options.startChangesetId, options.endChangesetId);
+    const changesets = await ChangeSummaryManager.downloadChangesets(requestContext, briefcase.iModelId, options.startChangesetId, options.endChangesetId);
     requestContext.enter();
     // ChangeSets need to be processed from newest to oldest
     changesets.reverse();

--- a/core/backend/src/IModelExporter.ts
+++ b/core/backend/src/IModelExporter.ts
@@ -13,7 +13,7 @@ import { IModelJsNative } from "@bentley/imodeljs-native";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { BisCoreSchema } from "./BisCoreSchema";
-import { ChangeSummaryExtractContext, ChangeSummaryManager } from "./ChangeSummaryManager";
+import { ChangeSummaryManager } from "./ChangeSummaryManager";
 import { ECSqlStatement } from "./ECSqlStatement";
 import { Element, GeometricElement, RecipeDefinitionElement, RepositoryLink } from "./Element";
 import { ElementAspect, ElementMultiAspect, ElementUniqueAspect } from "./ElementAspect";
@@ -750,16 +750,16 @@ class ChangedInstanceIds {
   public relationship = new ChangedInstanceOps();
   public font = new ChangedInstanceOps();
   private constructor() { }
-  public static async initialize(requestContext: AuthorizedClientRequestContext, iModelDb: BriefcaseDb, startChangeSetId: string): Promise<ChangedInstanceIds> {
+
+  public static async initialize(requestContext: AuthorizedClientRequestContext, iModel: BriefcaseDb, firstChangeSetId: string): Promise<ChangedInstanceIds> {
     requestContext.enter();
-    const extractContext = new ChangeSummaryExtractContext(iModelDb); // NOTE: ChangeSummaryExtractContext is nothing more than a wrapper around IModelDb that has a method to get the iModelId
-    // NOTE: ChangeSummaryManager.downloadChangesets has nothing really to do with change summaries but has the desired behavior of including the start changeSet (unlike BriefcaseManager.downloadChangesets)
-    const changeSets = await ChangeSummaryManager.downloadChangesets(requestContext, extractContext, startChangeSetId, iModelDb.changeSetId);
+
+    const changeSets = await ChangeSummaryManager.downloadChangesets(requestContext, iModel.iModelId, firstChangeSetId, iModel.changeSetId);
     requestContext.enter();
     const changedInstanceIds = new ChangedInstanceIds();
     changeSets.forEach((changeSet): void => {
       const changeSetPath = changeSet.pathname;
-      const statusOrResult = iModelDb.nativeDb.extractChangedInstanceIdsFromChangeSet(changeSetPath);
+      const statusOrResult = iModel.nativeDb.extractChangedInstanceIdsFromChangeSet(changeSetPath);
       if (undefined !== statusOrResult.error) {
         throw new IModelError(statusOrResult.error.status, "Error processing changeSet", Logger.logError, loggerCategory);
       }

--- a/core/backend/src/test/integration/ChangeSummary.test.ts
+++ b/core/backend/src/test/integration/ChangeSummary.test.ts
@@ -3,9 +3,9 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { DbResult, GuidString, Id64, Id64String, Logger, LogLevel, PerfLogger } from "@bentley/bentleyjs-core";
+import { DbResult, GuidString, Id64, Id64String, PerfLogger } from "@bentley/bentleyjs-core";
 import {
-  ChangedValueState, ChangeOpCode, ColorDef, IModel, IModelVersion, SubCategoryAppearance,
+  ChangedValueState, ChangeOpCode, ColorDef, IModel, IModelError, IModelVersion, SubCategoryAppearance,
 } from "@bentley/imodeljs-common";
 import { assert } from "chai";
 import * as path from "path";
@@ -34,6 +34,7 @@ function getChangeSummaryAsJson(iModel: BriefcaseDb, changeSummaryId: string) {
       const row = stmt.getRow();
 
       const instanceChange: any = ChangeSummaryManager.queryInstanceChange(iModel, Id64.fromJSON(row.id));
+
       switch (instanceChange.opCode) {
         case ChangeOpCode.Insert: {
           const rows: any[] = IModelTestUtils.executeQuery(iModel, ChangeSummaryManager.buildPropertyValueChangesECSql(iModel, instanceChange, ChangedValueState.AfterInsert));
@@ -68,45 +69,29 @@ function getChangeSummaryAsJson(iModel: BriefcaseDb, changeSummaryId: string) {
 
 describe("ChangeSummary (#integration)", () => {
   let requestContext: AuthorizedBackendRequestContext;
-  let testContextId: string;
-
-  let readOnlyTestIModelId: GuidString;
-  let readWriteTestIModelId: GuidString;
+  let contextId: string;
+  let iModelId: GuidString;
 
   before(async () => {
-    Logger.setLevel("DgnCore", LogLevel.Error);
-    Logger.setLevel("BeSQLite", LogLevel.Error);
-
     HubUtility.allowHubBriefcases = true;
     requestContext = await IModelTestUtils.getUserContext(TestUserType.Regular);
 
-    testContextId = await HubUtility.getTestContextId(requestContext);
-    requestContext.enter();
-    readOnlyTestIModelId = await HubUtility.getTestIModelId(requestContext, HubUtility.testIModelNames.readOnly);
-    requestContext.enter();
-    readWriteTestIModelId = await HubUtility.getTestIModelId(requestContext, HubUtility.testIModelNames.readWrite);
-    requestContext.enter();
+    contextId = await HubUtility.getTestContextId(requestContext);
+    iModelId = await HubUtility.getTestIModelId(requestContext, HubUtility.testIModelNames.readOnly);
 
-    await HubUtility.purgeAcquiredBriefcasesById(requestContext, readOnlyTestIModelId);
-    requestContext.enter();
-    await HubUtility.purgeAcquiredBriefcasesById(requestContext, readWriteTestIModelId);
-    requestContext.enter();
+    await HubUtility.purgeAcquiredBriefcasesById(requestContext, iModelId);
 
     // Purge briefcases that are close to reaching the acquire limit
     const managerRequestContext = await IModelTestUtils.getUserContext(TestUserType.Manager);
-    managerRequestContext.enter();
-    await HubUtility.purgeAcquiredBriefcasesById(managerRequestContext, readOnlyTestIModelId);
-    managerRequestContext.enter();
-    await HubUtility.purgeAcquiredBriefcasesById(managerRequestContext, readWriteTestIModelId);
-    managerRequestContext.enter();
+    await HubUtility.purgeAcquiredBriefcasesById(managerRequestContext, iModelId);
   });
 
   after(() => HubUtility.allowHubBriefcases = false);
 
   it("Attach / Detach ChangeCache file to closed imodel", async () => {
-    setupTest(readOnlyTestIModelId);
+    setupTest(iModelId);
 
-    const iModel = await IModelTestUtils.downloadAndOpenCheckpoint({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId });
+    const iModel = await IModelTestUtils.downloadAndOpenCheckpoint({ requestContext, contextId, iModelId });
     iModel.close();
     assert.exists(iModel);
     assert.throw(() => ChangeSummaryManager.isChangeCacheAttached(iModel));
@@ -114,12 +99,13 @@ describe("ChangeSummary (#integration)", () => {
   });
 
   it("Extract ChangeSummaries", async () => {
-    setupTest(readOnlyTestIModelId);
+    setupTest(iModelId);
 
-    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId });
+    const summaryIds = await ChangeSummaryManager.createChangeSummaries({ requestContext, contextId, iModelId, range: { first: 0 } });
+
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId });
     assert.exists(iModel);
     try {
-      const summaryIds = await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel);
       ChangeSummaryManager.attachChangeCache(iModel);
       assert.isTrue(ChangeSummaryManager.isChangeCacheAttached(iModel));
 
@@ -155,23 +141,22 @@ describe("ChangeSummary (#integration)", () => {
   });
 
   it("Extract ChangeSummary for single changeset", async () => {
-    setupTest(readOnlyTestIModelId);
+    setupTest(iModelId);
 
-    const changeSets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId: readOnlyTestIModelId });
+    const changeSets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId });
     assert.isAtLeast(changeSets.length, 3);
     // extract summary for second changeset
     const changesetId: string = changeSets[1].id;
 
-    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId });
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId });
     try {
       assert.exists(iModel);
-      await iModel.reverseChanges(requestContext, IModelVersion.asOfChangeSet(changesetId));// eslint-disable-line deprecation/deprecation
+      await iModel.reverseChanges(requestContext, IModelVersion.asOfChangeSet(changesetId)); // eslint-disable-line deprecation/deprecation
 
       // now extract change summary for that one changeset
-      const summaryIds = await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel, { currentVersionOnly: true });
-      assert.equal(summaryIds.length, 1);
-      assert.isTrue(Id64.isValidId64(summaryIds[0]));
-      assert.isTrue(IModelJsFs.existsSync(BriefcaseManager.getChangeCachePathName(readOnlyTestIModelId)));
+      const summaryId = await ChangeSummaryManager.createChangeSummary(requestContext, iModel);
+      assert.isTrue(Id64.isValidId64(summaryId));
+      assert.isTrue(IModelJsFs.existsSync(BriefcaseManager.getChangeCachePathName(iModelId)));
       assert.exists(iModel);
       ChangeSummaryManager.attachChangeCache(iModel);
       assert.isTrue(ChangeSummaryManager.isChangeCacheAttached(iModel));
@@ -182,7 +167,7 @@ describe("ChangeSummary (#integration)", () => {
         assert.isDefined(row.wsgId);
         assert.equal(row.wsgId, changesetId);
         assert.isDefined(row.summary);
-        assert.equal(row.summary.id, summaryIds[0]);
+        assert.equal(row.summary.id, summaryId);
         assert.isDefined(row.pushDate, "IModelChange.ChangeSet.PushDate is expected to be set for the changesets used in this test.");
         assert.isDefined(row.userCreated, "IModelChange.ChangeSet.UserCreated is expected to be set for the changesets used in this test.");
         // the other properties are not used, but using them in the ECSQL is important to verify preparation works
@@ -194,22 +179,19 @@ describe("ChangeSummary (#integration)", () => {
   });
 
   it("Extracting ChangeSummaries for a range of changesets", async () => {
-    setupTest(readOnlyTestIModelId);
+    setupTest(iModelId);
 
-    const changeSets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId: readOnlyTestIModelId });
-    assert.isAtLeast(changeSets.length, 3);
-    const startChangeSetId: string = changeSets[0].id;
-    const endChangeSetId: string = changeSets[1].id;
-    const startVersion: IModelVersion = IModelVersion.asOfChangeSet(startChangeSetId);
-    const endVersion: IModelVersion = IModelVersion.asOfChangeSet(endChangeSetId);
+    const changesets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId });
+    assert.isAtLeast(changesets.length, 3);
+    const firstChangeSet = changesets[0];
+    const lastChangeSet = changesets[1];
 
-    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId, asOf: endVersion.toJSON() });
+    const summaryIds = await ChangeSummaryManager.createChangeSummaries({ requestContext, contextId, iModelId, range: { first: firstChangeSet.index, end: lastChangeSet.index } });
+    assert.equal(summaryIds.length, 2);
+    assert.isTrue(IModelJsFs.existsSync(BriefcaseManager.getChangeCachePathName(iModelId)));
+
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId, asOf: IModelVersion.asOfChangeSet(lastChangeSet.id).toJSON() });
     try {
-      assert.exists(iModel);
-      const summaryIds = await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel, { startVersion });
-      assert.equal(summaryIds.length, 2);
-      assert.isTrue(IModelJsFs.existsSync(BriefcaseManager.getChangeCachePathName(readOnlyTestIModelId)));
-
       assert.exists(iModel);
       ChangeSummaryManager.attachChangeCache(iModel);
       assert.isTrue(ChangeSummaryManager.isChangeCacheAttached(iModel));
@@ -219,7 +201,7 @@ describe("ChangeSummary (#integration)", () => {
         let row: any = myStmt.getRow();
         assert.isDefined(row.wsgId);
         // Change summaries are extracted from end to start, so order is inverse of changesets
-        assert.equal(row.wsgId, endChangeSetId);
+        assert.equal(row.wsgId, firstChangeSet.id);
         assert.isDefined(row.summary);
         assert.equal(row.summary.id, summaryIds[0]);
         assert.isDefined(row.pushDate, "IModelChange.ChangeSet.PushDate is expected to be set for the changesets used in this test.");
@@ -228,7 +210,7 @@ describe("ChangeSummary (#integration)", () => {
         assert.equal(myStmt.step(), DbResult.BE_SQLITE_ROW);
         row = myStmt.getRow();
         assert.isDefined(row.wsgId);
-        assert.equal(row.wsgId, startChangeSetId);
+        assert.equal(row.wsgId, lastChangeSet.id);
         assert.isDefined(row.summary);
         assert.equal(row.summary.id, summaryIds[1]);
         assert.isDefined(row.pushDate, "IModelChange.ChangeSet.PushDate is expected to be set for the changesets used in this test.");
@@ -240,22 +222,21 @@ describe("ChangeSummary (#integration)", () => {
   });
 
   it("Subsequent ChangeSummary extractions", async () => {
-    setupTest(readOnlyTestIModelId);
+    setupTest(iModelId);
 
-    const changeSets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId: readOnlyTestIModelId });
+    const changeSets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId });
     assert.isAtLeast(changeSets.length, 3);
     // first extraction: just first changeset
     const firstChangesetId: string = changeSets[0].id;
 
-    let iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId });
+    let iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId });
     try {
       assert.exists(iModel);
       await iModel.reverseChanges(requestContext, IModelVersion.asOfChangeSet(firstChangesetId));// eslint-disable-line deprecation/deprecation
 
       // now extract change summary for that one changeset
-      const summaryIds = await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel, { currentVersionOnly: true });
-      assert.equal(summaryIds.length, 1);
-      assert.isTrue(IModelJsFs.existsSync(BriefcaseManager.getChangeCachePathName(readOnlyTestIModelId)));
+      const summaryId = await ChangeSummaryManager.createChangeSummary(requestContext, iModel);
+      assert.isTrue(IModelJsFs.existsSync(BriefcaseManager.getChangeCachePathName(iModelId)));
 
       assert.exists(iModel);
       ChangeSummaryManager.attachChangeCache(iModel);
@@ -267,7 +248,7 @@ describe("ChangeSummary (#integration)", () => {
         assert.isDefined(row.wsgId);
         assert.equal(row.wsgId, firstChangesetId);
         assert.isDefined(row.summary);
-        assert.equal(row.summary.id, summaryIds[0]);
+        assert.equal(row.summary.id, summaryId);
         assert.isDefined(row.pushDate, "IModelChange.ChangeSet.PushDate is expected to be set for the changesets used in this test.");
         assert.isDefined(row.userCreated, "IModelChange.ChangeSet.UserCreated is expected to be set for the changesets used in this test.");
         // the other properties are not used, but using them in the ECSQL is important to verify preparation works
@@ -277,11 +258,11 @@ describe("ChangeSummary (#integration)", () => {
       // now do second extraction for last changeset
       const lastChangesetId: string = changeSets[changeSets.length - 1].id;
       await IModelTestUtils.closeAndDeleteBriefcaseDb(requestContext, iModel);
-      iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId, asOf: IModelVersion.asOfChangeSet(lastChangesetId).toJSON() });
+      iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId, asOf: IModelVersion.asOfChangeSet(lastChangesetId).toJSON() });
       // WIP not working yet until cache can be detached.
       // await iModel.pullAndMergeChanges(accessToken, IModelVersion.asOfChangeSet(lastChangesetId));
 
-      await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel, { currentVersionOnly: true });
+      await ChangeSummaryManager.createChangeSummary(requestContext, iModel);
 
       // WIP
       ChangeSummaryManager.attachChangeCache(iModel);
@@ -306,14 +287,17 @@ describe("ChangeSummary (#integration)", () => {
   });
 
   it("Query ChangeSummary content", async () => {
-    const testIModelId: string = readOnlyTestIModelId;
+    const testIModelId: string = iModelId;
     setupTest(testIModelId);
 
-    let perfLogger = new PerfLogger("IModelDb.open");
-    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId });
+    let perfLogger = new PerfLogger("CreateChangeSummaries");
+    await ChangeSummaryManager.createChangeSummaries({ requestContext, contextId, iModelId, range: { first: 0 } });
+    perfLogger.dispose();
+
+    perfLogger = new PerfLogger("IModelDb.open");
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId });
     perfLogger.dispose();
     try {
-      await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel);
       assert.exists(iModel);
       ChangeSummaryManager.attachChangeCache(iModel);
       assert.isTrue(ChangeSummaryManager.isChangeCacheAttached(iModel));
@@ -334,7 +318,7 @@ describe("ChangeSummary (#integration)", () => {
       });
 
       for (const changeSummary of changeSummaries) {
-        const filePath = path.join(outDir, `imodelid_${readWriteTestIModelId}_changesummaryid_${changeSummary.id}.changesummary.json`);
+        const filePath = path.join(outDir, `imodelid_${iModelId}_changesummaryid_${changeSummary.id}.changesummary.json`);
         if (IModelJsFs.existsSync(filePath))
           IModelJsFs.unlinkSync(filePath);
 
@@ -390,14 +374,14 @@ describe("ChangeSummary (#integration)", () => {
 
     // Recreate iModel
     const managerRequestContext = await IModelTestUtils.getUserContext(TestUserType.Manager);
-    const projectId = await HubUtility.getTestContextId(managerRequestContext);
-    const iModelId = await HubUtility.recreateIModel(managerRequestContext, projectId, iModelName);
+    const testContextId = await HubUtility.getTestContextId(managerRequestContext);
+    const testIModelId = await HubUtility.recreateIModel(managerRequestContext, testContextId, iModelName);
 
     // Cleanup local cache
-    setupTest(iModelId);
+    setupTest(testIModelId);
 
     // Populate the iModel with 3 elements
-    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext: managerRequestContext, contextId: projectId, iModelId });
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext: managerRequestContext, contextId: testContextId, iModelId: testIModelId });
     iModel.concurrencyControl.setPolicy(new ConcurrencyControl.OptimisticPolicy());
     const [, modelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(iModel, IModelTestUtils.getUniqueModelCode(iModel, "TestPhysicalModel"), true);
     await iModel.concurrencyControl.request(managerRequestContext);
@@ -430,7 +414,7 @@ describe("ChangeSummary (#integration)", () => {
 
     // Validate that the second change summary captures the change to the parent correctly
     try {
-      const changeSummaryIds = await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel);
+      const changeSummaryIds = await ChangeSummaryManager.extractChangeSummaries(requestContext, iModel); // eslint-disable-line deprecation/deprecation
       assert.strictEqual(2, changeSummaryIds.length);
 
       ChangeSummaryManager.attachChangeCache(iModel);
@@ -463,7 +447,7 @@ describe("ChangeSummary (#integration)", () => {
       await IModelTestUtils.closeAndDeleteBriefcaseDb(requestContext, iModel);
     }
 
-    await IModelHost.hubAccess.deleteIModel({ requestContext, contextId: projectId, iModelId });
+    await IModelHost.hubAccess.deleteIModel({ requestContext, contextId: testContextId, iModelId: testIModelId });
   });
 
   it.skip("should be able to extract the last change summary right after applying a change set", async () => {
@@ -487,7 +471,7 @@ describe("ChangeSummary (#integration)", () => {
     // User2 applies the change set and extracts the change summary
     await iModel.pullAndMergeChanges(userContext2, IModelVersion.latest());
 
-    const changeSummariesIds = await ChangeSummaryManager.extractChangeSummaries(userContext2, iModel, { currentVersionOnly: true });
+    const changeSummariesIds = await ChangeSummaryManager.extractChangeSummaries(userContext2, iModel, { currentVersionOnly: true }); // eslint-disable-line deprecation/deprecation
     if (changeSummariesIds.length !== 1)
       throw new Error("ChangeSet summary extraction returned invalid ChangeSet summary IDs.");
 
@@ -511,6 +495,158 @@ describe("ChangeSummary (#integration)", () => {
           assert.isAbove(changedPropertyValueNames.length, 0);
         }
       });
+  });
+
+  it("Detaching and reattaching change cache", async () => {
+    setupTest(iModelId);
+    const changeSets = await IModelHost.hubAccess.queryChangesets({ requestContext, iModelId });
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId, asOf: IModelVersion.first().toJSON(), briefcaseId: 0 });
+    try {
+      for (const changeSet of changeSets) {
+        await iModel.pullAndMergeChanges(requestContext, IModelVersion.asOfChangeSet(changeSet.id));
+
+        const changeSummaryId = await ChangeSummaryManager.createChangeSummary(requestContext, iModel);
+
+        ChangeSummaryManager.attachChangeCache(iModel);
+        assert.isTrue(ChangeSummaryManager.isChangeCacheAttached(iModel));
+
+        iModel.withPreparedStatement("SELECT WsgId, Summary FROM imodelchange.ChangeSet WHERE Summary.Id=?", (myStmt) => {
+          myStmt.bindId(1, changeSummaryId);
+          assert.equal(myStmt.step(), DbResult.BE_SQLITE_ROW);
+          const row: any = myStmt.getRow();
+          assert.isDefined(row.wsgId);
+          assert.equal(row.wsgId, changeSet.id);
+          assert.isDefined(row.summary);
+          assert.equal(row.summary.id, changeSummaryId);
+        });
+
+        for await (const row of iModel.query("SELECT WsgId, Summary FROM imodelchange.ChangeSet WHERE Summary.Id=?", [changeSummaryId])) {
+          assert.isDefined(row.wsgId);
+          assert.equal(row.wsgId, changeSet.id);
+          assert.isDefined(row.summary);
+          assert.equal(row.summary.id, changeSummaryId);
+        }
+
+        // Reattach caches and try queries again
+        ChangeSummaryManager.detachChangeCache(iModel);
+        assert.isFalse(ChangeSummaryManager.isChangeCacheAttached(iModel));
+        ChangeSummaryManager.attachChangeCache(iModel);
+        assert.isTrue(ChangeSummaryManager.isChangeCacheAttached(iModel));
+
+        iModel.withPreparedStatement("SELECT WsgId, Summary FROM imodelchange.ChangeSet WHERE Summary.Id=?", (myStmt) => {
+          myStmt.bindId(1, changeSummaryId);
+          assert.equal(myStmt.step(), DbResult.BE_SQLITE_ROW);
+          const row: any = myStmt.getRow();
+          assert.isDefined(row.wsgId);
+          assert.equal(row.wsgId, changeSet.id);
+          assert.isDefined(row.summary);
+          assert.equal(row.summary.id, changeSummaryId);
+        });
+
+        for await (const row of iModel.query("SELECT WsgId, Summary FROM imodelchange.ChangeSet WHERE Summary.Id=?", [changeSummaryId])) {
+          assert.isDefined(row.wsgId);
+          assert.equal(row.wsgId, changeSet.id);
+          assert.isDefined(row.summary);
+          assert.equal(row.summary.id, changeSummaryId);
+        }
+
+        // Detach before the next creation
+        ChangeSummaryManager.detachChangeCache(iModel);
+        assert.isFalse(ChangeSummaryManager.isChangeCacheAttached(iModel));
+      }
+
+    } finally {
+      await IModelTestUtils.closeAndDeleteBriefcaseDb(requestContext, iModel);
+    }
+  });
+
+  it("Create change summaries for all change sets", async () => {
+    setupTest(iModelId);
+
+    const summaryIds = await ChangeSummaryManager.createChangeSummaries({ requestContext, contextId, iModelId, range: { first: 0 } });
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId });
+
+    try {
+      ChangeSummaryManager.attachChangeCache(iModel);
+
+      iModel.withPreparedStatement("SELECT ECInstanceId,ECClassId,ExtendedProperties FROM change.ChangeSummary ORDER BY ECInstanceId", (myStmt) => {
+        let rowCount: number = 0;
+        while (myStmt.step() === DbResult.BE_SQLITE_ROW) {
+          rowCount++;
+          const row: any = myStmt.getRow();
+          assert.equal(row.className, "ECDbChange.ChangeSummary");
+        }
+        assert.isAtLeast(rowCount, 4);
+      });
+
+      iModel.withPreparedStatement("SELECT ECClassId,Summary,WsgId,ParentWsgId,Description,PushDate,UserCreated FROM imodelchange.ChangeSet ORDER BY Summary.Id", (myStmt) => {
+        let rowCount: number = 0;
+        while (myStmt.step() === DbResult.BE_SQLITE_ROW) {
+          rowCount++;
+          const row: any = myStmt.getRow();
+          assert.equal(row.className, "IModelChange.ChangeSet");
+          assert.equal(row.summary.id, summaryIds[rowCount - 1]);
+          assert.equal(row.summary.relClassName, "IModelChange.ChangeSummaryIsExtractedFromChangeset");
+        }
+        assert.isAtLeast(rowCount, 4);
+      });
+
+    } finally {
+      ChangeSummaryManager.detachChangeCache(iModel);
+      await IModelTestUtils.closeAndDeleteBriefcaseDb(requestContext, iModel);
+    }
+  });
+
+  it("Create change summaries for just the latest change set", async () => {
+    setupTest(iModelId);
+
+    const first = (await IModelHost.hubAccess.getChangesetFromVersion({ requestContext, iModelId, version: IModelVersion.latest() })).index;
+
+    const summaryIds = await ChangeSummaryManager.createChangeSummaries({ requestContext, contextId, iModelId, range: { first } });
+    const iModel = await IModelTestUtils.downloadAndOpenBriefcase({ requestContext, contextId, iModelId });
+
+    try {
+      ChangeSummaryManager.attachChangeCache(iModel);
+
+      iModel.withPreparedStatement("SELECT ECInstanceId,ECClassId,ExtendedProperties FROM change.ChangeSummary ORDER BY ECInstanceId", (myStmt) => {
+        let rowCount: number = 0;
+        while (myStmt.step() === DbResult.BE_SQLITE_ROW) {
+          rowCount++;
+          const row: any = myStmt.getRow();
+          assert.equal(row.className, "ECDbChange.ChangeSummary");
+        }
+        assert.strictEqual(rowCount, 1);
+      });
+
+      iModel.withPreparedStatement("SELECT ECClassId,Summary,WsgId,ParentWsgId,Description,PushDate,UserCreated FROM imodelchange.ChangeSet ORDER BY Summary.Id", (myStmt) => {
+        let rowCount: number = 0;
+        while (myStmt.step() === DbResult.BE_SQLITE_ROW) {
+          rowCount++;
+          const row: any = myStmt.getRow();
+          assert.equal(row.className, "IModelChange.ChangeSet");
+          assert.equal(row.summary.id, summaryIds[rowCount - 1]);
+        }
+        assert.strictEqual(rowCount, 1);
+      });
+
+    } finally {
+      ChangeSummaryManager.detachChangeCache(iModel);
+      await IModelTestUtils.closeAndDeleteBriefcaseDb(requestContext, iModel);
+    }
+  });
+
+  it("Create change summaries for an invalid range of change sets", async () => {
+    setupTest(iModelId);
+    let errorThrown = false;
+
+    const first = (await IModelHost.hubAccess.getChangesetFromVersion({ requestContext, iModelId, version: IModelVersion.latest() })).index;
+    try {
+      await ChangeSummaryManager.createChangeSummaries({ requestContext, contextId, iModelId, range: { first, end: 0 } });
+    } catch (err) {
+      errorThrown = true;
+      assert.isTrue(err instanceof IModelError);
+    }
+    assert.isTrue(errorThrown);
   });
 
 });

--- a/core/common/src/IModelVersion.ts
+++ b/core/common/src/IModelVersion.ts
@@ -121,7 +121,7 @@ export class IModelVersion {
    * that Id without any validation.
    * @deprecated use IModelHost/IModelApp hubAccess.getChangesetIdFromVersion
    */
-  public async evaluateChangeSet(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, imodelClient: IModelClient): Promise<GuidString> {
+  public async evaluateChangeSet(requestContext: AuthorizedClientRequestContext, iModelId: GuidString, imodelClient: IModelClient): Promise<string> {
     if (this._first)
       return "";
 
@@ -150,7 +150,7 @@ export class IModelVersion {
    * @internal - public only so tests can catch calls to it and fail.
    * @deprecated use IModelHost/IModelApp hubAccess.getChangesetIdFromVersion
    */
-  public static async getChangeSetFromNamedVersion(requestContext: AuthorizedClientRequestContext, imodelClient: IModelClient, iModelId: GuidString, versionName: string): Promise<GuidString> {
+  public static async getChangeSetFromNamedVersion(requestContext: AuthorizedClientRequestContext, imodelClient: IModelClient, iModelId: GuidString, versionName: string): Promise<string> {
     const versions = await imodelClient.versions.get(requestContext, iModelId, new VersionQuery().select("ChangeSetId").byName(versionName));
 
     if (!versions[0] || !versions[0].changeSetId)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,19 @@ publish: false
 
 The [AnalysisStyle]($common) APIs have been cleaned up and promoted to `@public`. An AnalysisStyle is used to animate a mesh that has been supplemented with [PolyfaceAuxData]($geometry-core), by recoloring and/or deforming its vertices over time. This enables visualization of the effects of computed, changing variables like stress and temperature.
 
+## Modifications to the Change Summary API
+
+[ChangeSummaryManager.extractChangeSummaries]($imodeljs-backend) has now been deprecated, and replaced with two methods - [ChangeSummaryManager.createChangeSummaries]($imodeljs-backend) and [ChangeSummaryManager.createChangeSummary]($imodeljs-backend).
+
+The deprecated method works by creating a range of Change Summaries by starting with the end version, reversing Changesets one by one until the specified start version. Since Changesets containing schema changes cannot be reversed, the method may fail to create some Change Summaries. The new replacement instead walks the versions in the forward direction.
+
+- [ChangeSummaryManager.createChangeSummaries]($imodeljs-backend) creates Change Summaries for a range of Changesets by walking the versions in a forward direction starting with the specified first version.
+- [ChangeSummaryManager.createChangeSummary]($imodeljs-backend) creates a single Change Summary for the current version of the iModel, i.e., the last applied Changeset.
+
+[ChangeSummaryManager.detachChangeCache] can now be used to detach the cache after querying the change summary to continue change summary creation if necessary.
+
+[ChangeSummaryExtractOptions]($imodeljs-backend) and [ChangeSummaryExtractContext]($imodeljs-backend) are also deprecated as a consequence of the above changes. [CreateChangeSummaryArgs]($imodel-backend) serves a similar purpose with the newer methods.
+
 ## UI changes
 
 ### @bentley/ui-abstract package


### PR DESCRIPTION
- Deprecated ChangeSummaryManager.extractChangeSummaries
- Added ChangeSummaryManager.createChangeSummaries, ChangeSummaryManager.createChangeSummary
- Re-enabled ChangeSummaryManager.detachChangeCache (wraps native code changes done earlier)
