### PR TITLE
Attempting to compute range of analysis mesh.

### DIFF
--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -16,7 +16,7 @@ import {
   Range3d, Ray3d, Transform, Vector3d, XAndY, XYAndZ, XYZ,
 } from "@bentley/geometry-core";
 import {
-  BackgroundMapProps, BackgroundMapSettings, Camera, ClipStyle, ColorDef, DisplayStyleSettingsProps, Easing,
+  AnalysisStyle, BackgroundMapProps, BackgroundMapSettings, Camera, ClipStyle, ColorDef, DisplayStyleSettingsProps, Easing,
   ElementProps, FeatureAppearance, Frustum, GlobeMode, GridOrientationType, Hilite, ImageBuffer, Interpolation,
   isPlacement2dProps, LightSettings, MapLayerSettings, Npc, NpcCenter, Placement, Placement2d, Placement3d, PlacementProps,
   SolarShadowSettings, SubCategoryAppearance, SubCategoryOverride, ViewFlags,
@@ -2561,6 +2561,31 @@ export abstract class Viewport implements IDisposable {
    */
   public removeScreenSpaceEffects(): void {
     this.screenSpaceEffects = [];
+  }
+
+  public addOnAnalysisStyleChangedListener(listener: (newStyle: AnalysisStyle | undefined) => void): () => void {
+    const addSettingsListener = (style: DisplayStyleState) => style.settings.onAnalysisStyleChanged.addListener(listener);
+    let removeSettingsListener = addSettingsListener(this.displayStyle);
+
+    const addStyleListener = (view: ViewState) => view.onDisplayStyleChanged.addListener((style) => {
+      listener(style.settings.analysisStyle);
+      removeSettingsListener();
+      removeSettingsListener = addSettingsListener(view.displayStyle);
+    });
+
+    let removeStyleListener = addStyleListener(this.view);
+
+    const removeViewListener = this.onChangeView.addListener((vp) => {
+      listener(vp.view.displayStyle.settings.analysisStyle);
+      removeStyleListener();
+      addStyleListener(vp.view);
+    });
+
+    return () => {
+      removeSettingsListener();
+      removeStyleListener();
+      removeViewListener();
+    };
   }
 }
 

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -56,7 +56,7 @@ export class GeometryAccumulator {
 
   private getPrimitiveRange(geom: PrimitiveGeometryType): Range3d | undefined {
     const range = new Range3d();
-    if (geom instanceof IndexedPolyface)
+    if (geom instanceof IndexedPolyface && undefined !== this.analysisStyleDisplacementScale)
       geom.data.computeRange({ includeDisplacements: true, displacementScale: this.analysisStyleDisplacementScale }, range);
     else
       geom.range(undefined, range);

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -46,7 +46,7 @@ export class GeometryAccumulator {
   private getPrimitiveRange(geom: PrimitiveGeometryType): Range3d | undefined {
     const range = new Range3d();
     if (geom instanceof IndexedPolyface)
-      geom.data.computeRange({ includeDisplacements: true }, range);
+      geom.data.computeRange({ includeDisplacements: true, displacementScale: 100 }, range);
     else
       geom.range(undefined, range);
 

--- a/core/frontend/src/render/primitives/geometry/GeometryListBuilder.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryListBuilder.ts
@@ -121,7 +121,7 @@ export abstract class GeometryListBuilder extends GraphicBuilder {
 
   public addPolyface(meshData: Polyface): void {
     this.accum.addPolyface(meshData as IndexedPolyface, this.getMeshDisplayParams(), this.placement);
-    this.addRangeBox((meshData as IndexedPolyface).data.computeRange({ includeDisplacements: true }));
+    this.addRangeBox((meshData as IndexedPolyface).data.computeRange({ displacementScale: 100, includeDisplacements: true }));
   }
 
   public addSolidPrimitive(primitive: SolidPrimitive): void {

--- a/core/frontend/src/render/primitives/geometry/GeometryListBuilder.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryListBuilder.ts
@@ -121,6 +121,7 @@ export abstract class GeometryListBuilder extends GraphicBuilder {
 
   public addPolyface(meshData: Polyface): void {
     this.accum.addPolyface(meshData as IndexedPolyface, this.getMeshDisplayParams(), this.placement);
+    this.addRangeBox((meshData as IndexedPolyface).data.computeRange({ includeDisplacements: true }));
   }
 
   public addSolidPrimitive(primitive: SolidPrimitive): void {

--- a/core/frontend/src/test/render/primitives/GeometryAccumulator.test.ts
+++ b/core/frontend/src/test/render/primitives/GeometryAccumulator.test.ts
@@ -38,7 +38,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addPath works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -59,7 +59,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addLoop works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -83,7 +83,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addPolyface works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -121,7 +121,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addGeometry works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     expect(accum.geometries.isEmpty).to.be.true;
     expect(accum.isEmpty).to.be.true;
@@ -131,7 +131,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("clear works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     expect(accum.isEmpty).to.be.true;
     accum.addGeometry(new FakeGeometry());
@@ -141,7 +141,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("toMeshBuilderMap works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -182,7 +182,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("toMeshes works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -223,7 +223,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("saveToGraphicList works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));

--- a/core/geometry/src/polyface/AuxData.ts
+++ b/core/geometry/src/polyface/AuxData.ts
@@ -14,7 +14,7 @@ import { Matrix3d } from "../geometry3d/Matrix3d";
 import { Point3d } from "../geometry3d/Point3dVector3d";
 import { NumberArray } from "../geometry3d/PointHelpers";
 // import { Geometry } from "./Geometry";
-import { Range1d } from "../geometry3d/Range";
+import { Range1d, Range3d } from "../geometry3d/Range";
 
 /** The types of data that can be represented by an [[AuxChannelData]]. Each type of data contributes differently to the
  * animation applied by an [AnalysisStyle]($common) and responds differently when the host [[PolyfaceAuxData]] is transformed.
@@ -147,6 +147,21 @@ export class AuxChannel {
 
     return range;
   }
+
+  /** The minimum and maximum displacements, if [[dataType]] is [[AuxChannelDataType.Vector]]; or else a null range. */
+  public computeDisplacementRange(result?: Range3d): Range3d {
+    result = Range3d.createNull(result);
+
+    if (AuxChannelDataType.Vector === this.dataType) {
+      for (const data of this.data) {
+        const v = data.values;
+        for (let i = 0; i < v.length; i += 3)
+          result.extendXYZ(v[i], v[i + 1], v[i + 2]);
+      }
+    }
+
+    return result;
+  }
 }
 
 /**  The `PolyfaceAuxData` structure contains one or more analytical data channels for each vertex of a [[Polyface]], allowing the polyface to be styled
@@ -252,6 +267,16 @@ export class PolyfaceAuxData {
     }
 
     return true;
+  }
+
+  /** Compute the minimum and maximum displacements from all channels of [[AuxChannelDataType.Vector]]. */
+  public computeDisplacementRange(result?: Range3d): Range3d {
+    result = Range3d.createNull(result);
+    const channelRange = Range3d.createNull();
+    for (const channel of this.channels)
+      result.extendRange(channel.computeDisplacementRange(channelRange));
+
+    return result;
   }
 }
 

--- a/core/geometry/src/polyface/AuxData.ts
+++ b/core/geometry/src/polyface/AuxData.ts
@@ -149,14 +149,14 @@ export class AuxChannel {
   }
 
   /** The minimum and maximum displacements, if [[dataType]] is [[AuxChannelDataType.Vector]]; or else a null range. */
-  public computeDisplacementRange(result?: Range3d): Range3d {
+  public computeDisplacementRange(scale = 1, result?: Range3d): Range3d {
     result = Range3d.createNull(result);
 
     if (AuxChannelDataType.Vector === this.dataType) {
       for (const data of this.data) {
         const v = data.values;
         for (let i = 0; i < v.length; i += 3)
-          result.extendXYZ(v[i], v[i + 1], v[i + 2]);
+          result.extendXYZ(v[i] * scale, v[i + 1] * scale, v[i + 2] * scale);
       }
     }
 
@@ -270,11 +270,11 @@ export class PolyfaceAuxData {
   }
 
   /** Compute the minimum and maximum displacements from all channels of [[AuxChannelDataType.Vector]]. */
-  public computeDisplacementRange(result?: Range3d): Range3d {
+  public computeDisplacementRange(scale = 1, result?: Range3d): Range3d {
     result = Range3d.createNull(result);
     const channelRange = Range3d.createNull();
     for (const channel of this.channels)
-      result.extendRange(channel.computeDisplacementRange(channelRange));
+      result.extendRange(channel.computeDisplacementRange(scale, channelRange));
 
     return result;
   }

--- a/core/geometry/src/polyface/PolyfaceData.ts
+++ b/core/geometry/src/polyface/PolyfaceData.ts
@@ -353,10 +353,10 @@ export class PolyfaceData {
    * @param result Caller-allocated destination.
    * @returns The full range of the point array computed based on the supplied options.
    */
-  public computeRange(options?: { transform?: Transform, includeDisplacements?: boolean }, result?: Range3d): Range3d {
+  public computeRange(options?: { transform?: Transform, includeDisplacements?: boolean, displacementScale?: number }, result?: Range3d): Range3d {
     let displacementRange;
     if (options?.includeDisplacements)
-      displacementRange = this.auxData?.computeDisplacementRange();
+      displacementRange = this.auxData?.computeDisplacementRange(options?.displacementScale);
 
     if (!displacementRange || displacementRange.isNull)
       return this.range(result, options?.transform);

--- a/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
+++ b/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
@@ -63,8 +63,11 @@ async function createCantilever(): Promise<Polyface> {
   const polyface = IModelJson.Reader.parse(await response.json()) as Polyface;
   assert(polyface instanceof Polyface);
 
-  const transform = Transform.createScaleAboutPoint(new Point3d(), 30);
-  polyface.tryTransformInPlace(transform);
+  const doTransform = false;
+  if (doTransform) {
+    const transform = Transform.createScaleAboutPoint(new Point3d(), 30);
+    polyface.tryTransformInPlace(transform);
+  }
 
   return polyface;
 }


### PR DESCRIPTION
Element locate culls based on the range of the graphic. The graphic's range is computed from the static mesh. If an analysis mesh has displacement, locate fails when mousing over portions of the deformed mesh outside the static mesh's range.

I attempted to correct this by computing the maximal range of the deformed mesh. This works for the flat mesh with waves. It does not work for the cantilever mesh - the range is far too small (only slightly enlarged in negative Z). I'm missing something.