### PR TITLE
Fix VSCode eslint extension failing to load @bentley/eslint-plugin

### DIFF
--- a/common/changes/@bentley/eslint-plugin/fix-vscode-eslint_2021-07-06-18-37.json
+++ b/common/changes/@bentley/eslint-plugin/fix-vscode-eslint_2021-07-06-18-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/eslint-plugin",
+  "email": "33036725+wgoehrig@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4448,12 +4448,13 @@ importers:
       eslint-plugin-react: 7.24.0
       eslint-plugin-react-hooks: 4.2.0
       require-dir: ^1.2.0
+      typescript: ~4.1.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.26.0_@typescript-eslint+parser@4.26.0
-      '@typescript-eslint/parser': 4.26.0
+      '@typescript-eslint/eslint-plugin': 4.26.0_31c20f200547c1d160801d0f391140c1
+      '@typescript-eslint/parser': 4.26.0_typescript@4.1.5
       eslint-import-resolver-node: 0.3.4
       eslint-import-resolver-typescript: 2.4.0_eslint-plugin-import@2.23.4
-      eslint-plugin-deprecation: 1.2.1
+      eslint-plugin-deprecation: 1.2.1_typescript@4.1.5
       eslint-plugin-import: 2.23.4
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 35.1.3
@@ -4462,6 +4463,8 @@ importers:
       eslint-plugin-react: 7.24.0
       eslint-plugin-react-hooks: 4.2.0
       require-dir: 1.2.0
+    devDependencies:
+      typescript: 4.1.5
 
   ../../tools/extension-cli:
     specifiers:
@@ -11562,6 +11565,31 @@ packages:
     dev: false
     optional: true
 
+  /@typescript-eslint/eslint-plugin/4.26.0_31c20f200547c1d160801d0f391140c1:
+    resolution: {integrity: sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^4.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/experimental-utils': 4.26.0_typescript@4.1.5
+      '@typescript-eslint/parser': 4.26.0_typescript@4.1.5
+      '@typescript-eslint/scope-manager': 4.26.0
+      debug: 4.3.1
+      functional-red-black-tree: 1.0.1
+      lodash: 4.17.21
+      regexpp: 3.1.0
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.1.5
+      typescript: 4.1.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/eslint-plugin/4.26.0_94f238412993144fe49c52fa75718185:
     resolution: {integrity: sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -11588,46 +11616,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.26.0_@typescript-eslint+parser@4.26.0:
-    resolution: {integrity: sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/experimental-utils': 4.26.0
-      '@typescript-eslint/parser': 4.26.0
-      '@typescript-eslint/scope-manager': 4.26.0
-      debug: 4.3.1
-      functional-red-black-tree: 1.0.1
-      lodash: 4.17.21
-      regexpp: 3.1.0
-      semver: 7.3.5
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/experimental-utils/3.10.1:
-    resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.7
-      '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
   /@typescript-eslint/experimental-utils/3.10.1_eslint@7.28.0+typescript@4.1.5:
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -11645,18 +11633,17 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.26.0:
-    resolution: {integrity: sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==}
+  /@typescript-eslint/experimental-utils/3.10.1_typescript@4.1.5:
+    resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       eslint: '*'
     dependencies:
       '@types/json-schema': 7.0.7
-      '@typescript-eslint/scope-manager': 4.26.0
-      '@typescript-eslint/types': 4.26.0
-      '@typescript-eslint/typescript-estree': 4.26.0
+      '@typescript-eslint/types': 3.10.1
+      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.1.5
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0
+      eslint-utils: 2.1.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11680,6 +11667,23 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/4.26.0_typescript@4.1.5:
+    resolution: {integrity: sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.7
+      '@typescript-eslint/scope-manager': 4.26.0
+      '@typescript-eslint/types': 4.26.0
+      '@typescript-eslint/typescript-estree': 4.26.0_typescript@4.1.5
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/experimental-utils/4.26.1_eslint@7.28.0+typescript@4.1.5:
     resolution: {integrity: sha512-sQHBugRhrXzRCs9PaGg6rowie4i8s/iD/DpTB+EXte8OMDfdCG5TvO73XlO9Wc/zi0uyN4qOmX9hIjQEyhnbmQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -11697,24 +11701,6 @@ packages:
       - supports-color
       - typescript
     dev: true
-
-  /@typescript-eslint/parser/4.26.0:
-    resolution: {integrity: sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 4.26.0
-      '@typescript-eslint/types': 4.26.0
-      '@typescript-eslint/typescript-estree': 4.26.0
-      debug: 4.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@typescript-eslint/parser/4.26.0_eslint@7.28.0+typescript@4.1.5:
     resolution: {integrity: sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==}
@@ -11735,6 +11721,25 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@typescript-eslint/parser/4.26.0_typescript@4.1.5:
+    resolution: {integrity: sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 4.26.0
+      '@typescript-eslint/types': 4.26.0
+      '@typescript-eslint/typescript-estree': 4.26.0_typescript@4.1.5
+      debug: 4.3.1
+      typescript: 4.1.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@typescript-eslint/scope-manager/4.26.0:
     resolution: {integrity: sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==}
@@ -11764,27 +11769,6 @@ packages:
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dev: true
 
-  /@typescript-eslint/typescript-estree/3.10.1:
-    resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/visitor-keys': 3.10.1
-      debug: 4.3.1
-      glob: 7.1.7
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      semver: 7.3.5
-      tsutils: 3.17.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@typescript-eslint/typescript-estree/3.10.1_typescript@4.1.5:
     resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -11805,27 +11789,6 @@ packages:
       typescript: 4.1.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree/4.26.0:
-    resolution: {integrity: sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.26.0
-      '@typescript-eslint/visitor-keys': 4.26.0
-      debug: 4.3.1
-      globby: 11.0.3
-      is-glob: 4.0.1
-      semver: 7.3.5
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@typescript-eslint/typescript-estree/4.26.0_typescript@4.1.5:
     resolution: {integrity: sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==}
@@ -11846,7 +11809,6 @@ packages:
       typescript: 4.1.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree/4.26.1_typescript@4.1.5:
     resolution: {integrity: sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==}
@@ -15735,15 +15697,16 @@ packages:
       debug: 3.2.7
       pkg-dir: 2.0.0
 
-  /eslint-plugin-deprecation/1.2.1:
+  /eslint-plugin-deprecation/1.2.1_typescript@4.1.5:
     resolution: {integrity: sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
       typescript: ^3.7.5 || ^4.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1
+      '@typescript-eslint/experimental-utils': 3.10.1_typescript@4.1.5
       tslib: 1.14.1
-      tsutils: 3.17.1
+      tsutils: 3.17.1_typescript@4.1.5
+      typescript: 4.1.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -25340,15 +25303,6 @@ packages:
       typescript: 4.1.5
     dev: false
 
-  /tsutils/3.17.1:
-    resolution: {integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
   /tsutils/3.17.1_typescript@4.1.5:
     resolution: {integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==}
     engines: {node: '>= 6'}
@@ -25358,15 +25312,6 @@ packages:
       tslib: 1.14.1
       typescript: 4.1.5
 
-  /tsutils/3.21.0:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
   /tsutils/3.21.0_typescript@4.1.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -25375,7 +25320,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.1.5
-    dev: true
 
   /tty-browserify/0.0.0:
     resolution: {integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=}

--- a/tools/eslint-plugin/package.json
+++ b/tools/eslint-plugin/package.json
@@ -44,5 +44,8 @@
   "peerDependencies": {
     "eslint": "^6.8.0 || ^7.0.0",
     "typescript": "^3.7.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "~4.1.0"
   }
 }


### PR DESCRIPTION
I noticed I had recently stopped getting lint warnings in VSCode, and tracked it back to this error:

```
[2:27 PM] Bill Goehrig
    
[Info  - 12:13:09 PM] ESLint server is starting
[Info  - 12:13:10 PM] ESLint server running in node v14.16.0
[Info  - 12:13:10 PM] ESLint server is running.
(node:73032) UnhandledPromiseRejectionWarning: Error: Failed to load plugin '@bentley' declared in '--config': Cannot find module 'typescript'
Require stack:
- D:\src\imodeljs\imodeljs\tools\eslint-plugin\dist\rules\import-spacing.js
- D:\src\imodeljs\imodeljs\common\temp\node_modules\.pnpm\require-dir@1.2.0\node_modules\require-dir\index.js
- D:\src\imodeljs\imodeljs\tools\eslint-plugin\dist\index.js
- D:\src\imodeljs\imodeljs\common\temp\node_modules\.pnpm\eslint@6.8.0\node_modules\eslint\lib\cli-engine\config-array-factory.js
- D:\src\imodeljs\imodeljs\common\temp\node_modules\.pnpm\eslint@6.8.0\node_modules\eslint\lib\cli-engine\cascading-config-array-factory.js
- D:\src\imodeljs\imodeljs\common\temp\node_modules\.pnpm\eslint@6.8.0\node_modules\eslint\lib\cli-engine\cli-engine.js
- D:\src\imodeljs\imodeljs\common\temp\node_modules\.pnpm\eslint@6.8.0\node_modules\eslint\lib\cli-engine\index.js
- D:\src\imodeljs\imodeljs\common\temp\node_modules\.pnpm\eslint@6.8.0\node_modules\eslint\lib\api.js
- c:\Users\Bill.Goehrig\.vscode\extensions\dbaeumer.vscode-eslint-2.1.23\server\out\eslintServer.js
Referenced from: D:\src\imodeljs\imodeljs\core\frontend\package.json
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:934:15)
    at Module._load (internal/modules/cjs/loader.js:779:27)
    at Function.f._load (electron/js2c/asar_bundle.js:5:12684)
    at Module.require (internal/modules/cjs/loader.js:1006:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (D:\src\imodeljs\imodeljs\tools\eslint-plugin\dist\rules\import-spacing.js:11:12)
    at Module._compile (internal/modules/cjs/loader.js:1125:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1155:10)
    at Module.load (internal/modules/cjs/loader.js:982:32)
    at Module._load (internal/modules/cjs/loader.js:823:14)
...
```

Adding typescript as a devDependency seems to fix the issue.