### PR TITLE
Ensure viewport dropped from ViewManager before window is unloaded

### DIFF
--- a/common/changes/@bentley/ui-components/ensureViewportDropped_2021-07-01-18-06.json
+++ b/common/changes/@bentley/ui-components/ensureViewportDropped_2021-07-01-18-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Add window \"beforeunload\" event listener to ensure viewport is dropped from ViewManager.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/components/src/ui-components/viewport/ViewportComponent.tsx
+++ b/ui/components/src/ui-components/viewport/ViewportComponent.tsx
@@ -86,7 +86,7 @@ export class ViewportComponent extends React.Component<ViewportProps, ViewportSt
       screenViewport.onViewChanged.removeListener(this._handleViewChanged);
       this._vp = undefined;
     }
-  }
+  };
 
   public async componentDidMount() {
     this._mounted = true;

--- a/ui/components/src/ui-components/viewport/ViewportComponent.tsx
+++ b/ui/components/src/ui-components/viewport/ViewportComponent.tsx
@@ -80,11 +80,18 @@ export class ViewportComponent extends React.Component<ViewportProps, ViewportSt
 
   private _handleDisconnectFromViewManager = () => {
     const screenViewport = this._vp;
+    const parentDiv = this._viewportDiv.current;
+
     if (screenViewport) {
       const viewManager = IModelApp.viewManager;
       viewManager.dropViewport(screenViewport, true);
       screenViewport.onViewChanged.removeListener(this._handleViewChanged);
       this._vp = undefined;
+    }
+    // istanbul ignore else
+    if (parentDiv) {
+      const parentWindow = parentDiv.ownerDocument.defaultView as Window;
+      parentWindow.removeEventListener("beforeunload", this._handleDisconnectFromViewManager, false);
     }
   };
 


### PR DESCRIPTION
Fix issue caused when frontstage is changed while there is a pop-out window displaying a ViewportComponent. The ViewportComponent must ensure it is properly disconnected from ViewManager before the pop-out window is closed.