### PR TITLE
Infinite loop in ContextMenu component

### DIFF
--- a/common/changes/@bentley/ui-core/ui-menu-fix-backport_2021-07-26-15-05.json
+++ b/common/changes/@bentley/ui-core/ui-menu-fix-backport_2021-07-26-15-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "Fix infinite loop in ContextMenu component for menus that are taller than parent window.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core",
+  "email": "45079789+NancyMcCallB@users.noreply.github.com"
+}

--- a/ui/core/src/ui-core/contextmenu/ContextMenu.tsx
+++ b/ui/core/src/ui-core/contextmenu/ContextMenu.tsx
@@ -71,6 +71,8 @@ export class ContextMenu extends React.PureComponent<ContextMenuProps, ContextMe
   private _lastDirection: ContextMenuDirection | undefined = ContextMenuDirection.BottomRight;
   private _lastSelectedIndex: number = 0;
   private _injectedChildren: React.ReactNode;
+  private _parentWindowHeight: number = 0;
+  private _parentWindowWidth: number = 0;
 
   public static defaultProps: Partial<ContextMenuProps> = {
     direction: ContextMenuDirection.BottomRight,
@@ -320,6 +322,11 @@ export class ContextMenu extends React.PureComponent<ContextMenuProps, ContextMe
     const parentWindow = this.getWindow();
 
     let renderDirection = parentMenu === undefined ? this.state.direction : direction;
+
+    if (parentWindow.innerHeight === this._parentWindowHeight && parentWindow.innerWidth === this._parentWindowWidth)
+      return;
+    this._parentWindowHeight = parentWindow.innerHeight;
+    this._parentWindowWidth = parentWindow.innerWidth;
 
     // check if menu should flip
     if (parentWindow && autoflip && parentMenu === undefined) {


### PR DESCRIPTION
Fix infinite loop in ContextMenu component by not recalculating the menu position when the parent window's size has not changed.