### PR TITLE
Reconstruct TileOptions from tree and content Ids

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -8209,6 +8209,11 @@ export interface TileOptions {
     readonly useProjectExtents: boolean;
 }
 
+// @internal (undocumented)
+export namespace TileOptions {
+    export function fromTreeIdAndContentId(treeId: string, contentId: string): TileOptions;
+}
+
 // @internal
 export interface TileProps {
     contentId: string;

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -632,6 +632,7 @@ internal;class TileHeader
 internal;TileMetadata 
 internal;TileMetadataReader
 internal;TileOptions
+internal;TileOptions
 internal;TileProps
 internal;TileReadError 
 internal;TileReadStatus

--- a/common/changes/@bentley/imodeljs-common/tile-options-from-ids_2021-06-29-13-14.json
+++ b/common/changes/@bentley/imodeljs-common/tile-options-from-ids_2021-06-29-13-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Add internal API for reconstructing TileOptions from tree and content Ids.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/common/src/test/TileMetadata.test.ts
+++ b/core/common/src/test/TileMetadata.test.ts
@@ -250,9 +250,20 @@ describe("TileMetadata", () => {
 
     test("", "", "tree");
     test("4_1-0x1c", "", "content");
-    test("", "-4-0-1-2-3-4-5", "tree");
+    test("", "-0-1-2-3-4-5", "tree");
 
     test("blah", "blah", "tree");
-    test("4-0_0x1c", "blah", "content");
+    test("4_0-0x1c", "blah", "content");
+    test("4-1_0x1c", "-0-1-2-3-4-5", "tree");
+    test("4_1-0x1c", "0-1-2-3-4-5", "content");
+
+    test("4_0-0x1c", "-0-0", { version: 4 });
+    test("Ad_1", "-0-0", { version: 0xad, projectExtents: true });
+    test("f_2", "-0-0", { version: 15 });
+    test("f_3", "-0-0", { version: 15, projectExtents: true });
+
+    test("4_0", "-3-0", { version: 4, elision: true, instancing: true });
+    test("4_0", "-c-5", { version: 4, noPatterns: true, externalTextures: true });
+    test("a_1", "-F-2", { version: 10, projectExtents: true, noPatterns: true, externalTextures: true, instancing: true, elision: true });
   });
 });

--- a/core/common/src/test/TileMetadata.test.ts
+++ b/core/common/src/test/TileMetadata.test.ts
@@ -221,12 +221,12 @@ describe("TileMetadata", () => {
 
   it("computes TileOptions from tree and content Ids", () => {
     interface Options {
-      version: number,
-      instancing?: boolean,
-      elision?: boolean,
-      noPatterns?: boolean,
-      externalTextures?: boolean,
-      projectExtents?: boolean,
+      version: number;
+      instancing?: boolean;
+      elision?: boolean;
+      noPatterns?: boolean;
+      externalTextures?: boolean;
+      projectExtents?: boolean;
     }
 
     function test(treeId: string, contentId: string, expected: Options | "content" | "tree"): void {

--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -65,6 +65,31 @@ export interface TileOptions {
 }
 
 /** @internal */
+export namespace TileOptions {
+  /** Given the string representation of an [[IModelTileTreeId]] and the contentId of a [Tile]($frontend) belonging to that [TileTree]($frontend),
+   * compute the [[TileOptions]] that were used to generate the Ids.
+   * @throws Error if `treeId` or `contentId` are not valid Ids.
+   * @note `treeId` and `contentId` are assumed to be valid Ids. They are not fully parsed and validated - only the information required by this function is extracted.
+   * @note `treeId` and `contentId` are assumed to have been produced for version 4 or later of the iMdl tile format.
+   */
+  export function fromTreeIdAndContentId(treeId: string, contentId: string): TileOptions {
+    const tree = treeFlagsAndFormatVersionFromId(treeId);
+    const contentFlags = contentFlagsFromId(contentId);
+
+    return {
+      maximumMajorTileFormatVersion: tree.version,
+      enableInstancing: 0 !== (contentFlags & ContentFlags.AllowInstancing),
+      enableImprovedElision: 0 !== (contentFlags & ContentFlags.ImprovedElision),
+      ignoreAreaPatterns: 0 !== (contentFlags & ContentFlags.IgnoreAreaPatterns),
+      enableExternalTextures: 0 !== (contentFlags & ContentFlags.ExternalTextures),
+      useProjectExtents: 0 !== (tree.flags & TreeFlags.UseProjectExtents),
+      disableMagnification: false,
+      alwaysSubdivideIncompleteTiles: false,
+    };
+  }
+}
+
+/** @internal */
 export const defaultTileOptions: TileOptions = Object.freeze({
   maximumMajorTileFormatVersion: CurrentImdlVersion.Major,
   enableInstancing: true,
@@ -75,6 +100,36 @@ export const defaultTileOptions: TileOptions = Object.freeze({
   disableMagnification: false,
   alwaysSubdivideIncompleteTiles: false,
 });
+
+function contentFlagsFromId(id: string): ContentFlags {
+  if (0 === id.length || "-" !== id[0])
+    throw new Error("Invalid content Id");
+
+  // V4: -flags-d-i-j-k-m - version in tree Id
+  const end = id.indexOf("-", 1);
+  if (-1 !== end) {
+    const flags = Number.parseInt(id.substring(1, end), 16);
+    if (!Number.isNaN(flags))
+      return flags;
+  }
+
+  throw new Error("Invalid content Id");
+}
+
+function treeFlagsAndFormatVersionFromId(id: string): { flags: TreeFlags, version: number } {
+  if (0 === id.length)
+    throw new Error("Invalid tree Id");
+
+  const parts = id.split("-");
+  if (parts.length >= 2) {
+    const version = Number.parseInt(parts[0], 16);
+    const flags = Number.parseInt(parts[1], 16);
+    if (!Number.isNaN(version) || !Number.isNaN(flags))
+      return { version, flags };
+  }
+
+  throw new Error("Invalid tree Id");
+}
 
 /** @internal */
 export function getMaximumMajorTileFormatVersion(maxMajorVersion: number, formatVersion?: number): number {

--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -120,12 +120,15 @@ function treeFlagsAndFormatVersionFromId(id: string): { flags: TreeFlags, versio
   if (0 === id.length)
     throw new Error("Invalid tree Id");
 
-  const parts = id.split("-");
-  if (parts.length >= 2) {
-    const version = Number.parseInt(parts[0], 16);
-    const flags = Number.parseInt(parts[1], 16);
-    if (!Number.isNaN(version) || !Number.isNaN(flags))
-      return { version, flags };
+  let parts = id.split("-");
+  if (parts.length > 0) {
+    parts = parts[0].split("_");
+    if (parts.length === 2) {
+      const version = Number.parseInt(parts[0], 16);
+      const flags = Number.parseInt(parts[1], 16);
+      if (!Number.isNaN(version) || !Number.isNaN(flags))
+        return { version, flags };
+    }
   }
 
   throw new Error("Invalid tree Id");


### PR DESCRIPTION
To implement [this feature](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/630936) requested for tile agents.
It assumes tile format version 4 or later because that version pre-dates cloud storage tile cache.