### PR TITLE
Support minimum LOD for ESRI layers

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -1121,6 +1121,8 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
     // (undocumented)
     get maximumZoomLevel(): number;
     // (undocumented)
+    get minimumZoomLevel(): number;
+    // (undocumented)
     serviceJson: any;
     // (undocumented)
     protected _testChildAvailability(tile: ImageryMapTile, resolveChildren: () => void): void;
@@ -5637,6 +5639,8 @@ export class MapTileLoader extends RealityTileLoader {
     // (undocumented)
     get maxDepth(): number;
     // (undocumented)
+    get minDepth(): number;
+    // (undocumented)
     protected _modelId: Id64String;
     // (undocumented)
     get priority(): TileLoadPriority;
@@ -7665,6 +7669,8 @@ export abstract class RealityTileLoader {
     // (undocumented)
     abstract get maxDepth(): number;
     // (undocumented)
+    abstract get minDepth(): number;
+    // (undocumented)
     get parentsAndChildrenExclusive(): boolean;
     // (undocumented)
     readonly preloadRealityParentDepth: number;
@@ -7715,6 +7721,8 @@ export class RealityTileTree extends TileTree {
     protected logTiles(label: string, tiles: IterableIterator<Tile>): void;
     // (undocumented)
     get maxDepth(): number;
+    // (undocumented)
+    get minDepth(): number;
     // (undocumented)
     get parentsAndChildrenExclusive(): boolean;
     // (undocumented)

--- a/common/changes/@bentley/imodeljs-frontend/geo-esriMinLod_2021-07-01-13-38.json
+++ b/common/changes/@bentley/imodeljs-frontend/geo-esriMinLod_2021-07-01-13-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Added support for ESRI MapServer exposing a minimum LOD.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "mdastous-bentley@users.noreply.github.com"
+}

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -349,6 +349,7 @@ class RealityModelTileLoader extends RealityTileLoader {
   public get doDrapeBackgroundMap(): boolean { return this.tree.doDrapeBackgroundMap; }
 
   public get maxDepth(): number { return 32; }  // Can be removed when element tile selector is working.
+  public get minDepth(): number { return 0; }
   public get priority(): TileLoadPriority { return TileLoadPriority.Context; }
   public getBatchIdMap(): BatchedTileIdMap | undefined { return this._batchedIdMap; }
   public get clipLowResolutionTiles(): boolean { return true; }

--- a/core/frontend/src/tile/RealityTileLoader.ts
+++ b/core/frontend/src/tile/RealityTileLoader.ts
@@ -45,6 +45,7 @@ export abstract class RealityTileLoader {
   public abstract getRequestChannel(tile: Tile): TileRequestChannel;
   public abstract requestTileContent(tile: Tile, isCanceled: () => boolean): Promise<TileRequest.Response>;
   public abstract get maxDepth(): number;
+  public abstract get minDepth(): number;
   public abstract get priority(): TileLoadPriority;
   protected get _batchType(): BatchType { return BatchType.Primary; }
   protected get _loadEdges(): boolean { return true; }

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -128,6 +128,7 @@ export class RealityTileTree extends TileTree {
   public get rootTile(): RealityTile { return this._rootTile; }
   public get is3d() { return true; }
   public get maxDepth() { return this.loader.maxDepth; }
+  public get minDepth() { return this.loader.minDepth; }
   public get isContentUnbounded() { return this.loader.isContentUnbounded; }
   public get isTransparent() { return false; }
 

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -21,7 +21,7 @@ const scratchQuadId = new QuadId(0, 0, 0);
 /** @internal */
 export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
   private _maxDepthFromLod = 0;
-  private _minDepthFromLod = 10;   // TODO: read from capabilities
+  private _minDepthFromLod = 0;
   private _copyrightText = "Copyright";
   private _querySupported = false;
   private _tileMapSupported = false;
@@ -33,8 +33,7 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
 
   protected get _filterByCartoRange() { return false; }      // Can't trust footprint ranges (USGS Hydro)
 
-  public get minimumZoomLevel(): number { return this._minDepthFromLod; }
-
+  public get minimumZoomLevel() { return Math.max(super.minimumZoomLevel, this._minDepthFromLod); }
   public get maximumZoomLevel() { return this._maxDepthFromLod > 0 ? this._maxDepthFromLod : super.maximumZoomLevel; }
 
   public uintToString(uintArray: any) {
@@ -106,15 +105,8 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
       return undefined;
     }
   }
-  /*
-  protected _testChildAvailability(_tile: ImageryMapTile, resolveChildren: () => void) {
-    resolveChildren();
-  }
-  */
-
   protected _testChildAvailability(tile: ImageryMapTile, resolveChildren: () => void) {
-    // if (!this._tileMapSupported || tile.quadId.level < 4) {
-    if (!this._tileMapSupported || tile.quadId.level < this.minimumZoomLevel) {
+    if (!this._tileMapSupported || tile.quadId.level < Math.max(4, this.minimumZoomLevel)) {
       resolveChildren();
       return;
     }
@@ -192,6 +184,14 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
             this.cartoRange = MapCartoRectangle.createFromDegrees(layer.layerDefinition.extent.xmin, layer.layerDefinition.extent.ymin, layer.layerDefinition.extent.xmax, layer.layerDefinition.extent.ymax);
             break;
           }
+        }
+      }
+
+      // Read minLOD if available
+      if (json.minLOD !== undefined) {
+        const minLod = parseInt(json.minLOD, 10);
+        if (!Number.isNaN(minLod)) {
+          this._minDepthFromLod = minLod;
         }
       }
     }

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -96,7 +96,11 @@ export class ImageryMapTile extends RealityTile {
       const row = this.quadId.row * 2;
       const children = [];
       const childrenAreLeaves = (this.depth + 1) === imageryTree.maxDepth;
-      const childrenAreDisabled = (this.depth + 1) <= 10;   // TODO: Get the min LOD from capabilities
+
+      // If children depth is lower than min LOD, mark them as disabled.
+      // This is important: if those tiles are requested and the server refuse to serve them,
+      // they will be marked as not found and their descendant will never be displayed.
+      const childrenAreDisabled = (this.depth + 1) < imageryTree.minDepth;
       const tilingScheme = imageryTree.tilingScheme;
       for (let j = 0; j < rowCount; j++) {
         for (let i = 0; i < columnCount; i++) {
@@ -179,6 +183,7 @@ class ImageryTileLoader extends RealityTileLoader {
   }  // Prioritized fast, cached tiles first.
 
   public get maxDepth(): number { return this._imageryProvider.maximumZoomLevel; }
+  public get minDepth(): number { return this._imageryProvider.minimumZoomLevel; }
   public get priority(): TileLoadPriority { return TileLoadPriority.Map; }
   public getLogo(vp: ScreenViewport): HTMLTableRowElement | undefined { return this._imageryProvider.getLogo(vp); }
   public get maximumScreenSize(): number { return this._imageryProvider.maximumScreenSize; }

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -96,13 +96,14 @@ export class ImageryMapTile extends RealityTile {
       const row = this.quadId.row * 2;
       const children = [];
       const childrenAreLeaves = (this.depth + 1) === imageryTree.maxDepth;
+      const childrenAreDisabled = (this.depth + 1) <= 10;   // TODO: Get the min LOD from capabilities
       const tilingScheme = imageryTree.tilingScheme;
       for (let j = 0; j < rowCount; j++) {
         for (let i = 0; i < columnCount; i++) {
           const quadId = new QuadId(level, column + i, row + j);
           const rectangle = tilingScheme.tileXYToRectangle(quadId.column, quadId.row, quadId.level);
           const range = Range3d.createXYZXYZ(rectangle.low.x, rectangle.low.x, 0, rectangle.high.x, rectangle.high.y, 0);
-          const maximumSize = imageryTree.imageryLoader.maximumScreenSize;
+          const maximumSize = (childrenAreDisabled ?  0 : imageryTree.imageryLoader.maximumScreenSize);
           children.push(new ImageryMapTile({ parent: this, isLeaf: childrenAreLeaves, contentId: quadId.contentId, range, maximumSize }, imageryTree, quadId, rectangle));
         }
       }

--- a/core/frontend/src/tile/map/MapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryProvider.ts
@@ -33,7 +33,7 @@ export abstract class MapLayerImageryProvider {
 
   public get tileSize(): number { return this._usesCachedTiles ? tileImageSize : untiledImageSize; }
   public get maximumScreenSize() { return 2 * this.tileSize; }
-  public get minimumZoomLevel(): number { return 4; }
+  public get minimumZoomLevel(): number { return 0; }
   public get maximumZoomLevel(): number { return 22; }
   public get usesCachedTiles() { return this._usesCachedTiles; }
   public get mutualExclusiveSubLayer(): boolean { return false; }

--- a/core/frontend/src/tile/map/MapTileLoader.ts
+++ b/core/frontend/src/tile/map/MapTileLoader.ts
@@ -41,6 +41,7 @@ export class MapTileLoader extends RealityTileLoader {
   }
 
   public get maxDepth(): number { return this._terrainProvider.maxDepth; }
+  public get minDepth(): number { return 0;}
   public get terrainProvider(): TerrainMeshProvider { return this._terrainProvider; }
 
   public getRequestChannel(_tile: Tile) {


### PR DESCRIPTION
Some ESRI Mapserver define a minimum LOD in its capabilities.  Any tile request made for a tile on a smaller LOD, will result in a failed tile request.  In the previous implement, this would prevent the proper display of children tiles on levels inside the lod validity range (i.e. level>=minLod && level<=maxLod).

The solution is to flag as disabled tiles on LOD outside the validity range.  Disabled tiles can have visible children per definition.

To reproduce the issue, following key-in can be used:
`fdt attach arcgis maplayer https://tiles.arcgis.com/tiles/IMCZpp2qXhYVmRXp/arcgis/rest/services/Stockholm_%C3%96P_Stadsutvecklingskartan/MapServer stockholm`

Dataset is geo located in Stockholm/Sweden.

A sample BIM can be found in attachment of this [bug](https://bentleycs.visualstudio.com/DigitalCities/_workitems/edit/645784)
