### PR TITLE
Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/rpc-open-fix-2_2021-07-06-14-23.json
+++ b/common/changes/@bentley/imodeljs-backend/rpc-open-fix-2_2021-07-06-14-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "32458710+ramanujam-raman@users.noreply.github.com"
+}

--- a/core/backend/src/rpc-impl/RpcBriefcaseUtility.ts
+++ b/core/backend/src/rpc-impl/RpcBriefcaseUtility.ts
@@ -76,7 +76,7 @@ export class RpcBriefcaseUtility {
     const request: RequestNewBriefcaseProps = {
       contextId: tokenProps.contextId!,
       iModelId,
-      briefcaseId: myBriefcaseIds.length > 0 ? myBriefcaseIds[0] : undefined, // if briefcaseId is undefined, we'll acquire a new one.
+      briefcaseId: args.syncMode === SyncMode.PullOnly ? 0 : undefined, // if briefcaseId is undefined, we'll acquire a new one.
     };
 
     const props = await BriefcaseManager.downloadBriefcase(requestContext, request);

--- a/core/backend/src/test/integration/BriefcaseManager.test.ts
+++ b/core/backend/src/test/integration/BriefcaseManager.test.ts
@@ -409,7 +409,7 @@ describe("BriefcaseManager (#integration)", () => {
   });
 
   it("should reuse a briefcaseId when re-opening iModels for pullAndPush workflows", async () => {
-    const args = { requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId, deleteFirst: true };
+    const args = { requestContext, contextId: testContextId, iModelId: readOnlyTestIModelId, deleteFirst: false };
     const iModel1 = await IModelTestUtils.openBriefcaseUsingRpc(args);
     const briefcaseId1: number = iModel1.briefcaseId;
     iModel1.close(); // Keeps the briefcase by default


### PR DESCRIPTION
In ReadWrite workflows using the soon-to-be-removed RPC interfaces -- acquire a new briefcase when a local briefcase belonging to the user wasn't found. 

This closes VSTS #651570