### PR TITLE
Fix table column resize bug when table was created in an closed widget tab

### DIFF
--- a/common/api/summary/ui-core.exports.csv
+++ b/common/api/summary/ui-core.exports.csv
@@ -313,7 +313,7 @@ public;UnderlinedButton(props: UnderlinedButtonProps): JSX.Element
 public;UnderlinedButtonProps
 public;useDisposable
 public;useEffectSkipFirst(callback: () => (void | (() => void | undefined)) | void, deps?: any[]): void
-internal;useLayoutResizeObserver(ref: React.RefObject
+internal;useLayoutResizeObserver(inElement: HTMLElement | null, onResize?: (width?: number, height?: number) => void): (number | undefined)[]
 public;useOptionalDisposable
 internal;useProximityToMouse: (elementSet: WidgetElementSet, snap?: boolean, threshold?: number) => number
 internal;useRefEffect

--- a/common/api/ui-core.api.md
+++ b/common/api/ui-core.api.md
@@ -686,7 +686,7 @@ export const DivWithOutsideClick: {
 
 // @beta
 export function ElementResizeObserver({ watchedElement, render }: {
-    watchedElement: React.RefObject<HTMLElement>;
+    watchedElement: HTMLElement | null;
     render: (props: RenderPropsArgs) => JSX.Element;
 }): JSX.Element;
 
@@ -2597,7 +2597,7 @@ export function useDisposable<TDisposable extends IDisposable>(createDisposable:
 export function useEffectSkipFirst(callback: () => (void | (() => void | undefined)) | void, deps?: any[]): void;
 
 // @internal
-export function useLayoutResizeObserver(ref: React.RefObject<HTMLElement>, onResize?: (width?: number, height?: number) => void): (number | undefined)[];
+export function useLayoutResizeObserver(inElement: HTMLElement | null, onResize?: (width?: number, height?: number) => void): (number | undefined)[];
 
 // @public
 export function useOnOutsideClick<T extends Element>(onOutsideClick?: () => void,

--- a/common/changes/@bentley/ui-components/fixTableInWidgetResizeBug_2021-06-30-04-31.json
+++ b/common/changes/@bentley/ui-components/fixTableInWidgetResizeBug_2021-06-30-04-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Update table to pass HtmlDivElement to ElementResizeObserver.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-core/fixTableInWidgetResizeBug_2021-06-30-04-31.json
+++ b/common/changes/@bentley/ui-core/fixTableInWidgetResizeBug_2021-06-30-04-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Fix bug in ElementResizeObserver caused by using React.Ref and not an HTMLElement as a usedEffect dependency.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/fixTableInWidgetResizeBug_2021-06-30-04-31.json
+++ b/common/changes/@bentley/ui-framework/fixTableInWidgetResizeBug_2021-06-30-04-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Update component to pass HtmlDivElement to ElementResizeObserver.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/components/src/test/breadcrumb/breadcrumbdetails/BreadcrumbDetails.test.tsx
+++ b/ui/components/src/test/breadcrumb/breadcrumbdetails/BreadcrumbDetails.test.tsx
@@ -13,20 +13,37 @@ import { ImmediatelyLoadedTreeNodeItem, TreeNodeItem } from "../../../ui-compone
 import { waitForUpdate } from "../../test-helpers/misc";
 import TestUtils from "../../TestUtils";
 import { mockInterfaceTreeDataProvider, mockRawTreeDataProvider } from "../mockTreeDataProvider";
+import { createDOMRect } from "../../Utils";
 
 /* eslint-disable deprecation/deprecation */
 
 describe("BreadcrumbDetails", () => {
   let renderSpy: sinon.SinonSpy;
   let renderedComponent: RenderResult;
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+    sinon.restore();
+  });
 
   before(async () => {
+    sinon.restore();
     await TestUtils.initializeUiComponents();
   });
 
+  after(() => {
+    TestUtils.terminateUiComponents();
+  });
+
   beforeEach(() => {
-    sinon.restore();
     renderSpy = sinon.spy();
+    sandbox.stub(Element.prototype, "getBoundingClientRect").callsFake(function (this: HTMLElement) {
+      if (this.classList.contains("react-grid-Container")) {
+        return createDOMRect({ width: 400, height: 500 });
+      }
+      return createDOMRect();
+    });
   });
 
   afterEach(cleanup);
@@ -55,7 +72,7 @@ describe("BreadcrumbDetails", () => {
     it("should update path to child", async () => {
       const path = new BreadcrumbPath(mockRawTreeDataProvider);
       path.setCurrentNode(undefined);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 12);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 13);
       const node = mockRawTreeDataProvider[1];
       expect(await waitForElement(() => renderedComponent.getByText(getPropertyRecordAsString(node.label)))).to.exist;
     });
@@ -63,14 +80,14 @@ describe("BreadcrumbDetails", () => {
     it("should render when node is defined", async () => {
       const path = new BreadcrumbPath(mockRawTreeDataProvider);
       path.setCurrentNode(mockRawTreeDataProvider[1]);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 9);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 10);
       const node = mockRawTreeDataProvider[1].children![0];
       expect(await waitForElement(() => renderedComponent.getByText(getPropertyRecordAsString(node.label)))).to.exist;
     });
 
     it("should change path", async () => {
       const path1 = new BreadcrumbPath(mockRawTreeDataProvider);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path1} />), renderSpy, 12);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path1} />), renderSpy, 13);
       const path2 = new BreadcrumbPath(mockRawTreeDataProvider);
       await waitForUpdate(() => renderedComponent.rerender(<BreadcrumbDetails onRender={renderSpy} path={path2} />), renderSpy, 2);
     });
@@ -95,7 +112,7 @@ describe("BreadcrumbDetails", () => {
 
     it("rerenders when currentNode is set to undefined", async () => {
       const path = new BreadcrumbPath(mockInterfaceTreeDataProvider);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 7);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 8);
       renderSpy.resetHistory();
       path.setCurrentNode(undefined);
       expect(renderSpy).to.have.been.called;
@@ -104,7 +121,7 @@ describe("BreadcrumbDetails", () => {
     it("rerenders when currentNode is set to node", async () => {
       const node = (await mockInterfaceTreeDataProvider.getNodes())[0];
       const path = new BreadcrumbPath(mockInterfaceTreeDataProvider);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 7);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 8);
       renderSpy.resetHistory();
       path.setCurrentNode(node);
       expect(renderSpy).to.have.been.called;
@@ -113,7 +130,7 @@ describe("BreadcrumbDetails", () => {
     it("pops a tree level when currentNode is set to node without children", async () => {
       const node = mockRawTreeDataProvider[1].children![1];
       const path = new BreadcrumbPath(mockRawTreeDataProvider);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 12);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 13);
       renderSpy.resetHistory();
       path.setCurrentNode(node);
       expect(renderSpy).to.have.been.called;
@@ -122,7 +139,7 @@ describe("BreadcrumbDetails", () => {
     it("pops a tree level to a non root node when currentNode is set to a deep node without children", async () => {
       const node = (mockRawTreeDataProvider[1].children![0] as ImmediatelyLoadedTreeNodeItem).children![0];
       const path = new BreadcrumbPath(mockRawTreeDataProvider);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 12);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 13);
       renderSpy.resetHistory();
       path.setCurrentNode(node);
       expect(renderSpy).to.have.been.called;
@@ -133,7 +150,7 @@ describe("BreadcrumbDetails", () => {
       const path = new BreadcrumbPath(mockRawTreeDataProvider);
       const pathUpdateSpy = sinon.stub();
       path.BreadcrumbUpdateEvent.addListener(pathUpdateSpy);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 12);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 13);
       const listRow = renderedComponent.getByText(getPropertyRecordAsString(node.label));
       const event = new MouseEvent("click", { bubbles: true });
       await waitForUpdate(() => listRow.dispatchEvent(event), pathUpdateSpy, 1);
@@ -143,7 +160,7 @@ describe("BreadcrumbDetails", () => {
     describe("Interface DataProvider", () => {
       it("rerenders when `onTreeNodeChanged` is broadcasted with undefined", async () => {
         const path = new BreadcrumbPath(mockInterfaceTreeDataProvider);
-        await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 7);
+        await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 8);
         renderSpy.resetHistory();
         mockInterfaceTreeDataProvider.onTreeNodeChanged.raiseEvent([undefined]);
         expect(renderSpy).to.have.been.called;
@@ -153,7 +170,7 @@ describe("BreadcrumbDetails", () => {
         const node = (await mockInterfaceTreeDataProvider.getNodes())[0];
         const path = new BreadcrumbPath(mockInterfaceTreeDataProvider);
         path.setCurrentNode(node);
-        await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 7);
+        await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} />), renderSpy, 8);
         renderSpy.resetHistory();
         mockInterfaceTreeDataProvider.onTreeNodeChanged.raiseEvent([node]);
         expect(renderSpy).to.have.been.called;
@@ -164,7 +181,7 @@ describe("BreadcrumbDetails", () => {
     it("should call onRootNodesLoaded correctly", async () => {
       const onRootNodesLoadedSpy = sinon.spy();
       const path = new BreadcrumbPath(mockRawTreeDataProvider);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} onRootNodesLoaded={onRootNodesLoadedSpy} />), renderSpy, 12);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} onRootNodesLoaded={onRootNodesLoadedSpy} />), renderSpy, 13);
       expect(onRootNodesLoadedSpy).to.have.been.calledOnce;
     });
     it("should call onChildrenLoaded correctly", async () => {
@@ -172,7 +189,7 @@ describe("BreadcrumbDetails", () => {
       const node = (await mockInterfaceTreeDataProvider.getNodes())[0];
       const path = new BreadcrumbPath(mockInterfaceTreeDataProvider);
       path.setCurrentNode(node);
-      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} onChildrenLoaded={onChildrenLoadedSpy} />), renderSpy, 7);
+      await waitForUpdate(() => renderedComponent = render(<BreadcrumbDetails onRender={renderSpy} path={path} onChildrenLoaded={onChildrenLoadedSpy} />), renderSpy, 8);
       expect(onChildrenLoadedSpy).to.have.have.callCount(3);
     });
   });

--- a/ui/components/src/ui-components/lineweight/WeightPickerButton.tsx
+++ b/ui/components/src/ui-components/lineweight/WeightPickerButton.tsx
@@ -41,6 +41,7 @@ export interface WeightPickerProps extends React.ButtonHTMLAttributes<HTMLButton
 /** @internal */
 interface WeightPickerState {
   showPopup: boolean;
+  targetElement: HTMLDivElement | null;
 }
 
 /** WeightPickerButton component
@@ -55,7 +56,7 @@ export class WeightPickerButton extends React.PureComponent<WeightPickerProps, W
   constructor(props: WeightPickerProps) {
     super(props);
 
-    this.state = { showPopup: false };
+    this.state = { showPopup: false, targetElement: null };
   }
 
   public setFocus(): void {
@@ -88,6 +89,7 @@ export class WeightPickerButton extends React.PureComponent<WeightPickerProps, W
   public componentDidMount() {
     // eslint-disable-next-line no-console
     // console.log(`WeightPickerButton.componentDidMount focusRef=${this._focusTarget && this._focusTarget.current ? "set" : "unset"}`);
+    this.setState({ targetElement: this._target.current });
   }
 
   private buildIdForWeight(weight: number): string {
@@ -207,7 +209,7 @@ export class WeightPickerButton extends React.PureComponent<WeightPickerProps, W
             aria-expanded={this.state.showPopup}
             onClick={this._togglePopup} />
         </div>
-        <ElementResizeObserver watchedElement={this._target} render=
+        <ElementResizeObserver watchedElement={this.state.targetElement} render=
           {({ width }) => (
             <Popup
               className="components-weightpicker-popup"
@@ -220,7 +222,7 @@ export class WeightPickerButton extends React.PureComponent<WeightPickerProps, W
               onOpen={this._onPopupOpened}
               focusTarget={`#${this.buildIdForWeight(this.props.activeWeight)}`}
               moveFocus={true}
-              target={this._target.current}
+              target={this.state.targetElement}
               closeOnNestedPopupOutsideClick
             >
               {this.renderPopup(this.props.dropDownTitle)}

--- a/ui/components/src/ui-components/table/component/Table.tsx
+++ b/ui/components/src/ui-components/table/component/Table.tsx
@@ -239,6 +239,7 @@ interface TableState {
   keyboardEditorCellKey?: string;
   // TODO: Enable, when table gets refactored
   // popup?: PropertyPopupState;
+  gridContainer: HTMLDivElement | null;
 }
 
 const initialState: TableState = {
@@ -250,6 +251,7 @@ const initialState: TableState = {
   menuVisible: false,
   menuX: 0,
   menuY: 0,
+  gridContainer: null,
 };
 
 interface CellKey {
@@ -428,6 +430,8 @@ export class Table extends React.Component<TableProps, TableState> {
 
   /** @internal */
   public componentDidMount() {
+    let gridContainer: HTMLDivElement | null = null;
+
     this._isMounted = true;
 
     // The previously used ReactResizeDetector, which does not work in popout/child windows, used deprecated React.findDomNode
@@ -435,11 +439,12 @@ export class Table extends React.Component<TableProps, TableState> {
     // same HTMLDivElement from grid as was used previously by ReactResizeDetector.
     if (this._gridRef.current) {
       const grid = this._gridRef.current as any;
-      // hack force the _gridContainerRef to hold the proper DOM node
-      (this._gridContainerRef as React.MutableRefObject<HTMLDivElement | null>).current = grid.getDataGridDOMNode();
+      gridContainer = grid.getDataGridDOMNode();
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.update();
+    this.setState({ gridContainer }, () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.update();
+    });
   }
 
   /** @internal */
@@ -1225,6 +1230,7 @@ export class Table extends React.Component<TableProps, TableState> {
 
   private _createRowRenderer = () => {
     return (props: { row: RowProps, [k: string]: React.ReactNode }) => {
+      // istanbul ignore next
       const renderRow = this.props.renderRow ? this.props.renderRow : this.renderRow;
       const { row: rowProps, ...reactDataGridRowProps } = props;
       if (this._tableSelectionTarget === TableSelectionTarget.Row) {
@@ -1700,7 +1706,7 @@ export class Table extends React.Component<TableProps, TableState> {
               onClose={this._hideContextMenu}
               onShowHideChange={this._handleShowHideChange} />
           }
-          <ElementResizeObserver watchedElement={this._gridContainerRef}
+          <ElementResizeObserver watchedElement={this.state.gridContainer}
             render={({ width, height }) => (
               <ReactDataGrid
                 ref={this._gridRef}

--- a/ui/components/src/ui-components/timeline/SolarTimeline.tsx
+++ b/ui/components/src/ui-components/timeline/SolarTimeline.tsx
@@ -198,6 +198,7 @@ interface TimelineProps extends CommonProps {
 interface TimelineState {
   sunriseTooltipTarget: HTMLSpanElement | undefined;
   sunsetTooltipTarget: HTMLSpanElement | undefined;
+  timelineElement: HTMLDivElement | null;
 }
 
 class Timeline extends React.PureComponent<TimelineProps, TimelineState> {
@@ -205,6 +206,7 @@ class Timeline extends React.PureComponent<TimelineProps, TimelineState> {
   public readonly state = {
     sunriseTooltipTarget: undefined,
     sunsetTooltipTarget: undefined,
+    timelineElement: null,
   };
 
   private _getTickValues = (width: number) => {
@@ -235,6 +237,11 @@ class Timeline extends React.PureComponent<TimelineProps, TimelineState> {
     });
   };
 
+  /** @internal */
+  public componentDidMount() {
+    this.setState({ timelineElement: this._timelineRef.current });
+  }
+
   public render() {
     const { formatTick, formatTime, onChange, onUpdate, dayStartMs, sunSetOffsetMs, sunRiseOffsetMs, currentTimeOffsetMs } = this.props;
     const domain = [0, millisecPerDay];
@@ -252,7 +259,7 @@ class Timeline extends React.PureComponent<TimelineProps, TimelineState> {
           </Tooltip>
         </span>
         <div ref={this._timelineRef} className="ui-component-solar-slider-sizer">
-          <ElementResizeObserver watchedElement={this._timelineRef}
+          <ElementResizeObserver watchedElement={this.state.timelineElement}
             render={({ width }) => (
               <Slider
                 mode={(curr, next) => {
@@ -678,7 +685,7 @@ export class SolarTimeline extends React.PureComponent<SolarTimelineComponentPro
       width: `100%`,
       height: `100%`,
     };
-    const expandMinimizeLabel = isExpanded ? this._minimizeLabel : this._expandLabel;
+    const expandMinimizeLabel = isExpanded ? this._expandLabel : this._minimizeLabel;
 
     return (
       <div className={classnames("solar-timeline-wrapper", isExpanded && "expanded")} >

--- a/ui/core/src/test/utils/hooks/useResizeObserver.test.tsx
+++ b/ui/core/src/test/utils/hooks/useResizeObserver.test.tsx
@@ -156,7 +156,7 @@ describe("useLayoutResizeObserver", () => {
 
   const ResizableContainerObserverNoChildren = () => {
     // initial values are not used since size is faked below and value should come from initial layout in 'sizer' container
-    const [observedBounds, setObservedBounds] = React.useState({ width: 0, height: 0 });
+    const [, setObservedBounds] = React.useState({ width: 0, height: 0 });
     const onResize = React.useCallback((width: number, height: number) => {
       setObservedBounds({ width, height });
     }, []);
@@ -263,17 +263,13 @@ describe("useLayoutResizeObserver", () => {
   });
 
   it("ResizableContainerObserver - should call onResize (width and height)", async () => {
-    const resizeObserverSpy = sandbox.spy(ResizeObserverModule, "ResizeObserver");
     boundingClientRect = size_100_50;
 
     const wrapper = render(<ResizableContainerObserverNoChildren />);
     await TestUtils.flushAsyncOperations();
 
     const container = wrapper.container.querySelector("div.uicore-resizable-container") as HTMLDivElement;
-    expect(container!.style.display).to.be.eql("none");
+    expect(container.style.display).to.be.eql("none");
     wrapper.unmount();
   });
-
-
 });
-

--- a/ui/core/src/test/utils/hooks/useResizeObserver.test.tsx
+++ b/ui/core/src/test/utils/hooks/useResizeObserver.test.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import * as sinon from "sinon";
 import { act, renderHook } from "@testing-library/react-hooks";
 import * as ResizeObserverModule from "../../../ui-core/utils/hooks/ResizeObserverPolyfill";
-import { ElementResizeObserver, ResizableContainerObserver, useLayoutResizeObserver, useResizeObserver } from "../../../ui-core/utils/hooks/useResizeObserver";
+import { ElementResizeObserver, ResizableContainerObserver, useResizeObserver } from "../../../ui-core/utils/hooks/useResizeObserver";
 import { createDOMRect } from "../../Utils";
 import TestUtils from "../../TestUtils";
 import { render } from "@testing-library/react";
@@ -130,56 +130,60 @@ describe("useResizeObserver", () => {
 });
 
 describe("useLayoutResizeObserver", () => {
-  const Tester = () => {
-    const containerRef = React.useRef<HTMLDivElement>(null);
-    const [width, height] = useLayoutResizeObserver(containerRef);
+  const size_0_0 = createDOMRect({ width: 0, height: 0 });
+  const size_100_50 = createDOMRect({ width: 100, height: 50 });
+  const size_300_100 = createDOMRect({ width: 300, height: 100 });
+  let boundingClientRect = size_0_0;
+  stubRaf();
+  const sandbox = sinon.createSandbox();
+
+  const ResizableContainerObserverTester = () => {
+    // initial values are not used since size is faked below and value should come from initial layout in 'sizer' container
+    const [observedBounds, setObservedBounds] = React.useState({ width: 0, height: 0 });
+    const onResize = React.useCallback((width: number, height: number) => {
+      setObservedBounds({ width, height });
+    }, []);
+
     return (
-      <div data-testid="sizer" ref={containerRef} className="sizer">
-        <span data-testid="width">{width ?? 0}</span>
-        <span data-testid="height">{height ?? 0}</span>
+      <div data-testid="sizer" className="sizer">
+        <ResizableContainerObserver onResize={onResize}>
+          <span data-testid="width">{observedBounds.width}</span>
+          <span data-testid="height">{observedBounds.height}</span>
+        </ResizableContainerObserver>
       </div>
     );
   };
 
-  stubRaf();
-  const sandbox = sinon.createSandbox();
+  const ResizableContainerObserverNoChildren = () => {
+    // initial values are not used since size is faked below and value should come from initial layout in 'sizer' container
+    const [observedBounds, setObservedBounds] = React.useState({ width: 0, height: 0 });
+    const onResize = React.useCallback((width: number, height: number) => {
+      setObservedBounds({ width, height });
+    }, []);
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("should call onResize (width and height)", async () => {
-    const resizeObserverSpy = sandbox.spy(ResizeObserverModule, "ResizeObserver");
-    const wrapper = render(<Tester />);
-    expect(wrapper.getByTestId("width").textContent).to.eql("0");
-    expect(wrapper.getByTestId("height").textContent).to.eql("0");
-    const container = wrapper.getByTestId("sizer");
-    sinon.stub(container, "getBoundingClientRect").returns(createDOMRect({ width: 300, height: 100 }));
-    // Call the ResizeObserver callback.
-    resizeObserverSpy.firstCall.args[0]([{
-      contentRect: createDOMRect({ width: 300, height: 100 }), // not used - we call getBoundingClientRect in resize function
-      target: container,
-    }], resizeObserverSpy.firstCall.returnValue);
-    await TestUtils.flushAsyncOperations();
-    expect(wrapper.getByTestId("width").textContent).to.eql("300");
-    expect(wrapper.getByTestId("height").textContent).to.eql("100");
-    wrapper.unmount();
-  });
-});
-
-describe("ElementResizeObserver", () => {
-  stubRaf();
-  const sandbox = sinon.createSandbox();
-
-  afterEach(() => {
-    sandbox.restore();
-  });
+    return (
+      <div data-testid="sizer" className="sizer">
+        <ResizableContainerObserver onResize={onResize}>
+        </ResizableContainerObserver>
+      </div>
+    );
+  };
 
   const ElementResizeObserverTester = () => {
     const containerRef = React.useRef<HTMLDivElement>(null);
+    const [containerElement, setContainerElement] = React.useState<HTMLDivElement | null>(null);
+    const isMountedRef = React.useRef(false);
+
+    React.useEffect(() => {
+      if (!isMountedRef.current && containerRef.current) {
+        isMountedRef.current = true;
+        setContainerElement(containerRef.current);
+      }
+    }, []);
+
     return (
       <div data-testid="sizer" ref={containerRef} className="sizer">
-        <ElementResizeObserver watchedElement={containerRef} render=
+        <ElementResizeObserver watchedElement={containerElement} render=
           {({ width, height }) => (
             <>
               <span data-testid="width">{width ?? 0}</span>
@@ -191,72 +195,48 @@ describe("ElementResizeObserver", () => {
     );
   };
 
-  it("should call onResize (width and height)", async () => {
-    const resizeObserverSpy = sandbox.spy(ResizeObserverModule, "ResizeObserver");
-    let isFirstCall = true;
+  beforeEach(() => {
+    boundingClientRect = size_0_0;
+
     sandbox.stub(Element.prototype, "getBoundingClientRect").callsFake(function (this: HTMLElement) {
-      if (this.classList.contains("sizer")) {
-        if (isFirstCall) {
-          isFirstCall = false;
-          return createDOMRect({ width: 100, height: 50 });
-        }
-        return createDOMRect({ width: 300, height: 100 });
+      if (this.classList.contains("sizer") || this.classList.contains("uicore-resizable-container")) {
+        return boundingClientRect;
       }
       return createDOMRect();
     });
-
-    const wrapper = render(<ElementResizeObserverTester />);
-    expect(wrapper.getByTestId("width").textContent).to.eql("100");
-    expect(wrapper.getByTestId("height").textContent).to.eql("50");
-    const container = wrapper.getByTestId("sizer");
-    resizeObserverSpy.firstCall.args[0]([{
-      contentRect: createDOMRect({ width: 300, height: 100 }), // not used - we call getBoundingClientRect in resize function
-      target: container,
-    }], resizeObserverSpy.firstCall.returnValue);
-    await TestUtils.flushAsyncOperations();
-    expect(wrapper.getByTestId("width").textContent).to.eql("300");
-    expect(wrapper.getByTestId("height").textContent).to.eql("100");
-    wrapper.unmount();
   });
-});
-
-describe("ResizableContainerObserver", () => {
-  stubRaf();
-  const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  const ResizableContainerObserverTester = () => {
-    // initial values are not used since size is faked below and value should come from initial layout in 'sizer' container
-    const [observedBounds, setObservedBounds] = React.useState({ width: 0, height: 0 });
-    const onResize = React.useCallback((width: number, height: number) => {
-      setObservedBounds({ width, height });
-    }, []);
-
-    return (
-      <div data-testid="sizer" className="sizer">
-        <ResizableContainerObserver onResize={onResize} >
-          <span data-testid="width">{observedBounds.width}</span>
-          <span data-testid="height">{observedBounds.height}</span>
-        </ResizableContainerObserver>
-      </div>
-    );
-  };
-
-  it("should call onResize (width and height)", async () => {
+  it("ElementResizeObserver - should call onResize (width and height)", async () => {
     const resizeObserverSpy = sandbox.spy(ResizeObserverModule, "ResizeObserver");
-    let useFirstSize = true;
-    sandbox.stub(Element.prototype, "getBoundingClientRect").callsFake(function (this: HTMLElement) {
-      if (this.classList.contains("sizer") || this.classList.contains("uicore-resizable-container")) {
-        if (useFirstSize) {
-          return createDOMRect({ width: 100, height: 50 });
-        }
-        return createDOMRect({ width: 100, height: 200 });
-      }
-      return createDOMRect();
-    });
+    boundingClientRect = size_100_50;
+
+    const wrapper = render(<ElementResizeObserverTester />);
+    await TestUtils.flushAsyncOperations();
+
+    expect(wrapper.getByTestId("width").textContent).to.eql("100");
+    expect(wrapper.getByTestId("height").textContent).to.eql("50");
+    const container = wrapper.getByTestId("sizer");
+
+    boundingClientRect = size_300_100;
+    // Call the ResizeObserver callback.
+    resizeObserverSpy.firstCall.args[0]([{
+      contentRect: createDOMRect({ width: 300, height: 100 }), // we ignore this in hook and just get size from getBoundingClientRect method.
+      target: container,
+    }], resizeObserverSpy.firstCall.returnValue);
+    await TestUtils.flushAsyncOperations();
+
+    expect(wrapper.getByTestId("width").textContent).to.eql("300");
+    expect(wrapper.getByTestId("height").textContent).to.eql("100");
+    wrapper.unmount();
+  });
+
+  it("ResizableContainerObserver - should call onResize (width and height)", async () => {
+    const resizeObserverSpy = sandbox.spy(ResizeObserverModule, "ResizeObserver");
+    boundingClientRect = size_100_50;
 
     const wrapper = render(<ResizableContainerObserverTester />);
     await TestUtils.flushAsyncOperations();
@@ -267,27 +247,33 @@ describe("ResizableContainerObserver", () => {
     expect(container).to.not.be.null;
     await TestUtils.flushAsyncOperations();
 
+    boundingClientRect = size_300_100;
+    // Call the ResizeObserver callback.
     resizeObserverSpy.firstCall.args[0]([{
-      contentRect: createDOMRect({ width: 100, height: 50 }), // not used - we call getBoundingClientRect in resize function
+      contentRect: createDOMRect({ width: 300, height: 100 }), // we ignore this in hook and just get size from getBoundingClientRect method.
       target: container,
     }], resizeObserverSpy.firstCall.returnValue);
-
-    await TestUtils.flushAsyncOperations();
-    expect(wrapper.getByTestId("width").textContent).to.eql("100");
-    expect(wrapper.getByTestId("height").textContent).to.eql("50");
-
-    await TestUtils.flushAsyncOperations();
-    useFirstSize = false;
-    resizeObserverSpy.secondCall.args[0]([{
-      contentRect: createDOMRect({ width: 100, height: 200 }), // not used - we call getBoundingClientRect in resize function
-      target: container,
-    }], resizeObserverSpy.secondCall.returnValue);
     await TestUtils.flushAsyncOperations();
 
-    expect(wrapper.getByTestId("width").textContent).to.eql("100");
-    expect(wrapper.getByTestId("height").textContent).to.eql("200");
+    await TestUtils.flushAsyncOperations();
+    expect(wrapper.getByTestId("width").textContent).to.eql("300");
+    expect(wrapper.getByTestId("height").textContent).to.eql("100");
 
     wrapper.unmount();
   });
+
+  it("ResizableContainerObserver - should call onResize (width and height)", async () => {
+    const resizeObserverSpy = sandbox.spy(ResizeObserverModule, "ResizeObserver");
+    boundingClientRect = size_100_50;
+
+    const wrapper = render(<ResizableContainerObserverNoChildren />);
+    await TestUtils.flushAsyncOperations();
+
+    const container = wrapper.container.querySelector("div.uicore-resizable-container") as HTMLDivElement;
+    expect(container!.style.display).to.be.eql("none");
+    wrapper.unmount();
+  });
+
+
 });
 

--- a/ui/core/src/ui-core/utils/hooks/useResizeObserver.tsx
+++ b/ui/core/src/ui-core/utils/hooks/useResizeObserver.tsx
@@ -78,7 +78,7 @@ export function useResizeObserver<T extends Element>(onResize?: (width: number, 
     }
 
     return () => {
-      instance && resizeObserver.current && resizeObserver.current.unobserve(instance);
+      instance && resizeObserver.current!.unobserve(instance);
       resizeObserver.current = null;
     };
   }, [handleResize, onResize]);
@@ -101,8 +101,10 @@ export function useResizeObserver<T extends Element>(onResize?: (width: number, 
  * handles observing element in pop-out/child windows.
   * @internal
   */
-export function useLayoutResizeObserver(ref: React.RefObject<HTMLElement>, onResize?: (width?: number, height?: number) => void) {
-  const [bounds, setBounds] = React.useState<{ width?: number, height?: number }>({});
+export function useLayoutResizeObserver(inElement: HTMLElement | null, onResize?: (width?: number, height?: number) => void) {
+  const inBoundingRect = inElement?.getBoundingClientRect();
+  const [bounds, setBounds] = React.useState<{ width?: number, height?: number }>({ width: inBoundingRect?.width, height: inBoundingRect?.height });
+  const [watchedElement, setWatchedElement] = React.useState(inElement);
   const resizeObserver = React.useRef<ResizeObserver | null>(null);
   const rafRef = React.useRef(0);  // set to non-zero when requestAnimationFrame processing is active
   const isMountedRef = React.useRef(false);
@@ -119,13 +121,13 @@ export function useLayoutResizeObserver(ref: React.RefObject<HTMLElement>, onRes
 
   React.useEffect(() => {
     isMountedRef.current = true;
-    // istanbul ignore else
-    if (ref.current) {
-      const newBounds = ref.current.getBoundingClientRect();
-      if (newBounds.width || newBounds.height) {
-        onResize && onResize(newBounds.width, newBounds.height);
-        setBounds(newBounds);
-      }
+    setWatchedElement(inElement);
+
+    // istanbul ignore next
+    if (inElement) {
+      const newBounds = inElement.getBoundingClientRect();
+      onResize && onResize(newBounds.width, newBounds.height);
+      setBounds(newBounds);
     }
 
     return () => {
@@ -133,11 +135,11 @@ export function useLayoutResizeObserver(ref: React.RefObject<HTMLElement>, onRes
       (rafRef.current && owningWindowRef.current) && owningWindowRef.current.cancelAnimationFrame(rafRef.current);
       owningWindowRef.current && owningWindowRef.current.removeEventListener("beforeunload", resizeObserverCleanup);
     };
-  }, [onResize, ref]);
+  }, [onResize, inElement]);
 
   const processResize = React.useCallback((target: HTMLElement) => {
     const newBounds = target.getBoundingClientRect();
-    // istanbul ignore else
+    // istanbul ignore next
     if (isMountedRef.current && (bounds.width !== newBounds.width || bounds.height !== newBounds.height)) {
       onResize && onResize(newBounds.width, newBounds.height);
       setBounds(newBounds);
@@ -166,17 +168,17 @@ export function useLayoutResizeObserver(ref: React.RefObject<HTMLElement>, onRes
   }, [processResize]);
 
   React.useLayoutEffect(() => {
-    if (!ref.current) {
+    if (!watchedElement) {
       return;
     }
     resizeObserver.current = new ResizeObserver(handleResize);
-    resizeObserver.current.observe(ref.current);
+    resizeObserver.current.observe(watchedElement);
     return () => {
       // istanbul ignore next
       resizeObserver.current?.disconnect();
       resizeObserver.current = null;
     };
-  }, [handleResize, ref]);
+  }, [handleResize, watchedElement]);
 
   return [bounds.width, bounds.height];
 }
@@ -192,7 +194,7 @@ export interface RenderPropsArgs {
  * observing element in pop-out/child windows.
  *  @beta
  */
-export function ElementResizeObserver({ watchedElement, render }: { watchedElement: React.RefObject<HTMLElement>, render: (props: RenderPropsArgs) => JSX.Element }) {
+export function ElementResizeObserver({ watchedElement, render }: { watchedElement: HTMLElement | null, render: (props: RenderPropsArgs) => JSX.Element }) {
   const [width, height] = useLayoutResizeObserver(watchedElement);
   return render({ width, height });
 }
@@ -202,16 +204,29 @@ export function ElementResizeObserver({ watchedElement, render }: { watchedEleme
  * @beta */
 export function ResizableContainerObserver({ onResize, children }: { onResize: (width: number, height: number) => void, children?: React.ReactNode }) {
   const containerRef = React.useRef<HTMLDivElement>(null);  // set to non-zero when requestAnimationFrame processing is active
+  const [containerElement, setContainerElement] = React.useState<HTMLDivElement | null>(null);
+  const isMountedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    // istanbul ignore next
+    if (!isMountedRef.current && containerRef.current) {
+      isMountedRef.current = true;
+      setContainerElement(containerRef.current);
+    }
+  }, []);
 
   const processResize = React.useCallback((width?: number, height?: number) => {
     // istanbul ignore next
     onResize(width ?? 0, height ?? 0);
   }, [onResize]);
 
-  useLayoutResizeObserver(containerRef, processResize);
+  useLayoutResizeObserver(containerElement, processResize);
+  const hasChildren = React.Children.count(children) !== 0;
+  const style: React.CSSProperties = hasChildren ? { width: "100%", height: "100%" } : { display: "none" };
+
   return (
-    <div ref={containerRef} className="uicore-resizable-container" style={{ width: "100%", height: "100%" }}>
-      {!!children && children}
+    <div ref={containerRef} className="uicore-resizable-container" style={style}>
+      {hasChildren && children}
     </div>
   );
 }

--- a/ui/framework/src/ui-framework/messages/StatusMessagesContainer.tsx
+++ b/ui/framework/src/ui-framework/messages/StatusMessagesContainer.tsx
@@ -34,20 +34,30 @@ export interface StatusMessagesContainerProps {
  * @internal
  */
 export function StatusMessagesContainer(props: StatusMessagesContainerProps) {
+  const [containerElement, setContainerElement] = React.useState<HTMLDivElement | null>(null);
+  const isMountedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!isMountedRef.current && containerRef.current) {
+      isMountedRef.current = true;
+      setContainerElement(containerRef.current);
+    }
+  }, []);
+
   const messages = props.messages;
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const [, height] = useLayoutResizeObserver(containerRef);
+  const [, height] = useLayoutResizeObserver(containerElement);
   const [addScroll, setAddScroll] = React.useState(false);
 
   React.useLayoutEffect(() => {
     // istanbul ignore else
-    if (containerRef.current) {
+    if (containerElement) {
       // istanbul ignore next
-      const windowHeight = containerRef.current.ownerDocument.defaultView?.innerHeight ?? 800;
+      const windowHeight = containerElement.ownerDocument.defaultView?.innerHeight ?? 800;
       const maxHeight = Math.floor(windowHeight * .66);
       setAddScroll((height ?? 0) >= maxHeight);
     }
-  }, [height]);
+  }, [height, containerElement]);
 
   if (!(props.activityMessageInfo && props.isActivityMessageVisible) && props.messages.length === 0)
     return null;


### PR DESCRIPTION
- Fixed useLayoutResizeObserver by requiring an HTMLElement and not a React reference
- Update test to set up Element.getBoundingClientRect to provide container sizes used by resize hooks.
- Update uses of ResizableContainerObserver to pass element instead of Ref.