### PR TITLE
Adjust analysis mesh range based on analysis style displacement.

### DIFF
--- a/common/api/geometry-core.api.md
+++ b/common/api/geometry-core.api.md
@@ -311,6 +311,7 @@ export interface ArcVectors {
 export class AuxChannel {
     constructor(data: AuxChannelData[], dataType: AuxChannelDataType, name?: string, inputName?: string);
     clone(): AuxChannel;
+    computeDisplacementRange(scale?: number, result?: Range3d): Range3d;
     data: AuxChannelData[];
     dataType: AuxChannelDataType;
     get entriesPerValue(): number;

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -7,6 +7,7 @@
 import { AccessToken } from '@bentley/itwin-client';
 import { AmbientOcclusion } from '@bentley/imodeljs-common';
 import { AnalysisStyle } from '@bentley/imodeljs-common';
+import { AnalysisStyleDisplacement } from '@bentley/imodeljs-common';
 import { Angle } from '@bentley/geometry-core';
 import { AngleSweep } from '@bentley/geometry-core';
 import { AnyCurvePrimitive } from '@bentley/geometry-core';
@@ -12087,6 +12088,7 @@ export abstract class Viewport implements IDisposable {
     addFeatureOverrides(ovrs: FeatureSymbology.Overrides): void;
     // @internal
     addModelSubCategoryVisibilityOverrides(fs: FeatureSymbology.Overrides, ovrs: Id64.Uint32Map<Id64.Uint32Set>): void;
+    addOnAnalysisStyleChangedListener(listener: (newStyle: AnalysisStyle | undefined) => void): () => void;
     addScreenSpaceEffect(effectName: string): void;
     addTiledGraphicsProvider(provider: TiledGraphicsProvider): void;
     addViewedModels(models: Id64Arg): Promise<void>;

--- a/common/changes/@bentley/geometry-core/analysis-mesh-range-2_2021-07-09-15-02.json
+++ b/common/changes/@bentley/geometry-core/analysis-mesh-range-2_2021-07-09-15-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "Add AuxChannel.computeDisplacementRange.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-common/analysis-mesh-range-2_2021-07-09-15-02.json
+++ b/common/changes/@bentley/imodeljs-common/analysis-mesh-range-2_2021-07-09-15-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Do not raise DisplayStyleSettings.onAnalysisStyleChanged event if the style did not actually change.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/analysis-mesh-range-2_2021-07-09-15-02.json
+++ b/common/changes/@bentley/imodeljs-frontend/analysis-mesh-range-2_2021-07-09-15-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Adjust the range of a RenderGraphic based on displacement applied by the viewport's AnalysisStyle, if any, so that displaced portions of the mesh can be located by tools.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/common/src/DisplayStyleSettings.ts
+++ b/core/common/src/DisplayStyleSettings.ts
@@ -708,6 +708,9 @@ export class DisplayStyleSettings {
    */
   public get analysisStyle(): AnalysisStyle | undefined { return this._analysisStyle; }
   public set analysisStyle(style: AnalysisStyle | undefined) {
+    if (style === this.analysisStyle)
+      return;
+
     this.onAnalysisStyleChanged.raiseEvent(style);
     this._analysisStyle = style;
     if (style)

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -16,7 +16,7 @@ import {
   Range3d, Ray3d, Transform, Vector3d, XAndY, XYAndZ, XYZ,
 } from "@bentley/geometry-core";
 import {
-  BackgroundMapProps, BackgroundMapSettings, Camera, ClipStyle, ColorDef, DisplayStyleSettingsProps, Easing,
+  AnalysisStyle, BackgroundMapProps, BackgroundMapSettings, Camera, ClipStyle, ColorDef, DisplayStyleSettingsProps, Easing,
   ElementProps, FeatureAppearance, Frustum, GlobeMode, GridOrientationType, Hilite, ImageBuffer, Interpolation,
   isPlacement2dProps, LightSettings, MapLayerSettings, Npc, NpcCenter, Placement, Placement2d, Placement3d, PlacementProps,
   SolarShadowSettings, SubCategoryAppearance, SubCategoryOverride, ViewFlags,
@@ -62,7 +62,6 @@ import { ModelDisplayTransformProvider, ViewState } from "./ViewState";
 import { ViewStatus } from "./ViewStatus";
 import { queryVisibleFeatures, QueryVisibleFeaturesCallback, QueryVisibleFeaturesOptions } from "./render/VisibleFeature";
 import { FlashSettings } from "./FlashSettings";
-import { AnalysisStyle } from "@bentley/imodeljs-common";
 
 // cSpell:Ignore rect's ovrs subcat subcats unmounting UI's
 
@@ -2582,7 +2581,7 @@ export abstract class Viewport implements IDisposable {
       removeSettingsListener = addSettingsListener(view.displayStyle);
     });
 
-    let removeStyleListener = addStyleListener(this.view);
+    const removeStyleListener = addStyleListener(this.view);
 
     const removeViewListener = this.onChangeView.addListener((vp) => {
       listener(vp.view.displayStyle.settings.analysisStyle);

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -62,7 +62,7 @@ import { ModelDisplayTransformProvider, ViewState } from "./ViewState";
 import { ViewStatus } from "./ViewStatus";
 import { queryVisibleFeatures, QueryVisibleFeaturesCallback, QueryVisibleFeaturesOptions } from "./render/VisibleFeature";
 import { FlashSettings } from "./FlashSettings";
-import {AnalysisStyle} from "@bentley/imodeljs-common";
+import { AnalysisStyle } from "@bentley/imodeljs-common";
 
 // cSpell:Ignore rect's ovrs subcat subcats unmounting UI's
 
@@ -2564,6 +2564,14 @@ export abstract class Viewport implements IDisposable {
     this.screenSpaceEffects = [];
   }
 
+  /** Add an event listener to be invoked whenever the [AnalysisStyle]($common) associated with this viewport changes.
+   * The analysis style may change for any of several reasons:
+   *  - When the viewport's associated [DisplayStyleSettings.analysisStyle]($common).
+   *  - When the viewport's associated [[ViewState.displayStyle]] changes.
+   *  - When the viewport's associated [[ViewState]] changes via [[changeView]].
+   * @param listener Callback accepting the new analysis style, or undefined if there is no analysis style.
+   * @returns A function that can be invoked to remove the event listener.
+   */
   public addOnAnalysisStyleChangedListener(listener: (newStyle: AnalysisStyle | undefined) => void): () => void {
     const addSettingsListener = (style: DisplayStyleState) => style.settings.onAnalysisStyleChanged.addListener(listener);
     let removeSettingsListener = addSettingsListener(this.displayStyle);

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -105,9 +105,8 @@ export class GeometryAccumulator {
   }
 
   public addPolyface(pf: IndexedPolyface, displayParams: DisplayParams, transform: Transform): boolean {
-    let range;
-
     // Adjust the mesh range based on displacements applied to vertices by analysis style, if applicable.
+    let range;
     if (this._analysisDisplacement) {
       const channel = pf.data.auxData?.channels.find((x) => x.name === this._analysisDisplacement!.channelName);
       const displacementRange = channel?.computeDisplacementRange(this._analysisDisplacement.scale);

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -7,7 +7,7 @@
  */
 
 import { assert } from "@bentley/bentleyjs-core";
-import { AuxChannelDataType, IndexedPolyface, Loop, Path, Point3d, Range3d, SolidPrimitive, Transform } from "@bentley/geometry-core";
+import { IndexedPolyface, Loop, Path, Point3d, Range3d, SolidPrimitive, Transform } from "@bentley/geometry-core";
 import { AnalysisStyleDisplacement } from "@bentley/imodeljs-common";
 import { IModelConnection } from "../../../IModelConnection";
 import { GraphicBranch } from "../../GraphicBranch";
@@ -38,12 +38,12 @@ export class GeometryAccumulator {
   public get haveTransform(): boolean { return !this._transform.isIdentity; }
 
   public constructor(options: {
-    iModel: IModelConnection,
-    system?: RenderSystem,
-    surfacesOnly?: boolean,
-    transform?: Transform,
-    tileRange?: Range3d,
-    analysisStyleDisplacement?: AnalysisStyleDisplacement,
+    iModel: IModelConnection;
+    system?: RenderSystem;
+    surfacesOnly?: boolean;
+    transform?: Transform;
+    tileRange?: Range3d;
+    analysisStyleDisplacement?: AnalysisStyleDisplacement;
   }) {
     this.iModel = options.iModel;
     this.system = options.system ?? IModelApp.renderSystem;

--- a/core/frontend/src/render/webgl/Graphic.ts
+++ b/core/frontend/src/render/webgl/Graphic.ts
@@ -31,7 +31,7 @@ import { ThematicSensors } from "./ThematicSensors";
 export abstract class Graphic extends RenderGraphic implements WebGLDisposable {
   public abstract addCommands(_commands: RenderCommands): void;
   public abstract get isDisposed(): boolean;
-  public get isPickable(): boolean { return false; }
+  public abstract get isPickable(): boolean;
   public addHiliteCommands(_commands: RenderCommands, _pass: RenderPass): void { assert(false); }
   public toPrimitive(): Primitive | undefined { return undefined; }
 }
@@ -298,6 +298,10 @@ export class GraphicsArray extends Graphic {
   constructor(public graphics: RenderGraphic[]) { super(); }
 
   public get isDisposed(): boolean { return 0 === this.graphics.length; }
+
+  public override get isPickable(): boolean {
+    return this.graphics.some((x) => (x as Graphic).isPickable);
+  }
 
   public dispose() {
     for (const graphic of this.graphics)

--- a/core/frontend/src/render/webgl/Layer.ts
+++ b/core/frontend/src/render/webgl/Layer.ts
@@ -29,6 +29,10 @@ abstract class GraphicWrapper extends Graphic {
     return this.graphic.isDisposed;
   }
 
+  public override get isPickable(): boolean {
+    return this.graphic.isPickable;
+  }
+
   public collectStatistics(stats: RenderMemory.Statistics): void {
     this.graphic.collectStatistics(stats);
   }

--- a/core/frontend/src/render/webgl/Mesh.ts
+++ b/core/frontend/src/render/webgl/Mesh.ts
@@ -152,6 +152,7 @@ export class MeshGraphic extends Graphic {
   }
 
   public get isDisposed(): boolean { return this.meshData.isDisposed && 0 === this._primitives.length; }
+  public get isPickable() { return false; }
 
   public dispose() {
     dispose(this.meshData);

--- a/core/frontend/src/render/webgl/Primitive.ts
+++ b/core/frontend/src/render/webgl/Primitive.ts
@@ -53,6 +53,7 @@ export class Primitive extends Graphic {
   }
 
   public get isDisposed(): boolean { return this.cachedGeometry.isDisposed; }
+  public get isPickable() { return false; }
 
   public dispose() {
     dispose(this.cachedGeometry);

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
+import { AnalysisStyle } from "@bentley/imodeljs-common";
 import { ScreenViewport } from "../Viewport";
 import { IModelApp } from "../IModelApp";
 import { openBlankViewport } from "./openBlankViewport";
@@ -58,6 +59,63 @@ describe("Viewport", () => {
     it("prohibits assignment from within event callback", () => {
       viewport.onFlashedIdChanged.addOnce(() => viewport.flashedId = "0x12345");
       expect(() => viewport.flashedId = "0x12345").to.throw(Error, "Cannot assign to Viewport.flashedId from within an onFlashedIdChanged event callback");
+    });
+  });
+
+  describe("analysis style changed events", () => {
+    it("registers and unregisters for multiple events", () => {
+      function expectListeners(expected: boolean): void {
+        const expectedNum = expected ? 1 : 0;
+        expect(viewport.onChangeView.numberOfListeners).to.equal(expectedNum);
+
+        // The viewport registers its own listener for each of these.
+        expect(viewport.view.onDisplayStyleChanged.numberOfListeners).to.equal(expectedNum + 1);
+        expect(viewport.displayStyle.settings.onAnalysisStyleChanged.numberOfListeners).to.equal(expectedNum + 1);
+      }
+
+      expectListeners(false);
+      const removeListener = viewport.addOnAnalysisStyleChangedListener(() => undefined);
+      expectListeners(true);
+      removeListener();
+      expectListeners(false);
+    });
+
+    it("emits events when analysis style changes", () => {
+      type EventPayload = AnalysisStyle | "undefined" | "none";
+      function expectChangedEvent(expectedPayload: EventPayload, func: () => void): void {
+        let payload: EventPayload = "none";
+        const removeListener = viewport.addOnAnalysisStyleChangedListener((style) => {
+          expect(payload).to.equal("none");
+          payload = style ?? "undefined";
+        });
+
+        func();
+        removeListener();
+        expect(payload).to.equal(expectedPayload);
+      }
+
+      const a = AnalysisStyle.fromJSON({ normalChannelName: "a" });
+
+      expectChangedEvent(a, () => viewport.displayStyle.settings.analysisStyle = a);
+      expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = a);
+
+      const b = AnalysisStyle.fromJSON({ normalChannelName: "b" });
+      expectChangedEvent(b, () => {
+        const style = viewport.displayStyle.clone();
+        style.settings.analysisStyle = b;
+        viewport.displayStyle = style;
+      });
+
+      const c = AnalysisStyle.fromJSON({ normalChannelName: "c" });
+      expectChangedEvent(c, () => {
+        const view = viewport.view.clone();
+        expect(view.displayStyle).not.to.equal(viewport.view.displayStyle);
+        view.displayStyle.settings.analysisStyle = c;
+        viewport.changeView(view);
+      });
+
+      expectChangedEvent("undefined", () => viewport.displayStyle.settings.analysisStyle = undefined);
+      expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = undefined);
     });
   });
 });

--- a/core/frontend/src/test/render/primitives/GeometryAccumulator.test.ts
+++ b/core/frontend/src/test/render/primitives/GeometryAccumulator.test.ts
@@ -38,7 +38,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addPath works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -59,7 +59,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addLoop works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -83,7 +83,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addPolyface works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -121,7 +121,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("addGeometry works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     expect(accum.geometries.isEmpty).to.be.true;
     expect(accum.isEmpty).to.be.true;
@@ -131,7 +131,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("clear works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     expect(accum.isEmpty).to.be.true;
     accum.addGeometry(new FakeGeometry());
@@ -141,7 +141,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("toMeshBuilderMap works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -182,7 +182,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("toMeshes works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));
@@ -223,7 +223,7 @@ describe("GeometryAccumulator tests", () => {
   });
 
   it("saveToGraphicList works as expected", () => {
-    accum = new GeometryAccumulator(iModel, IModelApp.renderSystem);
+    accum = new GeometryAccumulator({ iModel });
 
     const points: Point3d[] = [];
     points.push(new Point3d(0, 0, 0));

--- a/core/geometry/src/polyface/AuxData.ts
+++ b/core/geometry/src/polyface/AuxData.ts
@@ -148,7 +148,11 @@ export class AuxChannel {
     return range;
   }
 
-  /** Compute the minimum and maximum displacements, if [[dataType]] is [[AuxChannelDataType.Vector]]; or else a null range. */
+  /** Compute the range of this channel's displacement values, if [[dataType]] is [[AuxChannelDataType.Vector]].
+   * @param scale Scale by which to multiply each displacement.
+   * @param result Preallocated object in which to store result.
+   * @returns The range encompassing all this channel's displacements scaled by `scale`; or a null range if this channel does not contain displacements.
+   */
   public computeDisplacementRange(scale = 1, result?: Range3d): Range3d {
     result = Range3d.createNull(result);
 

--- a/core/geometry/src/polyface/AuxData.ts
+++ b/core/geometry/src/polyface/AuxData.ts
@@ -14,7 +14,7 @@ import { Matrix3d } from "../geometry3d/Matrix3d";
 import { Point3d } from "../geometry3d/Point3dVector3d";
 import { NumberArray } from "../geometry3d/PointHelpers";
 // import { Geometry } from "./Geometry";
-import { Range1d } from "../geometry3d/Range";
+import { Range1d, Range3d } from "../geometry3d/Range";
 
 /** The types of data that can be represented by an [[AuxChannelData]]. Each type of data contributes differently to the
  * animation applied by an [AnalysisStyle]($common) and responds differently when the host [[PolyfaceAuxData]] is transformed.
@@ -146,6 +146,21 @@ export class AuxChannel {
       range.extendArray(data.values);
 
     return range;
+  }
+
+  /** Compute the minimum and maximum displacements, if [[dataType]] is [[AuxChannelDataType.Vector]]; or else a null range. */
+  public computeDisplacementRange(scale = 1, result?: Range3d): Range3d {
+    result = Range3d.createNull(result);
+
+    if (AuxChannelDataType.Vector === this.dataType) {
+      for (const data of this.data) {
+        const v = data.values;
+        for (let i = 0; i < v.length; i += 3)
+          result.extendXYZ(v[i] * scale, v[i + 1] * scale, v[i + 2] * scale);
+      }
+    }
+
+    return result;
   }
 }
 

--- a/full-stack-tests/core/src/frontend/standalone/PrimitiveBuilder.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/PrimitiveBuilder.test.ts
@@ -330,7 +330,7 @@ describe("PrimitiveBuilder", () => {
 
   it("should be able to finish graphics", () => {
     const primBuilder = new PrimitiveBuilder(IModelApp.renderSystem, { type: GraphicType.Scene, viewport });
-    const accum = new GeometryAccumulator(imodel, IModelApp.renderSystem);
+    const accum = new GeometryAccumulator({ iModel: imodel });
 
     const gfParams: GraphicParams = new GraphicParams();
     gfParams.lineColor = ColorDef.white;

--- a/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
@@ -234,8 +234,6 @@ describe("Viewport changed events", async () => {
       expectNoChange(() => settings.analysisFraction = settings.analysisFraction);
       mon.expect(ChangeFlag.DisplayStyle, ViewportState.AnalysisFraction, () => settings.analysisFraction = 0.123456);
       mon.expect(ChangeFlag.DisplayStyle, ViewportState.AnalysisFraction | ViewportState.RenderPlan, () => settings.analysisStyle = AnalysisStyle.fromJSON({ displacement: { channelName: "source" } }));
-      // AnalysisStyle is mutable and has no comparison method.
-      mon.expect(ChangeFlag.DisplayStyle, ViewportState.AnalysisFraction | ViewportState.RenderPlan, (() => settings.analysisStyle = settings.analysisStyle));
 
       mon.expect(ChangeFlag.DisplayStyle | ChangeFlag.FeatureOverrideProvider, ViewportState.TimePoint, () => settings.timePoint = 43);
       expectNoChange(() => settings.timePoint = 43);

--- a/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
+++ b/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
@@ -187,8 +187,19 @@ class AnalysisDecorator {
   public constructor(viewport: Viewport, mesh: AnalysisMesh) {
     this._viewport = viewport;
     this.mesh = mesh;
-    this._dispose = viewport.onDisposed.addOnce(() => this.dispose());
     this._id = viewport.iModel.transientIds.next;
+
+    const removeDisposalListener = viewport.onDisposed.addOnce(() => this.dispose());
+    const removeAnalysisStyleListener = viewport.addOnAnalysisStyleChangedListener(() => {
+      this._graphic?.disposeGraphic();
+      this._graphic = undefined;
+    });
+
+    this._dispose = () => {
+      removeAnalysisStyleListener();
+      removeDisposalListener();
+    };
+
     IModelApp.viewManager.addDecorator(this);
   }
 


### PR DESCRIPTION
Element locate culls based on the range of the graphic. The graphic's range is computed from the static mesh. If an analysis mesh has displacement, locate fails when mousing over portions of the deformed mesh outside the static mesh's range.

To fix this, the viewport's AnalysisStyleDisplacement is supplied to the GeometryAccumulator, which uses it to compute a range that accounts for the style's displacement.
The example decorator discards its cached analysis mesh graphic whenever the analysis style changes.

Incidentally fixed failure to locate pickable decorations that were inside a GraphicsArray.