### PR TITLE
Fix Arc3d.createCenterNormalRadius()

### DIFF
--- a/common/changes/@bentley/geometry-core/create-arc3d-fix_2021-06-28-13-37.json
+++ b/common/changes/@bentley/geometry-core/create-arc3d-fix_2021-06-28-13-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "Use ZXY axis order in Arc3d.createCenterNormalRadius().",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/core/geometry/src/curve/Arc3d.ts
+++ b/core/geometry/src/curve/Arc3d.ts
@@ -196,7 +196,7 @@ export class Arc3d extends CurvePrimitive implements BeJSONFunctions {
    * @param result optional preallocated result.
    */
   public static createCenterNormalRadius(center: Point3d | undefined, normal: Vector3d, radius: number, result?: Arc3d): Arc3d {
-    const frame = Matrix3d.createRigidHeadsUp(normal, AxisOrder.ZYX);
+    const frame = Matrix3d.createRigidHeadsUp(normal);
     return Arc3d.createScaledXYColumns(center, frame, radius, radius, undefined, result);
   }
 

--- a/core/geometry/src/test/curve/Arc3d.test.ts
+++ b/core/geometry/src/test/curve/Arc3d.test.ts
@@ -498,4 +498,15 @@ describe("Arc3d", () => {
     expect(ck.getNumErrors()).equals(0);
     GeometryCoreTestIO.saveGeometry(allGeometry, "Arc3d", "CodeCheckerArcTransitionD");
   });
+  it("CreateCenterNormalRadius", () => {
+    const ck = new Checker();
+
+    for (const normal of [Vector3d.unitX(), Vector3d.unitY(-2), Vector3d.unitZ(3), new Vector3d(1, 2, 3)]) {
+      const arc = Arc3d.createCenterNormalRadius(undefined, normal, 10);
+      ck.testVector3d(normal.normalize()!, arc.perpendicularVector, `for normal ${prettyPrint(normal)}`);
+    }
+
+    ck.checkpoint("Arc3d.CreateCenterNormalRadius");
+    expect(ck.getNumErrors()).equals(0);
+  });
 });


### PR DESCRIPTION
Use `AxisOrder.ZXY` in `Arc3d.createCenterNormalRadius()` to correctly create an Arc.

Perpendicular vector should match provided normal, i.e.:
```
const arc = Arc3d.createCenterNormalRadius(undefined, Vector3d.unitZ(), 1);
console.log(arc.perpendicularVector); // currently outputs { x: 0, y: 0, z: -1 }, but we expect { x: 0, y: 0, z: 1 }
```
