### PR TITLE
Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/rpc-open-fix_2021-07-06-13-13.json
+++ b/common/changes/@bentley/imodeljs-backend/rpc-open-fix_2021-07-06-13-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/core/backend/src/rpc-impl/RpcBriefcaseUtility.ts
+++ b/core/backend/src/rpc-impl/RpcBriefcaseUtility.ts
@@ -75,7 +75,7 @@ export class RpcBriefcaseUtility {
     const request: RequestNewBriefcaseProps = {
       contextId: tokenProps.contextId!,
       iModelId,
-      briefcaseId: myBriefcaseIds.length > 0 ? myBriefcaseIds[0] : undefined, // if briefcaseId is undefined, we'll acquire a new one.
+      briefcaseId: args.syncMode === SyncMode.PullOnly ? 0 : undefined, // if briefcaseId is undefined, we'll acquire a new one.
     };
 
     const props = await BriefcaseManager.downloadBriefcase(requestContext, request);

--- a/core/backend/src/test/integration/BriefcaseManager.test.ts
+++ b/core/backend/src/test/integration/BriefcaseManager.test.ts
@@ -256,7 +256,7 @@ describe("BriefcaseManager (#integration)", () => {
     HubMock.startup("briefcaseIdsReopen");
     const iModelId = await HubUtility.createIModel(requestContext, testContextId, "imodel1");
 
-    const args = { requestContext, contextId: testContextId, iModelId, deleteFirst: true };
+    const args = { requestContext, contextId: testContextId, iModelId, deleteFirst: false };
     const iModel1 = await IModelTestUtils.openBriefcaseUsingRpc(args);
     const briefcaseId1 = iModel1.briefcaseId;
     iModel1.close(); // Keeps the briefcase by default

--- a/core/backend/src/test/integration/RpcBriefcaseOpen.test.ts
+++ b/core/backend/src/test/integration/RpcBriefcaseOpen.test.ts
@@ -54,8 +54,8 @@ describe("RpcBriefcaseOpen (#integration)", () => {
 
     // Cleanup
     IModelJsFs.unlinkSync(newPathname);
-    IModelHost.hubAccess.releaseBriefcase({ requestContext, iModelId, briefcaseId });
-    IModelHost.hubAccess.releaseBriefcase({ requestContext, iModelId, briefcaseId: newBriefcaseId });
+    await IModelHost.hubAccess.releaseBriefcase({ requestContext, iModelId, briefcaseId });
+    await IModelHost.hubAccess.releaseBriefcase({ requestContext, iModelId, briefcaseId: newBriefcaseId });
 
     HubMock.shutdown();
   });

--- a/core/backend/src/test/integration/RpcBriefcaseOpen.test.ts
+++ b/core/backend/src/test/integration/RpcBriefcaseOpen.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { GuidString } from "@bentley/bentleyjs-core";
+import { SyncMode } from "@bentley/imodeljs-common";
+import { assert } from "chai";
+import { BriefcaseDb } from "../../IModelDb";
+import { AuthorizedBackendRequestContext, IModelHost, IModelJsFs } from "../../imodeljs-backend";
+import { RpcBriefcaseUtility } from "../../rpc-impl/RpcBriefcaseUtility";
+import { HubMock } from "../HubMock";
+import { IModelTestUtils, TestUserType } from "../IModelTestUtils";
+import { HubUtility } from "./HubUtility";
+
+describe("RpcBriefcaseOpen (#integration)", () => {
+  let requestContext: AuthorizedBackendRequestContext;
+  let contextId: GuidString;
+
+  before(async () => {
+    requestContext = await IModelTestUtils.getUserContext(TestUserType.Manager);
+    contextId = await HubUtility.getTestContextId(requestContext);
+  });
+
+  it("should acquire a new briefcase when a briefcase that belongs to the user is not found on disk (PullAndPush)", async () => {
+    HubMock.startup("RpcOpenTest");
+    const iModelId = await HubUtility.createIModel(requestContext, contextId, "RpcOpenTest");
+    const args = { requestContext, tokenProps: { contextId, iModelId, changeSetId: "" }, syncMode: SyncMode.PullAndPush };
+
+    // Setup a briefcase on disk
+    let iModel = await RpcBriefcaseUtility.open(args) as BriefcaseDb;
+    const briefcaseId = iModel.getBriefcaseId();
+    const pathname = iModel.pathName;
+    iModel.close();
+    assert.isTrue(IModelJsFs.existsSync(pathname));
+
+    // File still on disk - reopen should just reuse the same briefcase
+    iModel = await RpcBriefcaseUtility.open(args) as BriefcaseDb;
+    assert.strictEqual(iModel.briefcaseId, briefcaseId);
+    assert.strictEqual(iModel.pathName, pathname);
+
+    // Close and delete local file
+    iModel.close();
+    IModelJsFs.unlinkSync(pathname);
+    assert.isFalse(IModelJsFs.existsSync(pathname));
+
+    // Reopen briefcase - should NOT use the same briefcase id
+    iModel = await RpcBriefcaseUtility.open(args) as BriefcaseDb;
+    const newBriefcaseId = iModel.getBriefcaseId();
+    const newPathname = iModel.pathName;
+    assert.notStrictEqual(newBriefcaseId, briefcaseId);
+    assert.notStrictEqual(newPathname, pathname);
+    iModel.close();
+
+    // Cleanup
+    IModelJsFs.unlinkSync(newPathname);
+    IModelHost.hubAccess.releaseBriefcase({ requestContext, iModelId, briefcaseId });
+    IModelHost.hubAccess.releaseBriefcase({ requestContext, iModelId, briefcaseId: newBriefcaseId });
+
+    HubMock.shutdown();
+  });
+
+});


### PR DESCRIPTION
In ReadWrite workflows using the soon-to-be-removed RPC interfaces -- acquire a new briefcase when a local briefcase belonging to the user wasn't found. 

This closes VSTS #651570