### PR TITLE
RulesetEmbedder bug

### DIFF
--- a/presentation/backend/src/test/RulesetEmbedder.test.ts
+++ b/presentation/backend/src/test/RulesetEmbedder.test.ts
@@ -112,14 +112,18 @@ describe("RulesetEmbedder", () => {
 
     rootSubjectMock.setup((x) => x.id).returns(() => rootSubjectId);
     rootSubjectMock.setup((x) => x.model).returns(() => modelId);
+    moq.configureForPromiseResult(rootSubjectMock);
 
     presentationRulesSubjectMock.setup((x) => x.id).returns(() => presentationRulesSubjectId);
     presentationRulesSubjectMock.setup((x) => x.model).returns(() => modelId);
+    moq.configureForPromiseResult(presentationRulesSubjectMock);
 
     definitionPartitionMock.setup((x) => x.id).returns(() => definitionPartitionId);
     definitionPartitionMock.setup((x) => x.model).returns(() => modelId);
+    moq.configureForPromiseResult(definitionPartitionMock);
 
     rulesetModelMock.setup((x) => x.id).returns(() => modelId);
+    moq.configureForPromiseResult(rulesetModelMock);
   }
 
   function setupMocksForHandlingPrerequisites() {


### PR DESCRIPTION
- In this code all references to new callbacks in `RulesetEmbedder` are commented out.
- "inserts a single ruleset" test is marked with .only, this test  gets `DefinitionModel` from iModel and doesn't create it, yet this test still times-out.