### PR TITLE
Activate ecef gcs depend test

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/activate-ecef-gcs-depend-test_2021-07-16-14-19.json
+++ b/common/changes/@bentley/imodeljs-backend/activate-ecef-gcs-depend-test_2021-07-16-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Reactivated test that stopped working when a previous PR for ecef dependency to geographicCRS was reverted",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "73677355+AlainRobertAtBentley@users.noreply.github.com"
+}

--- a/core/backend/src/test/standalone/IModel.test.ts
+++ b/core/backend/src/test/standalone/IModel.test.ts
@@ -1822,8 +1822,7 @@ describe("iModel", () => {
     iModel2.close();
   });
 
-  // Deactivated since change was (temporarily) reverted
-  it.skip("presence of a GCS imposes the ecef value", async () => {
+  it("presence of a GCS imposes the ecef value", async () => {
     const args = {
       rootSubject: { name: "TestSubject", description: "test project" },
       client: "ABC Engineering",


### PR DESCRIPTION
Reactivated a test that stopped working when the changes from another PR was reverted. Now that ecef is computed when iModel has a gcs and stored value is not used then, the test makes sure that previous ecef value is recomputed when a GCS is set.