### PR TITLE
requestElementGraphics can produce section-cut graphics.

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -3576,6 +3576,7 @@ export interface GraphicsRequestProps {
     readonly id: string;
     readonly location?: TransformProps;
     readonly omitEdges?: boolean;
+    readonly sectionCut?: string;
     readonly toleranceLog10: number;
     // @alpha
     readonly treeFlags?: TreeFlags;

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -143,6 +143,7 @@ import { IModelConnectionProps } from '@bentley/imodeljs-common';
 import { IModelCoordinatesResponseProps } from '@bentley/imodeljs-common';
 import { IModelRpcProps } from '@bentley/imodeljs-common';
 import { IModelStatus } from '@bentley/imodeljs-common';
+import { IModelTileTreeId } from '@bentley/imodeljs-common';
 import { IModelTileTreeProps } from '@bentley/imodeljs-common';
 import { IModelVersion } from '@bentley/imodeljs-common';
 import { IModelVersionProps } from '@bentley/imodeljs-common';
@@ -4747,7 +4748,7 @@ export function iModelTileParamsFromJSON(props: TileProps, parent: IModelTile | 
 
 // @internal
 export class IModelTileTree extends TileTree {
-    constructor(params: IModelTileTreeParams);
+    constructor(params: IModelTileTreeParams, treeId: IModelTileTreeId);
     // (undocumented)
     get batchType(): BatchType;
     // (undocumented)
@@ -4781,6 +4782,8 @@ export class IModelTileTree extends TileTree {
     // (undocumented)
     protected _selectTiles(args: TileDrawArgs): Tile[];
     get staticBranch(): IModelTile;
+    // (undocumented)
+    readonly stringifiedSectionClip?: string;
     get tileState(): "static" | "dynamic" | "interactive" | "disposed";
     // (undocumented)
     get viewFlagOverrides(): ViewFlagOverrides;
@@ -10519,7 +10522,7 @@ export abstract class TileTreeReference {
 // @public
 export interface TileTreeSupplier {
     // @internal
-    addModelsAnimatedByScript?: (modelIds: Set<Id64String_2>, scriptSourceId: Id64String_2, trees: Iterable<{
+    addModelsAnimatedByScript?: (modelIds: Set<Id64String>, scriptSourceId: Id64String, trees: Iterable<{
         id: any;
         owner: TileTreeOwner;
     }>) => void;

--- a/common/changes/@bentley/imodeljs-common/section-cut-element-graphics_2021-06-25-13-56.json
+++ b/common/changes/@bentley/imodeljs-common/section-cut-element-graphics_2021-06-25-13-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Added support for section clip to ElementGraphicsRequestProps.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/section-cut-element-graphics_2021-06-25-13-56.json
+++ b/common/changes/@bentley/imodeljs-frontend/section-cut-element-graphics_2021-06-25-13-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "TileAdmin.requestElementGraphics can now produce section-cut graphics.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -37,6 +37,11 @@ export interface GraphicsRequestProps {
   readonly omitEdges?: boolean;
   /** If true, the element's graphics will be clipped against the iModel's project extents. */
   readonly clipToProjectExtents?: boolean;
+  /** If defined, the compact string representation of a [ClipVector]($geometry-core) to be applied to the geometry to produce section-cut
+   * geometry at the intersections with the clip planes. Any geometry *not* intersecting the clip planes is omitted from the tiles.
+   * @see [ClipVector.toCompactString]($geometry-core) to produce the string representation.
+   */
+  readonly sectionCut?: string;
 }
 
 /** Wire format describing a request to produce graphics in "iMdl" format for a single element.

--- a/core/frontend/src/tile/ClassifierTileTree.ts
+++ b/core/frontend/src/tile/ClassifierTileTree.ts
@@ -60,7 +60,7 @@ class ClassifierTreeSupplier implements TileTreeSupplier {
     };
 
     const params = iModelTileTreeParamsFromJSON(props, iModel, id.modelId, options);
-    return new IModelTileTree(params);
+    return new IModelTileTree(params, id);
   }
 
   public getOwner(id: ClassifierTreeId, iModel: IModelConnection): TileTreeOwner {

--- a/core/frontend/src/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/tile/DynamicIModelTile.ts
@@ -11,7 +11,7 @@ import {
 } from "@bentley/bentleyjs-core";
 import { Range3d, Transform } from "@bentley/geometry-core";
 import {
-  BatchType, ElementGeometryChange, FeatureAppearance, FeatureAppearanceProvider, FeatureAppearanceSource, GeometryClass, TileFormat,
+  BatchType, ElementGeometryChange, ElementGraphicsRequestProps, FeatureAppearance, FeatureAppearanceProvider, FeatureAppearanceSource, GeometryClass, TileFormat,
 } from "@bentley/imodeljs-common";
 import { RenderSystem } from "../render/RenderSystem";
 import { Viewport } from "../Viewport";
@@ -353,7 +353,7 @@ class GraphicsTile extends Tile {
     assert(this.tree instanceof IModelTileTree);
     const idProvider = this.tree.contentIdProvider;
 
-    const props = {
+    const props: ElementGraphicsRequestProps = {
       id: requestId.value.toString(16),
       elementId: this.parent.contentId,
       toleranceLog10: this.toleranceLog10,
@@ -362,6 +362,7 @@ class GraphicsTile extends Tile {
       contentFlags: idProvider.contentFlags,
       omitEdges: !this.tree.hasEdges,
       clipToProjectExtents: true,
+      sectionCut: this.tree.stringifiedSectionClip,
     };
 
     return IModelApp.tileAdmin.requestElementGraphics(this.tree.iModel, props);

--- a/core/frontend/src/tile/IModelTileTree.ts
+++ b/core/frontend/src/tile/IModelTileTree.ts
@@ -10,7 +10,7 @@ import { assert, BeTimePoint, GuidString, Id64Array, Id64String } from "@bentley
 import { Range3d, Transform } from "@bentley/geometry-core";
 import {
   BatchType, ContentIdProvider, ElementAlignedBox3d, ElementGeometryChange, FeatureAppearanceProvider,
-  IModelTileTreeProps, ModelGeometryChanges, TileProps, ViewFlagOverrides,
+  IModelTileTreeId, IModelTileTreeProps, ModelGeometryChanges, TileProps, ViewFlagOverrides,
 } from "@bentley/imodeljs-common";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
@@ -316,6 +316,7 @@ export class IModelTileTree extends TileTree {
   public readonly maxTilesToSkip: number;
   public readonly maxInitialTilesToSkip: number;
   public readonly contentIdProvider: ContentIdProvider;
+  public readonly stringifiedSectionClip?: string;
   /** Strictly for debugging/testing - forces tile selection to halt at the specified depth. */
   public debugMaxDepth?: number;
   /** A little hacky...we must not override selectTiles(), but draw() needs to distinguish between static and dynamic tiles.
@@ -324,10 +325,13 @@ export class IModelTileTree extends TileTree {
    */
   private _numStaticTilesSelected = 0;
 
-  public constructor(params: IModelTileTreeParams) {
+  public constructor(params: IModelTileTreeParams, treeId: IModelTileTreeId) {
     super(params);
     this.contentIdQualifier = params.contentIdQualifier;
     this.geometryGuid = params.geometryGuid;
+
+    if (BatchType.Primary === treeId.type)
+      this.stringifiedSectionClip = treeId.sectionCut;
 
     this.maxInitialTilesToSkip = params.maxInitialTilesToSkip ?? 0;
     this.maxTilesToSkip = IModelApp.tileAdmin.maximumLevelsToSkip;

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -35,8 +35,8 @@ interface PrimaryTreeId {
 class PlanProjectionTileTree extends IModelTileTree {
   public readonly baseElevation: number;
 
-  public constructor(params: IModelTileTreeParams, baseElevation: number) {
-    super(params);
+  public constructor(params: IModelTileTreeParams, treeId: PrimaryTileTreeId, baseElevation: number) {
+    super(params, treeId);
     this.baseElevation = baseElevation;
   }
 }
@@ -71,7 +71,7 @@ class PrimaryTreeSupplier implements TileTreeSupplier {
 
     const params = iModelTileTreeParamsFromJSON(props, iModel, id.modelId, options);
     if (!id.isPlanProjection)
-      return new IModelTileTree(params);
+      return new IModelTileTree(params, id.treeId);
 
     let elevation = 0;
     try {
@@ -87,7 +87,7 @@ class PrimaryTreeSupplier implements TileTreeSupplier {
       //
     }
 
-    return new PlanProjectionTileTree(params, elevation);
+    return new PlanProjectionTileTree(params, id.treeId, elevation);
   }
 
   public getOwner(id: PrimaryTreeId, iModel: IModelConnection): TileTreeOwner {

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,10 @@ publish: false
 
 The [AnalysisStyle]($common) APIs have been cleaned up and promoted to `@public`. An AnalysisStyle is used to animate a mesh that has been supplemented with [PolyfaceAuxData]($geometry-core), by recoloring and/or deforming its vertices over time. This enables visualization of the effects of computed, changing variables like stress and temperature.
 
+## Section-cut element graphics
+
+[TileAdmin.requestElementGraphics]($frontend) can now produce section-cut graphics if [ElementGraphicsRequestProps.sectionCut]($common) is supplied. The temporary element graphics produced during interactive editing will automatically include section-cut graphics based on the viewport's [CutStyle]($common).
+
 ## UI changes
 
 ### @bentley/ui-abstract package


### PR DESCRIPTION
Supply stringified ClipVector via `ElementGraphicsRequestProps.sectionCut`.
Temporary graphics generated during interactive editing automatically produce section-cut graphics based on the view's ClipStyle.
[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/174083).