### PR TITLE
UI: Fix test pollution caused by iTwinUI-React components

### DIFF
--- a/common/changes/@bentley/ui-framework/ui-framework-fix-test-pollution_2021-07-26-14-57.json
+++ b/common/changes/@bentley/ui-framework/ui-framework-fix-test-pollution_2021-07-26-14-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-framework",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-framework",
+  "email": "70327485+roluk@users.noreply.github.com"
+}

--- a/ui/framework/src/test/imodel-components/category-tree/CategoriesTree.test.snap
+++ b/ui/framework/src/test/imodel-components/category-tree/CategoriesTree.test.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CategoryTree <CategoryTree /> should match snapshot 1`] = `
-<body
-  class="iui-body"
->
+<body>
   <div>
     <div
       class="ui-fw-categories-tree"

--- a/ui/framework/src/test/imodel-components/category-tree/CategoriesTreeWithSearchBox.test.snap
+++ b/ui/framework/src/test/imodel-components/category-tree/CategoriesTreeWithSearchBox.test.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CategoryTreeWithSearchBox <CategoryTreeWithSearchBox /> should match snapshot 1`] = `
-<body
-  class="iui-body"
->
+<body>
   <div>
     <div
       class="ui-fw-categories-tree-with-search"

--- a/ui/framework/src/test/imodel-components/models-tree/ModelsTree.test.snap
+++ b/ui/framework/src/test/imodel-components/models-tree/ModelsTree.test.snap
@@ -3190,9 +3190,7 @@ Array [
 `;
 
 exports[`ModelsTree #unit <ModelsTree /> should match snapshot 1`] = `
-<body
-  class="iui-body"
->
+<body>
   <div>
     <div
       class="ui-fw-models-tree"

--- a/ui/framework/src/test/imodel-components/spatial-tree/SpatialContainmentTree.test.snap
+++ b/ui/framework/src/test/imodel-components/spatial-tree/SpatialContainmentTree.test.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SpatialContainmentTree <SpatialContainmentTree /> renders 1`] = `
-<body
-  class="iui-body"
->
+<body>
   <div>
     <div
       class="ui-fw-spatial-tree"

--- a/ui/framework/src/test/setup.test.ts
+++ b/ui/framework/src/test/setup.test.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+afterEach(() => {
+  // Undo DOM manipulations made by iTwinUI-React components
+  document.getElementsByTagName("html")[0].innerHTML = "";
+});


### PR DESCRIPTION
I noticed that `ModelsTree` tests fail when run in isolation.

It turns out that there is a dependency on previously run tests that mount components from iTwinUI-React, which manipulate the global state by inserting a class attribute into document's `body`.

The solution is to reset `jsdom` state between each test.