### PR TITLE
Fix CopyExternalsPlugin not logging/warning for missing externals.

### DIFF
--- a/common/changes/@bentley/webpack-tools-core/fix-missing-externals_2021-07-01-16-04.json
+++ b/common/changes/@bentley/webpack-tools-core/fix-missing-externals_2021-07-01-16-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webpack-tools-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webpack-tools-core",
+  "email": "33036725+wgoehrig@users.noreply.github.com"
+}

--- a/tools/webpack-core/src/test/CopyExternalsPlugin.test.ts
+++ b/tools/webpack-core/src/test/CopyExternalsPlugin.test.ts
@@ -96,6 +96,31 @@ describe("CopyExternalsPlugin", () => {
     expect(fs.readFileSync(path.join(__dirname, "dist/node_modules/bar/index.js"), "utf8")).to.equal(`console.log("This is bar inside foo");`);
   });
 
+  it("should log when optional dependency is not installed ", async () => {
+    fsFromJson({
+      "lib/test/assets/copy-externals-plugin-test/test.js": `try { require("foo"); } catch (err) {}`,
+    });
+    testConfig = getTestConfig("assets/copy-externals-plugin-test/test.js", [new CopyExternalsPlugin()], ["foo"]);
+
+    const result = await runWebpack(testConfig);
+    expect(fs.existsSync(path.join(__dirname, "dist/node_modules/foo"))).to.be.false;
+    expect(result.logging.CopyExternalsPlugin.entries.length).to.be.equal(2);
+    expect(result.warnings.length).to.be.equal(0);
+  });
+
+  it("should warn when non-optional dependency is not installed ", async () => {
+    fsFromJson({
+      "lib/test/assets/copy-externals-plugin-test/test.js": `require("foo");`,
+    });
+    testConfig = getTestConfig("assets/copy-externals-plugin-test/test.js", [new CopyExternalsPlugin()], ["foo"]);
+
+    const result = await runWebpack(testConfig);
+    expect(fs.existsSync(path.join(__dirname, "dist/node_modules/foo"))).to.be.false;
+    expect(result.logging.CopyExternalsPlugin.entries.length).to.be.equal(2);
+    expect(result.warnings.length).to.be.equal(1);
+    expect(result.warnings[0]).to.match(/Can't copy external package "foo" - it is not installed./);
+  });
+
   afterEach(() => {
     vol.reset();
     clearFileSystem(__dirname);

--- a/tools/webpack-core/src/test/TestUtils.ts
+++ b/tools/webpack-core/src/test/TestUtils.ts
@@ -29,6 +29,7 @@ export async function runWebpack(config: any, vol?: any) {
 
 export function getTestConfig(srcFile: string, pluginsToTest: any[], externalsToTest?: any[], rules?: any[]) {
   return {
+    mode: "production",
     entry: [
       path.join(__dirname, srcFile),
     ],


### PR DESCRIPTION
Trying to avoid getting mysterious unhandled exceptions when `CopyExternalsPlugin` tries to handle a package that's not installed.

Basically, if an "external" module is not installed, we will always log a warning, but this will only bubble up as a webpack compilation warning if the module was not considered "optional" (that is, if the `import`/`require` was _not_ wrapped in a `try`/`catch`).

This is pretty similar to how this all worked prior to #1253, except now we can confidently say the package is not installed, so we no longer have to warn just because something is not a "direct" dependency.