### PR TITLE
Add IModelTransformer CodeScope check

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/IModelTransformer-CodeScope-check_2021-06-28-21-05.json
+++ b/common/changes/@bentley/imodeljs-backend/IModelTransformer-CodeScope-check_2021-06-28-21-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "36768600+scsewall@users.noreply.github.com"
+}

--- a/core/backend/src/IModelTransformer.ts
+++ b/core/backend/src/IModelTransformer.ts
@@ -442,7 +442,8 @@ export class IModelTransformer extends IModelExportHandler {
       targetElementId = this.context.findTargetElementId(sourceElement.id);
       targetElementProps = this.onTransformElement(sourceElement);
     }
-    if (!Id64.isValidId64(targetElementId)) {
+    // if an existing remapping was not yet found, check by Code as long as the CodeScope is valid (invalid means a missing predecessor so not worth checking)
+    if (!Id64.isValidId64(targetElementId) && Id64.isValidId64(targetElementProps.code.scope)) {
       targetElementId = this.targetDb.elements.queryElementIdByCode(new Code(targetElementProps.code));
       if (undefined !== targetElementId) {
         const targetElement: Element = this.targetDb.elements.getElement(targetElementId);


### PR DESCRIPTION
Avoid queryElementIdByCode if CodeScope is invalid since it will cause queryElementIdByCode to fail. This is not an overall failure. Instead, it indicates a missing predecessor that will be detected later in the same method.