### PR TITLE
Presentation: Do not initialize UpdatesTracker if IPC host is not available

### DIFF
--- a/common/changes/@bentley/presentation-backend/presentation-do-not-initialize-UpdatesTracker-if-ipc-unavailable_2021-07-01-13-20.json
+++ b/common/changes/@bentley/presentation-backend/presentation-do-not-initialize-UpdatesTracker-if-ipc-unavailable_2021-07-01-13-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Do not initialize UpdatesTracker if IPC host is not available. Fixes a problem of presentation manager trying to use IPC after changes to the iModel are made.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -356,16 +356,13 @@ export class PresentationManager {
 
     this._isOneFrontendPerBackend = IpcHost.isValid;
 
-    // TODO: updates tracker should only be created for native app backends, but that's a breaking
-    // change - make it when moving to 3.0
-    if (isChangeTrackingEnabled) {
-      this._updatesTracker = UpdatesTracker.create({
-        nativePlatformGetter: this.getNativePlatform,
-        pollInterval: props!.updatesPollInterval!, // set if `isChangeTrackingEnabled == true`
-      });
-    }
-
     if (IpcHost.isValid) {
+      if (isChangeTrackingEnabled) {
+        this._updatesTracker = UpdatesTracker.create({
+          nativePlatformGetter: this.getNativePlatform,
+          pollInterval: props!.updatesPollInterval!,
+        });
+      }
       this._disposeIpcHandler = PresentationIpcHandler.register();
     }
   }

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -44,6 +44,7 @@ import { UpdatesTracker } from "../presentation-backend/UpdatesTracker";
 import { WithClientRequestContext } from "../presentation-backend/Utils";
 
 const deepEqual = require("deep-equal"); // eslint-disable-line @typescript-eslint/no-var-requires
+
 describe("PresentationManager", () => {
 
   before(async () => {
@@ -349,7 +350,10 @@ describe("PresentationManager", () => {
         });
       });
 
-      it("creates an `UpdateTracker` when in read-write mode and `updatesPollInterval` is specified", () => {
+      it("creates an `UpdateTracker` when in read-write mode, `updatesPollInterval` is specified and IPC host is available", () => {
+        sinon.stub(IpcHost, "isValid").get(() => true);
+        sinon.stub(PresentationIpcHandler, "register").returns(() => { });
+
         const tracker = sinon.createStubInstance(UpdatesTracker) as unknown as UpdatesTracker;
         const stub = sinon.stub(UpdatesTracker, "create").returns(tracker);
         using(new PresentationManager({ addon: addon.object, mode: PresentationManagerMode.ReadWrite, updatesPollInterval: 123 }), (_) => {
@@ -357,6 +361,14 @@ describe("PresentationManager", () => {
           expect(tracker.dispose).to.not.be.called; // eslint-disable-line @typescript-eslint/unbound-method
         });
         expect(tracker.dispose).to.be.calledOnce; // eslint-disable-line @typescript-eslint/unbound-method
+      });
+
+      it("doesn't create an `UpdateTracker` when IPC host is unavailable", () => {
+        sinon.stub(IpcHost, "isValid").get(() => false);
+        const stub = sinon.stub(UpdatesTracker, "create");
+        using(new PresentationManager({ addon: addon.object, mode: PresentationManagerMode.ReadWrite, updatesPollInterval: 123 }), (_) => {
+          expect(stub).to.not.be.called;
+        });
       });
 
     });


### PR DESCRIPTION
In some backends iModels are getting modified even when IPC host is not available. Ensure that doesn't cause issues for `PresentationManager`.