### PR TITLE
UI: Fix tree background not being rendered

### DIFF
--- a/common/changes/@bentley/ui-components/ui-components-fix-tree-background_2021-07-26-08-06.json
+++ b/common/changes/@bentley/ui-components/ui-components-fix-tree-background_2021-07-26-08-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "`ControlledTree`: Fix tree background not being rendered.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/ui/components/src/ui-components/tree/controlled/component/ControlledTree.scss
+++ b/ui/components/src/ui-components/tree/controlled/component/ControlledTree.scss
@@ -30,6 +30,7 @@
   .ReactVirtualized__Grid,
   .ReactWindow__VariableSizeList {
     overflow: auto !important;
+    background-color: inherit;
 
     @include uicore-scrollbar;
 


### PR DESCRIPTION
After swapping the order of some divs, the tree background became transparent. The difference it makes in presentation-test-app is subtle, but it is much more prominent in dark-themed UIs.