### PR TITLE
Add fallback query when models query fails

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/bug-fallback-models-query_2021-07-12-16-45.json
+++ b/common/changes/@bentley/imodeljs-frontend/bug-fallback-models-query_2021-07-12-16-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Handle failures in models query when isNotSpatiallyLocated property does not exist in the schema",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -254,9 +254,15 @@ export class ViewCreator3d {
    * Get all PhysicalModel ids in the connection
    */
   private async _getAllModels(): Promise<Id64Array> {
-
-    const query = "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false AND isNotSpatiallyLocated = false";
-    const models: Id64Array = await this._executeQuery(query);
+    let query = "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false AND isNotSpatiallyLocated = false";
+    let models = [];
+    try {
+      models = await this._executeQuery(query);
+    } catch {
+      // possible that the isNotSpatiallyLocated property is not available in the iModel's schema
+      query = "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false";
+      models = await this._executeQuery(query);
+    }
 
     return models;
   }


### PR DESCRIPTION
isNotSpatiallyLocated property may not be available in the iModel's schema