### PR TITLE
Fix BentleyMochaReporter error when packages are not correctly hoisted.

### DIFF
--- a/common/changes/@bentley/build-tools/fix-mocha-reporter_2021-07-01-16-45.json
+++ b/common/changes/@bentley/build-tools/fix-mocha-reporter_2021-07-01-16-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/build-tools",
+  "email": "33036725+wgoehrig@users.noreply.github.com"
+}

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -30,7 +30,7 @@ if (isCI) {
   if (typeof (mocha) !== "undefined")
     mocha.forbidOnly();
   else
-    require.cache[require.resolve("mocha/lib/mocharc.json")].exports.forbidOnly = true;
+    require.cache[require.resolve("mocha/lib/mocharc.json", { paths: require.main?.paths ?? module.paths })].exports.forbidOnly = true;
 }
 
 // This is necessary to enable colored output when running in rush test:


### PR DESCRIPTION
Sometimes npm is lazy and just leaves duplicate copies of mocha lying around node_modules.