### PR TITLE
Purge spatial tile trees when project extents change.

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -10519,7 +10519,12 @@ export abstract class TileTreeReference {
 // @public
 export interface TileTreeSupplier {
     // @internal
-    addModelsAnimatedByScript?: (modelIds: Set<Id64String_2>, scriptSourceId: Id64String_2, trees: Iterable<{
+    addModelsAnimatedByScript?: (modelIds: Set<Id64String>, scriptSourceId: Id64String, trees: Iterable<{
+        id: any;
+        owner: TileTreeOwner;
+    }>) => void;
+    // @internal
+    addSpatialModels?: (modelIds: Set<Id64String>, trees: Iterable<{
         id: any;
         owner: TileTreeOwner;
     }>) => void;

--- a/common/changes/@bentley/imodeljs-frontend/purge-tile-trees-on-project-extents-change_2021-06-25-15-19.json
+++ b/common/changes/@bentley/imodeljs-frontend/purge-tile-trees-on-project-extents-change_2021-06-25-15-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Update tile trees when project extents change.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/Tiles.ts
+++ b/core/frontend/src/Tiles.ts
@@ -93,10 +93,9 @@ export class Tiles {
     });
 
     // When project extents change, purge tile trees for spatial models.
-    const handleProjectExtents = false;
     iModel.onProjectExtentsChanged.addListener(async () => {
-      if (handleProjectExtents)
-        this.purgeModelTrees(this.getSpatialModels());
+      if (!iModel.isBriefcaseConnection() || !iModel.editingScope)
+        await this.purgeModelTrees(this.getSpatialModels());
     });
   }
 

--- a/core/frontend/src/Tiles.ts
+++ b/core/frontend/src/Tiles.ts
@@ -91,6 +91,13 @@ export class Tiles {
           this.dropSupplier(supplier);
       }
     });
+
+    // When project extents change, purge tile trees for spatial models.
+    const handleProjectExtents = false;
+    iModel.onProjectExtentsChanged.addListener(async () => {
+      if (handleProjectExtents)
+        this.purgeModelTrees(this.getSpatialModels());
+    });
   }
 
   /** @internal */
@@ -114,6 +121,15 @@ export class Tiles {
     return IModelApp.tileAdmin.purgeTileTrees(this._iModel, modelIds);
   }
 
+  private getModelsAnimatedByScheduleScript(scriptSourceElementId: Id64String): Set<Id64String> {
+    const modelIds = new Set<Id64String>();
+    for (const supplier of this._treesBySupplier.keys())
+      if (supplier.addModelsAnimatedByScript)
+        supplier.addModelsAnimatedByScript(modelIds, scriptSourceElementId, this.getTreeOwnersForSupplier(supplier));
+
+    return modelIds;
+  }
+
   /** Update the [[Tile]]s for any [[TileTree]]s that use the [RenderSchedule.Script]($common) hosted by the specified
    * [RenderTimeline]($backend) or [DisplayStyle]($backend) element. This method should be invoked after
    * the host element is updated in the database with a new script, so that any [[Viewport]]s displaying tiles produced
@@ -122,18 +138,25 @@ export class Tiles {
    * @public
    */
   public async updateForScheduleScript(scriptSourceElementId: Id64String): Promise<void> {
-    const modelIds = new Set<Id64String>();
-    for (const supplier of this._treesBySupplier.keys()) {
-      if (supplier.addModelsAnimatedByScript)
-        supplier.addModelsAnimatedByScript(modelIds, scriptSourceElementId, this.getTreeOwnersForSupplier(supplier));
-    }
+    return this.purgeModelTrees(this.getModelsAnimatedByScheduleScript(scriptSourceElementId));
+  }
 
+  private async purgeModelTrees(modelIds: Set<Id64String>): Promise<void> {
     if (0 === modelIds.size)
       return;
 
     const ids = Array.from(modelIds);
     await this.purgeTileTrees(ids);
     IModelApp.viewManager.refreshForModifiedModels(ids);
+  }
+
+  private getSpatialModels(): Set<Id64String> {
+    const modelIds = new Set<Id64String>();
+    for (const supplier of this._treesBySupplier.keys())
+      if (supplier.addSpatialModels)
+        supplier.addSpatialModels(modelIds, this.getTreeOwnersForSupplier(supplier));
+
+    return modelIds;
   }
 
   /** Obtain the owner of a TileTree.

--- a/core/frontend/src/tile/ClassifierTileTree.ts
+++ b/core/frontend/src/tile/ClassifierTileTree.ts
@@ -72,6 +72,11 @@ class ClassifierTreeSupplier implements TileTreeSupplier {
       if (tree.id.animationId === scriptSourceId)
         modelIds.add(tree.id.modelId);
   }
+
+  public addSpatialModels(modelIds: Set<Id64String>, trees: Iterable<{ id: ClassifierTreeId, owner: TileTreeOwner }>): void {
+    for (const tree of trees)
+      modelIds.add(tree.id.modelId);
+  }
 }
 
 const classifierTreeSupplier = new ClassifierTreeSupplier();

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -99,6 +99,12 @@ class PrimaryTreeSupplier implements TileTreeSupplier {
       if (tree.id.treeId.animationId === scriptSourceId)
         modelIds.add(tree.id.modelId);
   }
+
+  public addSpatialModels(modelIds: Set<Id64String>, trees: Iterable<{ id: PrimaryTreeId, owner: TileTreeOwner }>): void {
+    for (const tree of trees)
+      if (tree.id.is3d)
+        modelIds.add(tree.id.modelId);
+  }
 }
 
 const primaryTreeSupplier = new PrimaryTreeSupplier();

--- a/core/frontend/src/tile/TileTreeSupplier.ts
+++ b/core/frontend/src/tile/TileTreeSupplier.ts
@@ -34,7 +34,14 @@ export interface TileTreeSupplier {
 
   /** Given the set of trees belonging to this supplier, add the modelIds associated with any trees that are animated by
    * the schedule script hosted by the specified RenderTimeline or DisplayStyle element.
+   * @see [[Tiles.updateForScheduleScript]].
    * @internal
    */
   addModelsAnimatedByScript?: (modelIds: Set<Id64String>, scriptSourceId: Id64String, trees: Iterable<{ id: any, owner: TileTreeOwner }>) => void;
+
+  /** Given the set of trees belonging to this supplier, add the modelIds associated with any trees representing spatial models.
+   * @see [[Tiles.getSpatialModels]].
+   * @internal
+   */
+  addSpatialModels?: (modelIds: Set<Id64String>, trees: Iterable<{ id: any, owner: TileTreeOwner }>) => void;
 }


### PR DESCRIPTION
The range and transform associated with a spatial tile tree depends upon the project extents. When the extents change, purge the trees.
Native PR forthcoming.