### PR TITLE
Update a few release tags in geom-core

### DIFF
--- a/common/changes/@bentley/geometry-core/geom-add-missing-tags_2021-07-27-02-00.json
+++ b/common/changes/@bentley/geometry-core/geom-add-missing-tags_2021-07-27-02-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/core/geometry/src/curve/internalContexts/CloneCurvesContext.ts
+++ b/core/geometry/src/curve/internalContexts/CloneCurvesContext.ts
@@ -15,6 +15,7 @@ import { RecursiveCurveProcessorWithStack } from "../CurveProcessor";
  * Algorithmic class for cloning curve collections.
  * * recurse through collection nodes, building image nodes as needed and inserting clones of children.
  * * for individual primitive, invoke doClone (protected) for direct clone; insert into parent
+ * @internal
  */
 export class CloneCurvesContext extends RecursiveCurveProcessorWithStack {
   protected _result: CurveCollection | undefined;

--- a/core/geometry/src/curve/internalContexts/GapSearchContext.ts
+++ b/core/geometry/src/curve/internalContexts/GapSearchContext.ts
@@ -10,7 +10,6 @@ import { CurveChain, CurveCollection } from "../CurveCollection";
 import { CurvePrimitive } from "../CurvePrimitive";
 import { RecursiveCurveProcessorWithStack } from "../CurveProcessor";
 
-// import { SumLengthsContext, GapSearchContext, CountLinearPartsSearchContext, CloneCurvesContext, TransformInPlaceContext } from "./CurveSearches";
 /** Algorithmic class: Accumulate maximum gap between adjacent primitives of CurveChain.
  * @internal
  */

--- a/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
+++ b/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
@@ -266,7 +266,11 @@ export class MultiChainCollector {
     return bag;
   }
 }
-// static methods to assist offset sequences ....
+
+/**
+ * static methods to assist offset sequences ....
+ * @internal
+ */
 export class OffsetHelpers {
   // recursively sum lengths, allowing CurvePrimitive, CurveCollection, or array of such at any level.
   public static sumLengths(data: any): number {


### PR DESCRIPTION
@EarlinLutz I had a report that there was a class on the docs site that could not be imported from the package (class is `OffsetHelpers `). The file that the class is contained in is not a part of the barrel which i assume why the import was not working.

However, when looking it seems like most methods/classes in that folder, `internalContexts`, should be internal.  Is that the case or are some of them supposed to be usable?

@tomdicarlo, could you provide @EarlinLutz with the details of what you're trying to do? Maybe there's a better/recommended way or this is a reason to expose it.