### PR TITLE
update npmignore to not deliver pseudolocalized files

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/imodeljs-frontend/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-markup/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/imodeljs-markup/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-markup",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-markup",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/presentation-common/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-abstract/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/ui-abstract/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-abstract",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-abstract",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-components/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/ui-components/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-core/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/ui-core/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-framework/drop-psuedo-files_2021-07-02-14-19.json
+++ b/common/changes/@bentley/ui-framework/drop-psuedo-files_2021-07-02-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Stop delivering pseudo-localized strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/core/frontend/.npmignore
+++ b/core/frontend/.npmignore
@@ -5,5 +5,6 @@
 !lib/**/*.js
 !lib/**/*.js.map
 !lib/public/**
+lib/public/locales/en-PSEUDO
 test
 !*.md

--- a/core/markup/.npmignore
+++ b/core/markup/.npmignore
@@ -5,5 +5,6 @@
 !lib/**/*.js
 !lib/**/*.js.map
 !lib/public/**
+lib/public/locales/en-PSEUDO
 test
 !*.md

--- a/presentation/common/.npmignore
+++ b/presentation/common/.npmignore
@@ -11,3 +11,4 @@
 !*.md
 # then ignore some stuff again
 lib/test
+lib/public/locales/en-PSEUDO

--- a/ui/abstract/.npmignore
+++ b/ui/abstract/.npmignore
@@ -6,5 +6,6 @@
 !lib/**/*.js.map
 !lib/**/*.*css
 !lib/public/**/*
+lib/public/locales/en-PSEUDO
 lib/test
 !*.md

--- a/ui/components/.npmignore
+++ b/ui/components/.npmignore
@@ -6,5 +6,6 @@
 !lib/**/*.js.map
 !lib/**/*.*css
 !lib/public/**/*
+lib/public/locales/en-PSEUDO
 lib/test
 !*.md

--- a/ui/core/.npmignore
+++ b/ui/core/.npmignore
@@ -7,5 +7,6 @@
 !lib/**/*.*css
 !lib/**/*.svg
 !lib/public/**/*
+lib/public/locales/en-PSEUDO
 lib/test
 !*.md

--- a/ui/framework/.npmignore
+++ b/ui/framework/.npmignore
@@ -8,6 +8,7 @@
 !lib/**/*.json
 !lib/**/*.svg
 !lib/public/**/*
+lib/public/locales/en-PSEUDO
 lib/test
 !*.md
 !rulesets/**/*


### PR DESCRIPTION
Stop delivering pseudolocalized files from core.
Now that the CopyStaticAssetsPlugin has been released, all assets are available at app startup, and users have been complaining about some strings looking "weird". 

We've had other discussions about this, I believe the consensus then was provide a plugin in our cra fork to do pseudolocalization, and have users opt into that if they want it.