### PR TITLE
APIs for flashed element

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -1600,6 +1600,8 @@ export class BingMapsImageryLayerProvider extends MapLayerImageryProvider {
 // @public
 export class BlankConnection extends IModelConnection {
     close(): Promise<void>;
+    // @internal (undocumented)
+    closeSync(): void;
     get contextId(): GuidString | undefined;
     set contextId(contextId: GuidString | undefined);
     static create(props: BlankConnectionProps): BlankConnection;
@@ -6805,6 +6807,18 @@ export class OidcBrowserClient extends ImsAuthorizationClient implements Fronten
     signOut(requestContext?: ClientRequestContext): Promise<void>;
     }
 
+// @public
+export type OnFlashedIdChangedEventArgs = {
+    readonly current: Id64String;
+    readonly previous: Id64String;
+} | {
+    readonly current: Id64String;
+    readonly previous: undefined;
+} | {
+    readonly previous: Id64String;
+    readonly current: undefined;
+};
+
 // @alpha
 export type OnFrameStatsReadyEvent = BeEvent<(frameStats: Readonly<FrameStats>) => void>;
 
@@ -8978,6 +8992,8 @@ export class SheetViewState extends ViewState2d {
     getViewedExtents(): AxisAlignedBox3d;
     // @internal
     isDrawingView(): this is DrawingViewState;
+    // @internal
+    isSheetView(): this is SheetViewState;
     // @internal
     load(): Promise<void>;
     // @internal
@@ -12144,6 +12160,8 @@ export abstract class Viewport implements IDisposable {
     set featureOverrideProvider(provider: FeatureOverrideProvider | undefined);
     findFeatureOverrideProvider(predicate: (provider: FeatureOverrideProvider) => boolean): FeatureOverrideProvider | undefined;
     findFeatureOverrideProviderOfType<T>(type: Constructor<T>): T | undefined;
+    get flashedId(): Id64String | undefined;
+    set flashedId(id: Id64String | undefined);
     get flashSettings(): FlashSettings;
     set flashSettings(settings: FlashSettings);
     // @internal (undocumented)
@@ -12235,6 +12253,7 @@ export abstract class Viewport implements IDisposable {
     readonly onDisposed: BeEvent<(vp: Viewport) => void>;
     readonly onFeatureOverrideProviderChanged: BeEvent<(vp: Viewport) => void>;
     readonly onFeatureOverridesChanged: BeEvent<(vp: Viewport) => void>;
+    readonly onFlashedIdChanged: BeEvent<(vp: Viewport, args: OnFlashedIdChangedEventArgs) => void>;
     // @alpha
     readonly onFrameStats: BeEvent<(frameStats: Readonly<FrameStats>) => void>;
     readonly onNeverDrawnChanged: BeEvent<(vp: Viewport) => void>;
@@ -12285,6 +12304,7 @@ export abstract class Viewport implements IDisposable {
     setAlwaysDrawn(ids: Id64Set, exclusive?: boolean): void;
     setAnimator(animator?: Animator): void;
     setFeatureOverrideProviderChanged(): void;
+    // @deprecated
     setFlashed(id: string | undefined, _duration?: number): void;
     // (undocumented)
     setLightSettings(settings: LightSettings): void;
@@ -12615,6 +12635,7 @@ export abstract class ViewState extends ElementState {
     abstract isDrawingView(): this is DrawingViewState;
     // (undocumented)
     isPrivate?: boolean;
+    isSheetView(): this is SheetViewState;
     abstract isSpatialView(): this is SpatialViewState;
     // @internal (undocumented)
     isSubCategoryVisible(id: Id64String): boolean;

--- a/common/api/summary/imodeljs-frontend.exports.csv
+++ b/common/api/summary/imodeljs-frontend.exports.csv
@@ -388,6 +388,7 @@ public;OffScreenViewport
 public;OffScreenViewportOptions
 beta;OidcBrowserClient 
 deprecated;OidcBrowserClient 
+public;OnFlashedIdChangedEventArgs =
 alpha;OnFrameStatsReadyEvent = BeEvent
 internal;OnScreenTarget 
 beta;openImageDataUrlInNewWindow(url: string, title?: string): void

--- a/common/changes/@bentley/imodeljs-frontend/flashed-event_2021-07-06-17-36.json
+++ b/common/changes/@bentley/imodeljs-frontend/flashed-event_2021-07-06-17-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Add Viewport.flashedId property and corresponding onFlashedIdChanged event.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -513,9 +513,9 @@ export class AccuSnap implements Decorator {
 
   private unFlashViews() {
     this.needFlash.clear();
-    this.areFlashed.forEach((vp) => {
-      vp.setFlashed(undefined);
-    });
+    for (const vp of this.areFlashed)
+      vp.flashedId = undefined;
+
     this.areFlashed.clear();
   }
 

--- a/core/frontend/src/FrontendHubAccess.ts
+++ b/core/frontend/src/FrontendHubAccess.ts
@@ -11,7 +11,7 @@ import { addCsrfHeader, ChangeSet, ChangeSetQuery, IModelClient, IModelHubClient
 import { IModelError, IModelVersion } from "@bentley/imodeljs-common";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
 import { FrontendFeatureUsageTelemetryClient } from "@bentley/usage-logging-client";
-import { IModelApp } from "./imodeljs-frontend";
+import { IModelApp } from "./IModelApp";
 
 /** @internal */
 export type ChangeSetId = string;

--- a/core/frontend/src/HitDetail.ts
+++ b/core/frontend/src/HitDetail.ts
@@ -154,7 +154,9 @@ export class HitDetail {
   }
 
   /** Draw this HitDetail as a Decoration. Causes the picked element to *flash* */
-  public draw(_context: DecorateContext) { this.viewport.setFlashed(this.sourceId); }
+  public draw(_context: DecorateContext) {
+    this.viewport.flashedId = this.sourceId;
+  }
 
   /** Get the tooltip content for this HitDetail. */
   public async getToolTip(): Promise<HTMLElement | string> {

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -234,7 +234,7 @@ export abstract class IModelConnection extends IModel {
   /** Called prior to connection closing. Raises close events and calls tiles.dispose.
    * @internal
    */
-  protected beforeClose() {
+  protected beforeClose(): void {
     this.onClose.raiseEvent(this); // event for this connection
     IModelConnection.onClose.raiseEvent(this); // event for all connections
     this.tiles.dispose();
@@ -647,6 +647,11 @@ export class BlankConnection extends IModelConnection {
    * @note A BlankConnection should not be used after calling `close`.
    */
   public async close(): Promise<void> {
+    this.beforeClose();
+  }
+
+  /** @internal */
+  public closeSync(): void {
     this.beforeClose();
   }
 }

--- a/core/frontend/src/NativeApp.ts
+++ b/core/frontend/src/NativeApp.ts
@@ -14,7 +14,7 @@ import {
 } from "@bentley/imodeljs-common";
 import { AccessToken, AccessTokenProps, ProgressCallback, RequestGlobalOptions } from "@bentley/itwin-client";
 import { FrontendLoggerCategory } from "./FrontendLoggerCategory";
-import { IModelApp } from "./imodeljs-frontend";
+import { IModelApp } from "./IModelApp";
 import { AsyncMethodsOf, IpcApp, IpcAppOptions, NotificationHandler, PromiseReturnType } from "./IpcApp";
 import { NativeAppLogger } from "./NativeAppLogger";
 

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -319,6 +319,8 @@ export class SheetViewState extends ViewState2d {
 
   /** @internal override */
   public isDrawingView(): this is DrawingViewState { return false; }
+  /** @internal override */
+  public isSheetView(): this is SheetViewState { return true; }
 
   public constructor(props: ViewDefinition2dProps, iModel: IModelConnection, categories: CategorySelectorState, displayStyle: DisplayStyle2dState, sheetProps: SheetProps, attachments: Id64Array) {
     super(props, iModel, categories, displayStyle);

--- a/core/frontend/src/ViewCreator2d.ts
+++ b/core/frontend/src/ViewCreator2d.ts
@@ -12,7 +12,7 @@ API for creating a 2D view from a given modelId and modelType (classFullName).
 Additional options (such as background color) can be passed during view creation.
 */
 
-import { Id64Array, Id64String, IModelStatus, Logger } from "@bentley/bentleyjs-core";
+import { Id64Array, Id64String, IModelStatus } from "@bentley/bentleyjs-core";
 import { CategorySelectorProps, Code, ColorDef, DisplayStyleProps, IModel, IModelError, ModelSelectorProps, SheetProps, ViewDefinition2dProps, ViewStateProps } from "@bentley/imodeljs-common";
 import { Range3d } from "@bentley/geometry-core";
 import { DrawingModelState, SectionDrawingModelState, SheetModelState } from "./ModelState";

--- a/core/frontend/src/ViewCreator2d.ts
+++ b/core/frontend/src/ViewCreator2d.ts
@@ -20,7 +20,7 @@ import { IModelConnection } from "./IModelConnection";
 import { ViewState, ViewState2d } from "./ViewState";
 import { DrawingViewState } from "./DrawingViewState";
 import { SheetViewState } from "./SheetViewState";
-import { EntityState, loggerCategory } from "./imodeljs-frontend";
+import { EntityState } from "./EntityState";
 
 /** Options for creating a [[ViewState2d]] via [[ViewCreator2d]].
  *  @public
@@ -89,10 +89,10 @@ export class ViewCreator2d {
       const modelType = modelProps[0].classFullName;
       baseClassName = await this._imodel.findClassFor(modelType, undefined);
     } else
-      throw new IModelError(IModelStatus.BadModel, "ViewCreator2d._getModelBaseClassName: modelId is invalid", Logger.logError, loggerCategory, () => ({ modelId }));
+      throw new IModelError(IModelStatus.BadModel, "ViewCreator2d._getModelBaseClassName: modelId is invalid");
 
     if (baseClassName === undefined)
-      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d.getViewForModel: modelType is invalid", Logger.logError, loggerCategory, () => ({ modelId }));
+      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d.getViewForModel: modelType is invalid");
 
     return baseClassName;
   }
@@ -114,7 +114,7 @@ export class ViewCreator2d {
       props = await this._addSheetViewProps(modelId, props);
       viewState = SheetViewState.createFromProps(props, this._imodel);
     } else
-      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d._createViewState2d: modelType not supported", Logger.logError, loggerCategory, () => ({ modelType, modelId }));
+      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d._createViewState2d: modelType not supported");
 
     return viewState;
   }

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -19,7 +19,7 @@ import { StandardViewId } from "./StandardView";
 import { IModelConnection } from "./IModelConnection";
 import { ViewState } from "./ViewState";
 import { SpatialViewState } from "./SpatialViewState";
-import { Environment, loggerCategory } from "./imodeljs-frontend";
+import { Environment } from "./DisplayStyleState";
 
 /** Options for creating a [[ViewState3d]] via [[ViewCreator3d]].
  *  @public
@@ -64,7 +64,7 @@ export class ViewCreator3d {
 
     const models = modelIds ? modelIds : await this._getAllModels();
     if (models === undefined || models.length === 0)
-      throw new IModelError(IModelStatus.BadModel, "ViewCreator3d.createDefaultView: no 3D models found in iModel", Logger.logError, loggerCategory, () => ({ models }));
+      throw new IModelError(IModelStatus.BadModel, "ViewCreator3d.createDefaultView: no 3D models found in iModel");
 
     const props = await this._createViewStateProps(models, options);
     const viewState = SpatialViewState.createFromProps(props, this._imodel);

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -12,7 +12,7 @@ API for creating a 3D default view for an iModel.
 Either takes in a list of modelIds, or displays all 3D models by default.
 */
 
-import { Id64Array, Id64String, IModelStatus, Logger } from "@bentley/bentleyjs-core";
+import { Id64Array, Id64String, IModelStatus } from "@bentley/bentleyjs-core";
 import { Camera, CategorySelectorProps, Code, DisplayStyle3dProps, IModel, IModelError, IModelReadRpcInterface, ModelSelectorProps, RenderMode, ViewDefinition3dProps, ViewQueryParams, ViewStateProps } from "@bentley/imodeljs-common";
 import { Range3d } from "@bentley/geometry-core";
 import { StandardViewId } from "./StandardView";

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -39,6 +39,7 @@ import { ViewChangeOptions } from "./ViewAnimation";
 import { Viewport } from "./Viewport";
 import { DrawingViewState } from "./DrawingViewState";
 import { SpatialViewState } from "./SpatialViewState";
+import { SheetViewState } from "./SheetViewState";
 import { ViewStatus } from "./ViewStatus";
 import { ViewPose, ViewPose2d, ViewPose3d } from "./ViewPose";
 
@@ -338,6 +339,8 @@ export abstract class ViewState extends ElementState {
   public abstract isSpatialView(): this is SpatialViewState;
   /** Returns true if this ViewState is-a [[DrawingViewState]] */
   public abstract isDrawingView(): this is DrawingViewState;
+  /** Returns true if this ViewState is-a [[SheetViewState]] */
+  public isSheetView(): this is SheetViewState { return false; }
   /** Returns true if [[ViewTool]]s are allowed to operate in three dimensions on this view. */
   public abstract allow3dManipulations(): boolean;
   /** @internal */

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -180,7 +180,7 @@ export type OnFlashedIdChangedEventArgs = {
 } | {
   readonly previous: Id64String;
   readonly current: undefined;
-}
+};
 
 /** A Viewport renders the contents of one or more [GeometricModel]($backend)s onto an `HTMLCanvasElement`.
  *

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -46,7 +46,6 @@ import { GraphicList } from "./render/RenderGraphic";
 import { RenderMemory } from "./render/RenderMemory";
 import { createRenderPlanFromViewport } from "./render/RenderPlan";
 import { RenderTarget } from "./render/RenderTarget";
-import { SheetViewState } from "./SheetViewState";
 import { StandardView, StandardViewId } from "./StandardView";
 import { SubCategoriesCache } from "./SubCategoriesCache";
 import { DisclosedTileTreeSet, MapLayerImageryProvider, MapTileTreeReference, TileBoundingBoxes, TiledGraphicsProvider, TileTreeReference } from "./tile/internal";
@@ -657,7 +656,7 @@ export abstract class Viewport implements IDisposable {
     if (!this._sceneValid)
       return;
 
-    if (this.view.displayStyle.wantShadows || this.view instanceof SheetViewState)
+    if (this.view.displayStyle.wantShadows || this.view.isSheetView())
       this.invalidateScene();
   }
 

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -168,6 +168,20 @@ declare global {
   }
 }
 
+/** Payload for the [[Viewport.onFlashedIdChanged]] event indicating Ids of the currently- and/or previously-flashed objects.
+ * @public
+ */
+export type OnFlashedIdChangedEventArgs = {
+  readonly current: Id64String;
+  readonly previous: Id64String;
+} | {
+  readonly current: Id64String;
+  readonly previous: undefined;
+} | {
+  readonly previous: Id64String;
+  readonly current: undefined;
+}
+
 /** A Viewport renders the contents of one or more [GeometricModel]($backend)s onto an `HTMLCanvasElement`.
  *
  * It holds a [[ViewState]] object that defines its viewing parameters; the ViewState in turn defines the [[DisplayStyleState]],
@@ -235,6 +249,8 @@ export abstract class Viewport implements IDisposable {
   /** Event invoked after [[renderFrame]] detects that the dimensions of the viewport's [[ViewRect]] have changed.
    */
   public readonly onResized = new BeEvent<(vp: Viewport) => void>();
+  /** Event dispatched immediately after [[flashedId]] changes, supplying the Ids of the previousl-y and/or currently-flashed objects. */
+  public readonly onFlashedIdChanged = new BeEvent<(vp: Viewport, args: OnFlashedIdChangedEventArgs) => void>();
 
   /** This is initialized by a call to [[changeView]] sometime shortly after the constructor is invoked.
    * During that time it can be undefined. DO NOT assign directly to this member - use `setView()`.
@@ -1415,16 +1431,42 @@ export abstract class Viewport implements IDisposable {
     this.invalidateDecorations();
   }
 
+  /** The Id of the currently-flashed object.
+   * The "flashed" visual effect is typically applied to the object in the viewport currently under the mouse cursor, to indicate
+   * it is ready to be interacted with by a tool. [[ToolAdmin]] is responsible for updating it when the mouse cursor moves.
+   * The object is usually an [Element]($backend) but could also be a [Model]($backend) or pickable decoration produced by a [[Decorator]].
+   * The setter ignores any string that is not a well-formed [Id64String]($bentleyjs-core). Passing [Id64.invalid]($bentleyjs-core) to the
+   * setter is equivalent to passing `undefined` - both mean "nothing is flashed".
+   * @see [[onFlashedIdChanged]] to be notified when the flashed object changes.
+   * @see [[flashSettings]] to customize the visual effect.
+   */
+  public get flashedId(): Id64String | undefined {
+    return this._flashedElem;
+  }
+  public set flashedId(id: Id64String | undefined) {
+    if (id === Id64.invalid)
+      id = undefined;
+
+    const previous = this._lastFlashedElem;
+    if (id === previous || (undefined !== id && !Id64.isId64(id)))
+      return;
+
+    this._lastFlashedElem = this._flashedElem;
+    this._flashedElem = id;
+
+    // The comparison `id !== previous` above ensures the following assertion, but the compiler doesn't recognize it.
+    assert(undefined !== id || undefined !== previous);
+    this.onFlashedIdChanged.raiseEvent(this, { current: id!, previous });
+  }
+
   /** Set or clear the currently *flashed* element.
    * @note This method is not typically invoked directly - [[ToolAdmin]] will invoke it for you when the user hovers over an element.
    * @param id The Id of the element to flash. If undefined, remove (un-flash) the currently flashed element.
    * @param _duration Ignored - the duration from [[Viewport.flashSettings]] is used.
+   * @deprecated Set flashedId directly.
    */
   public setFlashed(id: string | undefined, _duration?: number): void {
-    if (id !== this._flashedElem) {
-      this._lastFlashedElem = this._flashedElem;
-      this._flashedElem = id;
-    }
+    this.flashedId = id;
   }
 
   public get auxCoordSystem(): AuxCoordSystemState { return this.view.auxiliaryCoordinateSystem; }
@@ -2099,14 +2141,14 @@ export abstract class Viewport implements IDisposable {
   private processFlash(): boolean {
     let needsFlashUpdate = false;
 
-    if (this._flashedElem !== this._lastFlashedElem) {
+    if (this.flashedId !== this._lastFlashedElem) {
       this._flashIntensity = 0.0;
       this._flashUpdateTime = BeTimePoint.now();
-      this._lastFlashedElem = this._flashedElem; // flashing has begun; this is now the previous flash
-      needsFlashUpdate = this._flashedElem === undefined; // notify render thread that flash has been turned off (signified by undefined elem)
+      this._lastFlashedElem = this.flashedId; // flashing has begun; this is now the previous flash
+      needsFlashUpdate = this.flashedId === undefined; // notify render thread that flash has been turned off (signified by undefined elem)
     }
 
-    if (this._flashedElem !== undefined && this._flashIntensity < this.flashSettings.maxIntensity) {
+    if (this.flashedId !== undefined && this._flashIntensity < this.flashSettings.maxIntensity) {
       assert(undefined !== this._flashUpdateTime);
 
       const flashDuration = this.flashSettings.duration;
@@ -2254,9 +2296,9 @@ export abstract class Viewport implements IDisposable {
 
     let requestNextAnimation = false;
     if (this.processFlash()) {
-      target.setFlashed(undefined !== this._flashedElem ? this._flashedElem : Id64.invalid, this._flashIntensity);
+      target.setFlashed(undefined !== this.flashedId ? this.flashedId : Id64.invalid, this._flashIntensity);
       isRedrawNeeded = true;
-      requestNextAnimation = undefined !== this._flashedElem;
+      requestNextAnimation = undefined !== this.flashedId;
     }
 
     this._frameStatsCollector.beginTime("onBeforeRenderTime");

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -12,7 +12,7 @@ import {
 } from "@bentley/imodeljs-quantity";
 import { IModelApp } from "../IModelApp";
 import { BasicUnitsProvider } from "./BasicUnitsProvider";
-import { IModelConnection } from "../imodeljs-frontend";
+import { IModelConnection } from "../IModelConnection";
 
 // cSpell:ignore FORMATPROPS FORMATKEY ussurvey uscustomary USCUSTOM
 

--- a/core/frontend/src/render/webgl/PlanarTextureProjection.ts
+++ b/core/frontend/src/render/webgl/PlanarTextureProjection.ts
@@ -13,8 +13,8 @@ import {
 } from "@bentley/geometry-core";
 import { Frustum, FrustumPlanes, Npc, RenderMode } from "@bentley/imodeljs-common";
 import { ApproximateTerrainHeights } from "../../ApproximateTerrainHeights";
-import { SceneContext, Tile } from "../../imodeljs-frontend";
-import { TileTreeReference } from "../../tile/internal";
+import { SceneContext } from "../../ViewContext";
+import { Tile, TileTreeReference } from "../../tile/internal";
 import { ViewState3d } from "../../ViewState";
 import { RenderState } from "./RenderState";
 import { Target } from "./Target";

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -10,7 +10,7 @@ import { assert, BeEvent, dispose, Id64String } from "@bentley/bentleyjs-core";
 import { ImageBuffer, ImageBufferFormat, ImageSource, ImageSourceFormat, isPowerOfTwo, nextHighestPowerOfTwo, RenderTexture } from "@bentley/imodeljs-common";
 import { imageBufferToPngDataUrl, imageElementFromImageSource, openImageDataUrlInNewWindow } from "../../ImageUtil";
 import { IModelConnection } from "../../IModelConnection";
-import { IModelApp } from "../../imodeljs-frontend";
+import { IModelApp } from "../../IModelApp";
 import { WebGLDisposable } from "./Disposable";
 import { GL } from "./GL";
 import { UniformHandle } from "./UniformHandle";

--- a/core/frontend/src/test/DeferredMarkerHtmlRemoval.test.ts
+++ b/core/frontend/src/test/DeferredMarkerHtmlRemoval.test.ts
@@ -4,11 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { ScreenViewport } from "../Viewport";
-import { Marker } from "../Marker";
 import { Decorator } from "../ViewManager";
 import { DecorateContext } from "../ViewContext";
 import { IModelApp } from "../IModelApp";
 import { openBlankViewport } from "./openBlankViewport";
+import { Marker } from "../Marker";
 
 describe("ScreenViewport", () => {
   beforeEach(async () => {

--- a/core/frontend/src/test/DeferredMarkerHtmlRemoval.test.ts
+++ b/core/frontend/src/test/DeferredMarkerHtmlRemoval.test.ts
@@ -8,9 +8,7 @@ import { Marker } from "../Marker";
 import { Decorator } from "../ViewManager";
 import { DecorateContext } from "../ViewContext";
 import { IModelApp } from "../IModelApp";
-import { SpatialViewState } from "../SpatialViewState";
-import { BlankConnection } from "../IModelConnection";
-import { Cartographic } from "@bentley/imodeljs-common";
+import { openBlankViewport } from "./openBlankViewport";
 
 describe("ScreenViewport", () => {
   beforeEach(async () => {
@@ -57,29 +55,8 @@ describe("ScreenViewport", () => {
     }
   }
 
-  function createMockViewport() {
-    const parentDiv = document.createElement("div");
-    parentDiv.setAttribute("height", "100px");
-    parentDiv.setAttribute("width", "100px");
-    parentDiv.style.height = parentDiv.style.width = "100px";
-    document.body.appendChild(parentDiv);
-    const vp = ScreenViewport.create(
-      parentDiv,
-      SpatialViewState.createBlank(
-        BlankConnection.create({
-          name: "test",
-          location: Cartographic.fromRadians(0, 0),
-          extents: { low: { x: 0, y: 0, z: 0 }, high: { x: 1, y: 1, z: 1 } },
-        }),
-        { x: 0, y: 0, z: 0 },
-        { x: 1, y: 1, z: 1 }
-      )
-    );
-    return vp;
-  }
-
   it("should not delete markers that are readded by registered decorators", () => {
-    const vp = createMockViewport();
+    const vp = openBlankViewport();
     const decorator = new AddMarkersAlwaysDecorator(vp);
     IModelApp.viewManager.addDecorator(decorator);
     IModelApp.viewManager.addViewport(vp);
@@ -104,7 +81,7 @@ describe("ScreenViewport", () => {
   });
 
   it("should delete markers that aren't readded by registered decorators", () => {
-    const vp = createMockViewport();
+    const vp = openBlankViewport();
     const decorator = new AddMarkersOnceDecorator(vp);
     IModelApp.viewManager.addDecorator(decorator);
     IModelApp.viewManager.addViewport(vp);

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { ScreenViewport } from "../Viewport";
+import { IModelApp } from "../IModelApp";
+import { openBlankViewport } from "./openBlankViewport";
+
+describe("Viewport", () => {
+  let viewport: ScreenViewport;
+
+  before(async () => await IModelApp.startup());
+  after(async () => await IModelApp.shutdown());
+  beforeEach(() => viewport = openBlankViewport());
+  afterEach(() => viewport.dispose());
+
+  describe("flashedId", () => {
+    type ChangedEvent = [string | undefined, string | undefined];
+
+    function expectFlashedId(expectedId: string | undefined, expectedEvent: ChangedEvent | undefined, func: () => void): void {
+      let event: ChangedEvent | undefined;
+      const removeListener = viewport.onFlashedIdChanged.addListener((vp, arg) => {
+        expect(vp).to.equal(viewport);
+        expect(event).to.be.undefined;
+        event = [arg.previous, arg.current];
+      });
+
+      func();
+      removeListener();
+
+      expect(viewport.flashedId).to.equal(expectedId);
+      expect(event).to.deep.equal(expectedEvent);
+    }
+
+    it("dispatches events when flashed Id changes", () => {
+      expectFlashedId("0x123", [undefined, "0x123"], () => viewport.flashedId = "0x123");
+      expectFlashedId("0x456", ["0x123", "0x456"], () => viewport.flashedId = "0x456");
+      expectFlashedId("0x456", undefined, () => viewport.flashedId = "0x456");
+      expectFlashedId(undefined, ["0x456", undefined], () => viewport.flashedId = undefined);
+      expectFlashedId(undefined, undefined, () => viewport.flashedId = undefined);
+    });
+
+    it("treats invalid Id as undefined", () => {
+      viewport.flashedId = "0x123";
+      expectFlashedId(undefined, ["0x123", undefined], () => viewport.flashedId = "0");
+      viewport.flashedId = "0x123";
+      expectFlashedId(undefined, ["0x123", undefined], () => viewport.flashedId = undefined);
+    });
+
+    it("rejects malformed Ids", () => {
+      expectFlashedId(undefined, undefined, () => viewport.flashedId = "not an id");
+      viewport.flashedId = "0x123";
+      expectFlashedId("0x123", undefined, () => viewport.flashedId = "not an id");
+    });
+
+    it("prohibits assignment from within event callback", () => {
+      viewport.onFlashedIdChanged.addOnce(() => viewport.flashedId = "0x12345");
+      expect(() => viewport.flashedId = "0x12345").to.throw(Error, "Cannot assign to Viewport.flashedId from within an onFlashedIdChanged event callback");
+    });
+  });
+});

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -11,8 +11,8 @@ import { openBlankViewport } from "./openBlankViewport";
 describe("Viewport", () => {
   let viewport: ScreenViewport;
 
-  before(async () => await IModelApp.startup());
-  after(async () => await IModelApp.shutdown());
+  before(async () => IModelApp.startup());
+  after(async () => IModelApp.shutdown());
   beforeEach(() => viewport = openBlankViewport());
   afterEach(() => viewport.dispose());
 

--- a/core/frontend/src/test/createBlankConnection.ts
+++ b/core/frontend/src/test/createBlankConnection.ts
@@ -5,12 +5,12 @@
 import { Guid } from "@bentley/bentleyjs-core";
 import { Range3d } from "@bentley/geometry-core";
 import { Cartographic } from "@bentley/imodeljs-common";
-import { BlankConnection, IModelConnection } from "../IModelConnection";
+import { BlankConnection } from "../IModelConnection";
 
 /** Open a blank connection for tests. */
 export function createBlankConnection(name = "test-blank-connection",
   location = Cartographic.fromDegrees(-75.686694, 40.065757, 0),
   extents = new Range3d(-1000, -1000, -100, 1000, 1000, 100),
-  contextId = Guid.createValue()): IModelConnection {
+  contextId = Guid.createValue()): BlankConnection {
   return BlankConnection.create({ name, location, extents, contextId });
 }

--- a/core/frontend/src/test/openBlankViewport.ts
+++ b/core/frontend/src/test/openBlankViewport.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { BlankConnection } from "../IModelConnection";
+import { ScreenViewport } from "../Viewport";
+import { SpatialViewState } from "../SpatialViewState";
+import { createBlankConnection } from "./createBlankConnection";
+
+/** Options for openBlankViewport.
+ * @internal
+ */
+export interface BlankViewportOptions {
+  /** Height in pixels. Default 100. */
+  height?: number;
+  /** Width in pixels. Default 100. */
+  width?: number;
+  /** iModel. If undefined, a new blank connection will be created. */
+  iModel?: BlankConnection;
+}
+
+/** Open a viewport for a blank spatial view.
+ * @internal
+ */
+export function openBlankViewport(options?: BlankViewportOptions): ScreenViewport {
+  const height = options?.height ?? 100;
+  const width = options?.width ?? 100;
+  const iModel = options?.iModel ?? createBlankConnection();
+
+  const parentDiv = document.createElement("div");
+  const hPx = `${height}px`;
+  const wPx = `${width}px`;
+
+  parentDiv.setAttribute("height", hPx);
+  parentDiv.setAttribute("width", wPx);
+  parentDiv.style.height = hPx;
+  parentDiv.style.width = wPx;
+  document.body.appendChild(parentDiv);
+
+  const view = SpatialViewState.createBlank(iModel, { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 });
+
+  /*
+  class BlankViewport extends ScreenViewport {
+    public dispose(): void {
+      document.body.removeChild(this.parentDiv);
+      super.dispose();
+    }
+  }
+  */
+
+  return /*Blank*/ ScreenViewport.create(parentDiv, view);
+}

--- a/core/frontend/src/test/openBlankViewport.ts
+++ b/core/frontend/src/test/openBlankViewport.ts
@@ -40,14 +40,19 @@ export function openBlankViewport(options?: BlankViewportOptions): ScreenViewpor
 
   const view = SpatialViewState.createBlank(iModel, { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 });
 
-  /*
   class BlankViewport extends ScreenViewport {
+    public ownedIModel?: BlankConnection;
+
     public dispose(): void {
       document.body.removeChild(this.parentDiv);
       super.dispose();
+      this.ownedIModel?.closeSync();
     }
   }
-  */
 
-  return /*Blank*/ ScreenViewport.create(parentDiv, view);
+  const viewport = BlankViewport.create(parentDiv, view) as BlankViewport;
+  if (undefined === options?.iModel)
+    viewport.ownedIModel = iModel;
+
+  return viewport;
 }

--- a/core/frontend/src/test/render/FrameStats.test.ts
+++ b/core/frontend/src/test/render/FrameStats.test.ts
@@ -3,13 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { Point3d, Vector3d } from "@bentley/geometry-core";
 import { IModelApp } from "../../IModelApp";
 import { IModelConnection } from "../../IModelConnection";
 import { createBlankConnection } from "../createBlankConnection";
 import { ScreenViewport } from "../../Viewport";
-import { SpatialViewState } from "../../SpatialViewState";
 import { FrameStats } from "../../render/FrameStats";
+import { openBlankViewport } from "../openBlankViewport";
 
 describe("FrameStats", () => {
   let imodel: IModelConnection;
@@ -25,24 +24,17 @@ describe("FrameStats", () => {
   });
 
   function testViewport(width: number, height: number, callback: (vp: ScreenViewport) => void): void {
-    const div = document.createElement("div");
-    div.style.width = `${width}px`;
-    div.style.height = `${height}px`;
-    div.style.position = "absolute";
-    div.style.top = div.style.left = "0px";
-    document.body.appendChild(div);
+    const vp = openBlankViewport({ width, height });
+    const vf = vp.viewFlags.clone();
+    vf.acsTriad = vf.grid = false;
+    vp.viewFlags = vf;
 
-    const view = SpatialViewState.createBlank(imodel, new Point3d(), new Vector3d(1, 1, 1));
-    view.viewFlags.acsTriad = view.viewFlags.grid = false;
-
-    const vp = ScreenViewport.create(div, view);
     IModelApp.viewManager.addViewport(vp);
 
     try {
       callback(vp);
     } finally {
       vp.dispose();
-      document.body.removeChild(div);
     }
   }
 

--- a/core/frontend/src/test/render/GraphicBuilder.test.ts
+++ b/core/frontend/src/test/render/GraphicBuilder.test.ts
@@ -13,18 +13,14 @@ import { IModelConnection } from "../../IModelConnection";
 import { createBlankConnection } from "../createBlankConnection";
 import { RenderSystem } from "../../render/RenderSystem";
 import { ScreenViewport } from "../../Viewport";
-import { SpatialViewState } from "../../SpatialViewState";
 import { MeshArgs, MeshParams, SurfaceType } from "../../render-primitives";
 import { MeshGraphic } from "../../render/webgl/Mesh";
 import { InstancedGraphicParams } from "../../render/InstancedGraphicParams";
+import { openBlankViewport } from "../openBlankViewport";
 
 describe("GraphicBuilder", () => {
   let imodel: IModelConnection;
   let viewport: ScreenViewport;
-
-  const viewDiv = document.createElement("div");
-  viewDiv.style.width = viewDiv.style.height = "1000px";
-  document.body.appendChild(viewDiv);
 
   before(async () => {
     await IModelApp.startup();
@@ -32,8 +28,7 @@ describe("GraphicBuilder", () => {
   });
 
   beforeEach(() => {
-    const spatialView = SpatialViewState.createBlank(imodel, { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 });
-    viewport = ScreenViewport.create(viewDiv, spatialView);
+    viewport = openBlankViewport();
   });
 
   afterEach(() => viewport.dispose());

--- a/core/frontend/src/test/render/primitives/GeometryAccumulator.test.ts
+++ b/core/frontend/src/test/render/primitives/GeometryAccumulator.test.ts
@@ -25,7 +25,7 @@ describe("GeometryAccumulator tests", () => {
   canvas.width = canvas.height = 1000;
   document.body.appendChild(canvas);
 
-  before(async () => {   // Create a ViewState to load into a Viewport
+  before(async () => {
     await IModelApp.startup();
     iModel = createBlankConnection();
     spatialView = SpatialViewState.createBlank(iModel, { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 });

--- a/core/frontend/src/test/render/primitives/MeshBuilder.test.ts
+++ b/core/frontend/src/test/render/primitives/MeshBuilder.test.ts
@@ -9,7 +9,6 @@ import { GraphicType } from "../../../render/GraphicBuilder";
 import { IModelApp } from "../../../IModelApp";
 import { MockRender } from "../../../render/MockRender";
 import { ScreenViewport } from "../../../Viewport";
-import { SpatialViewState } from "../../../SpatialViewState";
 import { DisplayParams } from "../../../render/primitives/DisplayParams";
 import { Geometry } from "../../../render/primitives/geometry/GeometryPrimitives";
 import { Mesh, MeshGraphicArgs } from "../../../render/primitives/mesh/MeshPrimitives";
@@ -17,9 +16,8 @@ import { PolyfacePrimitive, PolyfacePrimitiveList } from "../../../render/primit
 import { PrimitiveBuilder } from "../../../render/primitives/geometry/GeometryListBuilder";
 import { StrokesPrimitiveList, StrokesPrimitivePointLists } from "../../../render/primitives/Strokes";
 import { ToleranceRatio, Triangle } from "../../../render/primitives/Primitives";
-import { IModelConnection } from "../../../imodeljs-frontend";
-import { createBlankConnection } from "../../createBlankConnection";
 import { MeshBuilder, MeshEdgeCreationOptions, MeshParams } from "../../../render-primitives";
+import { openBlankViewport } from "../../openBlankViewport";
 
 class FakeDisplayParams extends DisplayParams {
   public constructor() {
@@ -30,22 +28,15 @@ class FakeDisplayParams extends DisplayParams {
 const edgeOptions = new MeshEdgeCreationOptions(MeshEdgeCreationOptions.Type.NoEdges);
 
 describe("Mesh Builder Tests", () => {
-  let imodel: IModelConnection;
-  let spatialView: SpatialViewState;
-
-  const viewDiv = document.createElement("div");
-  assert(null !== viewDiv);
-  viewDiv.style.width = viewDiv.style.height = "1000px";
-  document.body.appendChild(viewDiv);
+  let viewport: ScreenViewport;
 
   before(async () => {   // Create a ViewState to load into a Viewport
     await MockRender.App.startup();
-    imodel = createBlankConnection();
-    spatialView = SpatialViewState.createBlank(imodel, new Point3d(0, 0, 0), new Point3d(1, 1, 1));
+    viewport = openBlankViewport();
   });
 
   after(async () => {
-    if (imodel) await imodel.close();
+    viewport.dispose();
     await MockRender.App.shutdown();
   });
 
@@ -69,7 +60,6 @@ describe("Mesh Builder Tests", () => {
   });
 
   it("addStrokePointLists", () => {
-    const viewport = ScreenViewport.create(viewDiv, spatialView);
     const primBuilder = new PrimitiveBuilder(IModelApp.renderSystem, {type: GraphicType.Scene, viewport });
 
     const pointA = new Point3d(-100, 0, 0);

--- a/core/frontend/src/tile/GraphicsCollector.ts
+++ b/core/frontend/src/tile/GraphicsCollector.ts
@@ -8,7 +8,7 @@
 
 import { Map4d } from "@bentley/geometry-core";
 import { FrustumPlanes } from "@bentley/imodeljs-common";
-import { GraphicBranch } from "../imodeljs-frontend";
+import { GraphicBranch } from "../render/GraphicBranch";
 import { RenderGraphic } from "../render/RenderGraphic";
 import { SceneContext } from "../ViewContext";
 import { TileDrawArgs, TileGraphicType, TileTreeReference } from "./internal";

--- a/core/frontend/src/tile/map/ArcGisTokenGenerator.ts
+++ b/core/frontend/src/tile/map/ArcGisTokenGenerator.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { request, RequestOptions } from "@bentley/itwin-client";
-import { FrontendRequestContext } from "../../imodeljs-frontend";
+import { FrontendRequestContext } from "../../FrontendRequestContext";
 
 /** @packageDocumentation
  * @module Tiles

--- a/core/frontend/src/tile/map/ArcGisTokenManager.ts
+++ b/core/frontend/src/tile/map/ArcGisTokenManager.ts
@@ -6,7 +6,7 @@
  * @module Tiles
  */
 
-import { ArcGisGenerateTokenOptions, ArcGisToken, ArcGisTokenGenerator } from "../../imodeljs-frontend";
+import { ArcGisGenerateTokenOptions, ArcGisToken, ArcGisTokenGenerator } from "./ArcGisTokenGenerator";
 
 /** @internal */
 export class ArcGisTokenManager {

--- a/core/frontend/src/tile/map/ArcGisUtilities.ts
+++ b/core/frontend/src/tile/map/ArcGisUtilities.ts
@@ -5,7 +5,7 @@
 import { Angle } from "@bentley/geometry-core";
 import { MapSubLayerProps } from "@bentley/imodeljs-common";
 import { getJson, request, RequestBasicCredentials, RequestOptions, Response } from "@bentley/itwin-client";
-import { FrontendRequestContext } from "../../imodeljs-frontend";
+import { FrontendRequestContext } from "../../FrontendRequestContext";
 import { MapLayerSourceValidation } from "../internal";
 import { MapCartoRectangle } from "./MapCartoRectangle";
 import { MapLayerSource, MapLayerSourceStatus } from "./MapLayerSources";

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -10,9 +10,12 @@ import { Dictionary, IModelStatus } from "@bentley/bentleyjs-core";
 import { Cartographic, ImageSource, MapLayerSettings, ServerError } from "@bentley/imodeljs-common";
 import { getJson, request, RequestOptions, Response } from "@bentley/itwin-client";
 import { IModelApp } from "../../../IModelApp";
-import { ArcGisErrorCode, ArcGisTokenClientType, ImageryMapTile, ImageryMapTileTree, MapCartoRectangle, NotifyMessageDetails, OutputMessagePriority } from "../../../imodeljs-frontend";
+import {NotifyMessageDetails, OutputMessagePriority} from "../../../NotificationManager";
 import { ScreenViewport } from "../../../Viewport";
-import { ArcGisTokenManager, ArcGisUtilities, MapLayerImageryProvider, MapLayerImageryProviderStatus, QuadId } from "../../internal";
+import {
+  ArcGisErrorCode, ArcGisTokenClientType, ArcGisTokenManager, ArcGisUtilities, ImageryMapTile, ImageryMapTileTree, MapCartoRectangle,
+  MapLayerImageryProvider, MapLayerImageryProviderStatus, QuadId,
+} from "../../internal";
 
 // eslint-disable-next-line prefer-const
 let doToolTips = true;

--- a/core/frontend/src/tile/map/MapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryProvider.ts
@@ -10,7 +10,7 @@ import { BeEvent, ClientRequestContext } from "@bentley/bentleyjs-core";
 import { Cartographic, ImageSource, ImageSourceFormat, MapLayerSettings } from "@bentley/imodeljs-common";
 import { getJson, request, RequestBasicCredentials, RequestOptions, Response } from "@bentley/itwin-client";
 import { IModelApp } from "../../IModelApp";
-import { NotifyMessageDetails, OutputMessagePriority } from "../../imodeljs-frontend";
+import { NotifyMessageDetails, OutputMessagePriority } from "../../NotificationManager";
 import { ScreenViewport } from "../../Viewport";
 
 import { ImageryMapTile, ImageryMapTileTree, MapCartoRectangle, QuadId } from "../internal";

--- a/core/frontend/src/tile/map/MapTiledGraphicsProvider.ts
+++ b/core/frontend/src/tile/map/MapTiledGraphicsProvider.ts
@@ -8,10 +8,9 @@
 
 import { Id64String } from "@bentley/bentleyjs-core";
 import { BackgroundMapSettings, MapImagerySettings, MapLayerSettings } from "@bentley/imodeljs-common";
-import { MapLayerImageryProvider, Viewport, ViewState } from "../../imodeljs-frontend";
-import { TiledGraphicsProvider } from "../TiledGraphicsProvider";
-import { TileTreeReference } from "../TileTreeReference";
-import { MapTileTreeReference } from "./MapTileTree";
+import { Viewport } from "../../Viewport";
+import { ViewState } from "../../ViewState";
+import { MapLayerImageryProvider, MapTileTreeReference, TiledGraphicsProvider, TileTreeReference } from "../internal";
 
 /** @internal */
 export class MapTiledGraphicsProvider implements TiledGraphicsProvider {

--- a/core/frontend/src/tile/map/WmtsCapabilities.ts
+++ b/core/frontend/src/tile/map/WmtsCapabilities.ts
@@ -6,7 +6,7 @@ import { ClientRequestContext } from "@bentley/bentleyjs-core";
 import { Point2d, Range2d } from "@bentley/geometry-core";
 import { request, RequestBasicCredentials, RequestOptions } from "@bentley/itwin-client";
 import { xml2json } from "xml-js";
-import { MapCartoRectangle } from "../../imodeljs-frontend";
+import { MapCartoRectangle } from "../internal";
 import { WmsUtilities } from "./WmsUtilities"; // needed for getBaseUrl
 
 /** @packageDocumentation

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -377,7 +377,7 @@ export abstract class ViewManip extends ViewTool {
   /** @internal */
   public pickDepthPoint(ev: BeButtonEvent, isPreview: boolean = false): Point3d | undefined {
     if (!isPreview && ev.viewport && undefined !== this.getDepthPointGeometryId())
-      ev.viewport.setFlashed(undefined);
+      ev.viewport.flashedId = undefined;
 
     this.clearDepthPoint();
     if (isPreview && this.inDynamicUpdate)
@@ -521,7 +521,8 @@ export abstract class ViewManip extends ViewTool {
     if (ev.viewport && (showDepthChanged || prevSourceId)) {
       const currSourceId = this.getDepthPointGeometryId();
       if (currSourceId !== prevSourceId)
-        ev.viewport.setFlashed(currSourceId);
+        ev.viewport.flashedId = currSourceId;
+
       ev.viewport.invalidateDecorations();
     }
   }


### PR DESCRIPTION
Add `Viewport.flashedId` and corresponding event.
Deprecate Viewport.setFlashed, which took a second, deprecated and unused "duration" argument.

Incidentally:
- Consolidate some code for frontend tests that want to create a viewport.
- Fix a slew of bad imports resulting in circular dependencies (importing from imodeljs-frontend from within imodeljs-frontend, and importing directly from files in tile/ instead of from tile/internal).