### PR TITLE
Fix blank imodel connection

### DIFF
--- a/common/changes/@bentley/ui-framework/fixBlankImodelConnection_2021-07-15-16-02.json
+++ b/common/changes/@bentley/ui-framework/fixBlankImodelConnection_2021-07-15-16-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "Add test for the iModelConnection being blank to avoid asserts when setting up for new iModel.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/ui/framework/src/test/syncui/SyncUiEventDispatcher.test.ts
+++ b/ui/framework/src/test/syncui/SyncUiEventDispatcher.test.ts
@@ -296,6 +296,16 @@ describe("SyncUiEventDispatcher", () => {
       SyncUiEventDispatcher.clearConnectionEvents(imodelMock.object);
     });
 
+    it("initializeConnectionEvents with blank iModelConnection", () => {
+      imodelMock.setup((x) => x.isBlankConnection()).returns(() => true);
+      SyncUiEventDispatcher.initializeConnectionEvents(imodelMock.object);
+    });
+
+    it("initializeConnectionEvents with blank iModelConnection and an undefined iModelId", () => {
+      imodelMock.setup((x) => x.iModelId).returns(() => undefined);
+      imodelMock.setup((x) => x.isBlankConnection()).returns(() => true);
+      SyncUiEventDispatcher.initializeConnectionEvents(imodelMock.object);
+    });
   });
 
   describe("SelectedViewportChanged", () => {


### PR DESCRIPTION
Now that calling `UiFramework.setIModelConnection`  calls `SyncUiEventDispatcher.initializeConnectionEvents` we must avoid doing certain set-up processing if the  `IModelConnection` is blank (ie `IModelConnection.isBlankConnection()`) to avoid exceptions being thrown.