### PR TITLE
Fix the Nadir color for 2 colors skybox in the context of background map.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/geo-fix_2colors_skybox_map_2021-07-07-15-37.json
+++ b/common/changes/@bentley/imodeljs-frontend/geo-fix_2colors_skybox_map_2021-07-07-15-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix the Nadir color for 2 colors skybox in the context of background map.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "mdastous-bentley@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/glsl/SkySphere.ts
+++ b/core/frontend/src/render/webgl/glsl/SkySphere.ts
@@ -185,7 +185,7 @@ export function createSkySphereProgram(context: WebGLContext, isGradient: boolea
         if (plan.backgroundMapOn) {
           let clr = geom.skyColor;
           if (-1 === geom.typeAndExponents[0]) // 2-color gradient
-            clr = geom.zenithColor;
+            clr =  geom.nadirColor;
           if (plan.isGlobeMode3D) {
             modulateColor(clr, plan.globalViewTransition, scratch3Floats);
             uniform.setUniform3fv(scratch3Floats);


### PR DESCRIPTION
2 colors sky box became opaque when background map was turned ON