### PR TITLE
Presentation: Report deleted node positions in hierarchy comparison results

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1677,6 +1677,9 @@ export interface NodeArtifactsRule extends RuleBase, ConditionContainer {
 
 // @public
 export interface NodeDeletionInfo {
+    parent?: NodeKey;
+    position: number;
+    // @deprecated
     target: NodeKey;
     // (undocumented)
     type: "Delete";
@@ -1684,7 +1687,9 @@ export interface NodeDeletionInfo {
 
 // @public
 export interface NodeDeletionInfoJSON {
-    // (undocumented)
+    parent?: NodeKeyJSON;
+    position: number;
+    // @deprecated
     target: NodeKeyJSON;
     // (undocumented)
     type: "Delete";

--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -2996,7 +2996,7 @@ export class MutableTreeModel implements TreeModel {
     insertChild(parentId: string | undefined, childNodeInput: TreeModelNodeInput, offset: number): void;
     iterateTreeModelNodes(parentId?: string): IterableIterator<MutableTreeModelNode>;
     moveNode(sourceNodeId: string, targetParentId: string | undefined, targetIndex: number): boolean;
-    removeChild(parentId: string | undefined, childId: string): void;
+    removeChild(parentId: string | undefined, child: string | number): void;
     setChildren(parentId: string | undefined, nodeInputs: TreeModelNodeInput[], offset: number): void;
     setNumChildren(parentId: string | undefined, numChildren: number | undefined): void;
     }
@@ -4281,7 +4281,7 @@ export class SparseTree<T extends Node> {
     // (undocumented)
     moveNode(sourceParentId: string | undefined, sourceNodeId: string, targetParentId: string | undefined, targetIndex: number): void;
     // (undocumented)
-    removeChild(parentId: string | undefined, childId: string): void;
+    removeChild(parentId: string | undefined, child: string | number): void;
     // (undocumented)
     setChildren(parentId: string | undefined, children: T[], offset: number): void;
     // (undocumented)

--- a/common/changes/@bentley/presentation-backend/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
+++ b/common/changes/@bentley/presentation-backend/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
+++ b/common/changes/@bentley/presentation-common/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Provide more information on removed nodes in hierarchy comparison results.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
+++ b/common/changes/@bentley/presentation-components/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/common/changes/@bentley/ui-components/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
+++ b/common/changes/@bentley/ui-components/presentation-fix-tree-autoupdate_2021-07-02-12-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "`MutableTreeModel`: `removeChild` method now accepts child index for the second parameter.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -1276,6 +1276,8 @@ describe("PresentationManager", () => {
           changes: [{
             type: "Delete",
             target: createRandomECInstancesNodeJSON().key,
+            parent: createRandomECInstancesNodeJSON().key,
+            position: 123,
           }],
         };
         setup(addonResponse);

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -1648,6 +1648,8 @@ describe("PresentationRpcImpl", () => {
           changes: [{
             type: "Delete",
             target: createRandomECInstancesNode().key,
+            parent: createRandomECInstancesNode().key,
+            position: 123,
           }],
         };
         const rpcOptions: HierarchyCompareRpcOptions = {
@@ -1678,6 +1680,8 @@ describe("PresentationRpcImpl", () => {
           changes: [{
             type: "Delete",
             target: createRandomECInstancesNode().key,
+            parent: createRandomECInstancesNode().key,
+            position: 123,
           }],
         };
         const rpcOptions: HierarchyCompareRpcOptions = {
@@ -1715,6 +1719,8 @@ describe("PresentationRpcImpl", () => {
           changes: [{
             type: "Delete",
             target: createRandomECInstancesNode().key,
+            parent: createRandomECInstancesNode().key,
+            position: 123,
           }],
         };
         const rpcOptions: HierarchyCompareRpcOptions = {
@@ -1747,6 +1753,8 @@ describe("PresentationRpcImpl", () => {
           changes: [{
             type: "Delete",
             target: createRandomECInstancesNode().key,
+            parent: createRandomECInstancesNode().key,
+            position: 123,
           }],
         };
         const rpcOptions: HierarchyCompareRpcOptions = {
@@ -1782,6 +1790,8 @@ describe("PresentationRpcImpl", () => {
           changes: [{
             type: "Delete",
             target: createRandomECInstancesNode().key,
+            parent: createRandomECInstancesNode().key,
+            position: 123,
           }],
         };
         const rpcOptions: HierarchyCompareRpcOptions = {

--- a/presentation/common/src/presentation-common/Update.ts
+++ b/presentation/common/src/presentation-common/Update.ts
@@ -210,7 +210,10 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
       case "Delete":
         return {
           type: "Delete",
+          // eslint-disable-next-line deprecation/deprecation
           target: NodeKey.toJSON(obj.target),
+          parent: obj.parent === undefined ? undefined : NodeKey.toJSON(obj.parent),
+          position: obj.position,
         };
     }
   }
@@ -236,7 +239,10 @@ export namespace PartialHierarchyModification { // eslint-disable-line @typescri
       case "Delete":
         return {
           type: "Delete",
+          // eslint-disable-next-line deprecation/deprecation
           target: NodeKey.fromJSON(json.target),
+          parent: json.parent === undefined ? undefined : NodeKey.fromJSON(json.parent),
+          position: json.position,
         };
     }
   }
@@ -273,7 +279,15 @@ export interface NodeInsertionInfoJSON {
  */
 export interface NodeDeletionInfo {
   type: "Delete";
-  /** Key of the deleted node */
+  /** Parent of the deleted node */
+  parent?: NodeKey;
+  /** Position of the deleted node among its siblings in the initial, not updated tree */
+  position: number;
+
+  /**
+   * Key of the deleted node
+   * @deprecated Use `parent` with `position`
+   */
   target: NodeKey;
 }
 
@@ -283,6 +297,15 @@ export interface NodeDeletionInfo {
  */
 export interface NodeDeletionInfoJSON {
   type: "Delete";
+  /** Parent of the deleted node */
+  parent?: NodeKeyJSON;
+  /** Position of the deleted node among its siblings in the initial, not updated tree */
+  position: number;
+
+  /**
+   * Key of the deleted node
+   * @deprecated
+   */
   target: NodeKeyJSON;
 }
 

--- a/presentation/common/src/test/Update.test.snap
+++ b/presentation/common/src/test/Update.test.snap
@@ -68,6 +68,12 @@ Object {
       "type": "Update",
     },
     Object {
+      "parent": Object {
+        "instanceKeys": Array [],
+        "pathFromRoot": Array [],
+        "type": "ECInstancesNode",
+      },
+      "position": 0,
       "target": Object {
         "instanceKeys": Array [],
         "pathFromRoot": Array [],
@@ -115,6 +121,12 @@ Object {
       "type": "Update",
     },
     Object {
+      "parent": Object {
+        "instanceKeys": Array [],
+        "pathFromRoot": Array [],
+        "type": "ECInstancesNode",
+      },
+      "position": 0,
       "target": Object {
         "instanceKeys": Array [],
         "pathFromRoot": Array [],
@@ -206,8 +218,27 @@ Object {
 }
 `;
 
-exports[`PartialHierarchyModification fromJSON deserializes \`NodeDeletionInfo\` from JSON 1`] = `
+exports[`PartialHierarchyModification fromJSON deserializes \`NodeDeletionInfo\` with parent from JSON 1`] = `
 Object {
+  "parent": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
+  },
+  "position": 0,
+  "target": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
+  },
+  "type": "Delete",
+}
+`;
+
+exports[`PartialHierarchyModification fromJSON deserializes \`NodeDeletionInfo\` without parent from JSON 1`] = `
+Object {
+  "parent": undefined,
+  "position": 0,
   "target": Object {
     "instanceKeys": Array [],
     "pathFromRoot": Array [],
@@ -275,8 +306,27 @@ Object {
 }
 `;
 
-exports[`PartialHierarchyModification toJSON serializes \`NodeDeletionInfo\` 1`] = `
+exports[`PartialHierarchyModification toJSON serializes \`NodeDeletionInfo\` with parent 1`] = `
 Object {
+  "parent": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
+  },
+  "position": 123,
+  "target": Object {
+    "instanceKeys": Array [],
+    "pathFromRoot": Array [],
+    "type": "ECInstancesNode",
+  },
+  "type": "Delete",
+}
+`;
+
+exports[`PartialHierarchyModification toJSON serializes \`NodeDeletionInfo\` without parent 1`] = `
+Object {
+  "parent": undefined,
+  "position": 123,
   "target": Object {
     "instanceKeys": Array [],
     "pathFromRoot": Array [],

--- a/presentation/common/src/test/Update.test.ts
+++ b/presentation/common/src/test/Update.test.ts
@@ -199,10 +199,21 @@ describe("PartialHierarchyModification", () => {
       expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
     });
 
-    it("serializes `NodeDeletionInfo`", () => {
+    it("serializes `NodeDeletionInfo` with parent", () => {
       const info: NodeDeletionInfo = {
         type: "Delete",
         target: testNode.key,
+        parent: testNode.key,
+        position: 123,
+      };
+      expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
+    });
+
+    it("serializes `NodeDeletionInfo` without parent", () => {
+      const info: NodeDeletionInfo = {
+        type: "Delete",
+        target: testNode.key,
+        position: 123,
       };
       expect(PartialHierarchyModification.toJSON(info)).to.matchSnapshot();
     });
@@ -239,10 +250,21 @@ describe("PartialHierarchyModification", () => {
       expect(PartialHierarchyModification.fromJSON(info)).to.matchSnapshot();
     });
 
-    it("deserializes `NodeDeletionInfo` from JSON", () => {
+    it("deserializes `NodeDeletionInfo` without parent from JSON", () => {
       const info: NodeDeletionInfoJSON = {
         type: "Delete",
         target: testNodeJson.key,
+        position: 0,
+      };
+      expect(PartialHierarchyModification.fromJSON(info)).to.matchSnapshot();
+    });
+
+    it("deserializes `NodeDeletionInfo` with parent from JSON", () => {
+      const info: NodeDeletionInfoJSON = {
+        type: "Delete",
+        target: testNodeJson.key,
+        parent: testNodeJson.key,
+        position: 0,
       };
       expect(PartialHierarchyModification.fromJSON(info)).to.matchSnapshot();
     });
@@ -269,6 +291,8 @@ describe("HierarchyCompareInfo", () => {
           {
             type: "Delete",
             target: testNode.key,
+            parent: testNode.key,
+            position: 0,
           },
         ],
         continuationToken: {
@@ -299,6 +323,8 @@ describe("HierarchyCompareInfo", () => {
           {
             type: "Delete",
             target: testNodeJson.key,
+            parent: testNodeJson.key,
+            position: 0,
           },
         ],
         continuationToken: {

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -271,6 +271,7 @@ export function updateTreeModel(
           break;
 
         case "Delete":
+          // eslint-disable-next-line deprecation/deprecation
           const nodeToRemove = model.getNode(createTreeNodeId(modification.target));
           if (nodeToRemove === undefined) {
             break;

--- a/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
+++ b/presentation/components/src/test/tree/controlled/TreeHooks.test.ts
@@ -882,25 +882,41 @@ describe("updateTreeModel", () => {
   describe("node removal", () => {
     it("removes root node", () => {
       const initialTree = createTreeModel(["root1", "root2", "root3"]);
-      const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("root2").key }], {});
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{ type: "Delete", target: createNode("root2").key, parent: undefined, position: 1 }],
+        {},
+      );
       expectTree(updatedTree!, ["root1", "root3"]);
     });
 
     it("removes child node", () => {
       const initialTree = createTreeModel([{ ["root1"]: ["child1", "child2"] }, "root2"]);
-      const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("child1").key }], {});
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{ type: "Delete", target: createNode("child1").key, parent: createNode("root1").key, position: 0 }],
+        {},
+      );
       expectTree(updatedTree!, [{ ["root1"]: ["child2"] }, "root2"]);
     });
 
     it("removes children along with removed node", () => {
       const initialTree = createTreeModel([{ ["root1"]: ["child1", "child2"] }, "root2"]);
-      const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("root1").key }], {});
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{ type: "Delete", target: createNode("root1").key, parent: undefined, position: 0 }],
+        {},
+      );
       expectTree(updatedTree!, ["root2"]);
     });
 
     it("ignores deletion of node that does not exist", () => {
       const initialTree = createTreeModel(["root1", "root2"]);
-      const updatedTree = updateTreeModel(initialTree, [{ type: "Delete", target: createNode("root3").key }], {});
+      const updatedTree = updateTreeModel(
+        initialTree,
+        [{ type: "Delete", target: createNode("root3").key, parent: undefined, position: 2 }],
+        {},
+      );
       expect(updatedTree).to.be.equal(initialTree);
       expectTree(updatedTree!, ["root1", "root2"]);
     });

--- a/ui/components/src/test/tree/controlled/TreeModel.test.ts
+++ b/ui/components/src/test/tree/controlled/TreeModel.test.ts
@@ -451,6 +451,14 @@ describe("MutableTreeModel", () => {
       treeMock.verifyAll();
       expect(rootNode.numChildren).to.be.eq(childCountBefore - 1);
     });
+
+    it("removes node by index", () => {
+      treeModel = new MutableTreeModel();
+      treeModel.setChildren(undefined, [createTreeModelNodeInput("root1"), createTreeModelNodeInput("root2")], 0);
+
+      treeModel.removeChild(undefined, 0);
+      expect([...treeModel.getChildren(undefined)!]).to.be.deep.equal(["root2"]);
+    });
   });
 
   describe("clearChildren", () => {

--- a/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
+++ b/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
@@ -267,47 +267,94 @@ describe("SparseTree", () => {
   });
 
   describe("removeChild", () => {
-    it("removes root node", () => {
-      const rootNodes = createRandomMutableTreeModelNodes(3);
-      sparseTree.setChildren(undefined, rootNodes, 0);
-      sparseTree.removeChild(undefined, rootNodes[1].id);
-      const children = sparseTree.getChildren(undefined)!;
-      expect(children.getLength()).to.be.eq(2);
-      verifyNodes(children, [rootNodes[0], rootNodes[2]]);
+    describe("by child id", () => {
+      it("removes root node", () => {
+        const rootNodes = createRandomMutableTreeModelNodes(3);
+        sparseTree.setChildren(undefined, rootNodes, 0);
+        sparseTree.removeChild(undefined, rootNodes[1].id);
+        const children = sparseTree.getChildren(undefined)!;
+        expect(children.getLength()).to.be.eq(2);
+        verifyNodes(children, [rootNodes[0], rootNodes[2]]);
+      });
+
+      it("removes child node", () => {
+        const childNodes = createRandomMutableTreeModelNodes(3);
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.setChildren(rootNode.id, childNodes, 0);
+        sparseTree.removeChild(rootNode.id, childNodes[1].id);
+        const children = sparseTree.getChildren(rootNode.id)!;
+        expect(children.getLength()).to.be.eq(2);
+        verifyNodes(children, [childNodes[0], childNodes[2]]);
+      });
+
+      it("does not remove child if it is not found", () => {
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.removeChild(undefined, "nonExisting");
+        const children = sparseTree.getChildren(undefined)!;
+        expect(children.getLength()).to.be.eq(1);
+        verifyNodes(children, [rootNode]);
+      });
+
+      it("does not throw when parent does not have children", () => {
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.removeChild(rootNode.id, "childId");
+        const children = sparseTree.getChildren(rootNode.id);
+        expect(children).to.be.undefined;
+      });
+
+      it("removes child subtree", () => {
+        const childNodes = createRandomMutableTreeModelNodes();
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.setChildren(rootNode.id, childNodes, 0);
+        sparseTree.removeChild(undefined, rootNode.id);
+        const children = sparseTree.getChildren(rootNode.id);
+        expect(children).to.be.undefined;
+      });
     });
 
-    it("removes child node", () => {
-      const childNodes = createRandomMutableTreeModelNodes(3);
-      sparseTree.setChildren(undefined, [rootNode], 0);
-      sparseTree.setChildren(rootNode.id, childNodes, 0);
-      sparseTree.removeChild(rootNode.id, childNodes[1].id);
-      const children = sparseTree.getChildren(rootNode.id)!;
-      expect(children.getLength()).to.be.eq(2);
-      verifyNodes(children, [childNodes[0], childNodes[2]]);
-    });
+    describe("by child index", () => {
+      it("removes root node", () => {
+        const rootNodes = createRandomMutableTreeModelNodes(3);
+        sparseTree.setChildren(undefined, rootNodes, 0);
+        sparseTree.removeChild(undefined, 1);
+        const children = sparseTree.getChildren(undefined)!;
+        expect(children.getLength()).to.be.eq(2);
+        verifyNodes(children, [rootNodes[0], rootNodes[2]]);
+      });
 
-    it("does not remove child if it is not found", () => {
-      sparseTree.setChildren(undefined, [rootNode], 0);
-      sparseTree.removeChild(undefined, "nonExisting");
-      const children = sparseTree.getChildren(undefined)!;
-      expect(children.getLength()).to.be.eq(1);
-      verifyNodes(children, [rootNode]);
-    });
+      it("removes child node", () => {
+        const childNodes = createRandomMutableTreeModelNodes(3);
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.setChildren(rootNode.id, childNodes, 0);
+        sparseTree.removeChild(rootNode.id, 1);
+        const children = sparseTree.getChildren(rootNode.id)!;
+        expect(children.getLength()).to.be.eq(2);
+        verifyNodes(children, [childNodes[0], childNodes[2]]);
+      });
 
-    it("tries to remove child for parent with does not have children", () => {
-      sparseTree.setChildren(undefined, [rootNode], 0);
-      sparseTree.removeChild(rootNode.id, "childId");
-      const children = sparseTree.getChildren(rootNode.id);
-      expect(children).to.be.undefined;
-    });
+      it("does not remove child if it is not found", () => {
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.removeChild(undefined, 123);
+        const children = sparseTree.getChildren(undefined)!;
+        expect(children.getLength()).to.be.eq(1);
+        verifyNodes(children, [rootNode]);
+      });
 
-    it("removes child subtree", () => {
-      const childNodes = createRandomMutableTreeModelNodes();
-      sparseTree.setChildren(undefined, [rootNode], 0);
-      sparseTree.setChildren(rootNode.id, childNodes, 0);
-      sparseTree.removeChild(undefined, rootNode.id);
-      const children = sparseTree.getChildren(rootNode.id);
-      expect(children).to.be.undefined;
+      it("does not throw when parent does not have children", () => {
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.removeChild(rootNode.id, 0);
+        const children = sparseTree.getChildren(rootNode.id);
+        expect(children).to.be.undefined;
+      });
+
+      it("removes child subtree", () => {
+        const childNodes = createRandomMutableTreeModelNodes();
+        sparseTree.setChildren(undefined, [rootNode], 0);
+        sparseTree.setChildren(rootNode.id, childNodes, 0);
+        sparseTree.removeChild(undefined, 0);
+        const children = sparseTree.getChildren(rootNode.id);
+        expect(children).to.be.undefined;
+      });
     });
   });
 

--- a/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
+++ b/ui/components/src/test/tree/controlled/internal/SparseTree.test.ts
@@ -537,6 +537,15 @@ describe("SparseArray", () => {
       expect(sparseArray.getLength()).to.be.eq(7);
       expect(sparseArray.get(0)).to.be.eq(testItems[0].value);
     });
+
+    it("does nothing when attempting to remove at position past the end", () => {
+      sparseArray.insert(0, 0);
+      sparseArray.insert(1, 1);
+      sparseArray.remove(2);
+      expect(sparseArray.getLength()).to.be.eq(2);
+      expect(sparseArray.get(0)).to.be.eq(0);
+      expect(sparseArray.get(1)).to.be.eq(1);
+    });
   });
 
   describe("iterateValues", () => {

--- a/ui/components/src/ui-components/tree/controlled/TreeModel.ts
+++ b/ui/components/src/ui-components/tree/controlled/TreeModel.ts
@@ -382,12 +382,12 @@ export class MutableTreeModel implements TreeModel {
   }
 
   /** Removes children specified by id.
-   * @param parentId id of parent node or undefined to remove root node.
-   * @param childId id of node that should be removed.
+   * @param parentId id of the parent node.
+   * @param child child node id or index that should be removed.
    */
-  public removeChild(parentId: string | undefined, childId: string) {
+  public removeChild(parentId: string | undefined, child: string | number): void {
     const parentNode = parentId === undefined ? this._rootNode : this._tree.getNode(parentId);
-    this._tree.removeChild(parentId, childId);
+    this._tree.removeChild(parentId, child);
 
     // istanbul ignore else
     if (parentNode)

--- a/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
+++ b/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
@@ -215,7 +215,7 @@ export class SparseArray<T> implements Iterable<T | undefined> {
     this._length = Math.max(this._length, index + 1);
   }
 
-  /** Inserts value at specific position. Increases array length by 1. */
+  /** Inserts value at specific position. Increases array length by one. */
   public insert(index: number, value: T) {
     const { index: i } = this.lowerBound(index);
     this._array.splice(i, 0, [value, index]);
@@ -227,14 +227,19 @@ export class SparseArray<T> implements Iterable<T | undefined> {
     this._length = Math.max(this._length + 1, index + 1);
   }
 
-  /** Removes value at specific position. It could remove stored value or intermediate 'undefined' value. */
-  public remove(index: number) {
+  /** Removes value at specified index and reduces array length by one. */
+  public remove(index: number): void {
+    if (index >= this._length) {
+      return;
+    }
+
     const { index: i, equal } = this.lowerBound(index);
     this._array.splice(i, equal ? 1 : 0);
 
     for (let j = i; j < this._array.length; j++) {
       this._array[j][1]--;
     }
+
     this._length = Math.max(0, this._length - 1);
   }
 
@@ -267,7 +272,9 @@ export class SparseArray<T> implements Iterable<T | undefined> {
     })();
   }
 
-  private lowerBound(index: number): { index: number, equal: boolean } {
+  private lowerBound(index: number): {
+    index: number; equal: boolean;
+  } {
     return lowerBound(index, this._array, SparseArray.compare);
   }
 

--- a/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
+++ b/ui/components/src/ui-components/tree/controlled/internal/SparseTree.ts
@@ -130,17 +130,25 @@ export class SparseTree<T extends Node> {
     children.setLength(numChildren);
   }
 
-  public removeChild(parentId: string | undefined, childId: string) {
+  public removeChild(parentId: string | undefined, child: string | number): void {
     const children = this.getChildren(parentId);
     if (children === undefined)
       return;
 
-    const childIndex = children.getIndex(childId);
-    if (childIndex !== undefined) {
-      children.remove(childIndex);
-    }
+    if (typeof child === "string") {
+      const childIndex = children.getIndex(child);
+      if (childIndex !== undefined) {
+        children.remove(childIndex);
+      }
 
-    this.deleteSubtree(childId);
+      this.deleteSubtree(child);
+    } else {
+      const childId = children.get(child);
+      children.remove(child);
+      if (childId !== undefined) {
+        this.deleteSubtree(childId);
+      }
+    }
   }
 
   public deleteSubtree(parentId: string | undefined, deleteParent: boolean = true) {


### PR DESCRIPTION
When tree hierarchy is responding to iModel or ruleset data changes, frontends fail to remove not loaded nodes from the hierarchy, because nodes do not have known ids while in placeholder state.

In addition to reporting deleted node keys, also report deleted node's parent and position among its siblings, so that even not loaded nodes can be correctly identified for removal.

The fix for incorrect tree state after update is not included here, as it will be a bigger overhaul of the tree auto update logic.

[Parallel change for the native addon.](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/175813)