### PR TITLE
Update ResizableContainerObserver to allow monitoring parent resizing

### DIFF
--- a/common/api/summary/ui-core.exports.csv
+++ b/common/api/summary/ui-core.exports.csv
@@ -62,7 +62,7 @@ public;DisabledText(props: TextProps): JSX.Element
 public;Div(props: DivProps): JSX.Element
 public;DivProps 
 public;DivWithOutsideClick:
-beta;ElementResizeObserver({ watchedElement, render }:
+public;ElementResizeObserver({ watchedElement, render }:
 public;ElementSeparator: (props: ElementSeparatorProps) => JSX.Element
 public;ElementSeparatorProps 
 public;ExecuteHandler = (this: void) => void
@@ -227,8 +227,8 @@ internal;ReactStepFunctionProp = number | ((component: ReactNumericInput, direct
 deprecated;ReactStepFunctionProp = number | ((component: ReactNumericInput, direction: string) => number | undefined)
 internal;Rectangle 
 public;RectangleProps
-beta;RenderPropsArgs
-beta;ResizableContainerObserver({ onResize, children }:
+public;RenderPropsArgs
+public;ResizableContainerObserver({ onResize, children }:
 internal;ResizeObserver: ResizeObserverType
 internal;ResizeObserverType = typeof import("resize-observer-polyfill").default
 beta;ScrollPositionMaintainer 

--- a/common/api/ui-core.api.md
+++ b/common/api/ui-core.api.md
@@ -684,7 +684,7 @@ export const DivWithOutsideClick: {
     contextType?: React.Context<any> | undefined;
 };
 
-// @beta
+// @public
 export function ElementResizeObserver({ watchedElement, render }: {
     watchedElement: HTMLElement | null;
     render: (props: RenderPropsArgs) => JSX.Element;
@@ -1855,7 +1855,7 @@ export interface RectangleProps {
     readonly top: number;
 }
 
-// @beta
+// @public
 export interface RenderPropsArgs {
     // (undocumented)
     height?: number;
@@ -1863,7 +1863,7 @@ export interface RenderPropsArgs {
     width?: number;
 }
 
-// @beta
+// @public
 export function ResizableContainerObserver({ onResize, children }: {
     onResize: (width: number, height: number) => void;
     children?: React.ReactNode;

--- a/common/changes/@bentley/ui-core/updateResizableContainerObserverToAllowMonitoringParent_2021-07-01-11-38.json
+++ b/common/changes/@bentley/ui-core/updateResizableContainerObserverToAllowMonitoringParent_2021-07-01-11-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Update ResizableContainerObserver to monitor parent size if no children are specified.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}


### PR DESCRIPTION
Updates to support following class-based component scenario.
```tsx
      <div className="component-parent-container">
         <div className="component-sibling" />
         <ResizableContainerObserver onResize={this._onResize} />
      </div>
```
This allows the ResizableContainerObserver to call the components _onResize method when the size of the parent div changes.