### PR TITLE
Fix rpc-interface test for snapping

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/fix-snap-cancellation_2021-07-27-10-27.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-snap-cancellation_2021-07-27-10-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/common/changes/@bentley/rpcinterface-full-stack-tests/fix-snap-cancellation_2021-07-27-10-06.json
+++ b/common/changes/@bentley/rpcinterface-full-stack-tests/fix-snap-cancellation_2021-07-27-10-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/rpcinterface-full-stack-tests",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/backend/src/test/standalone/DgnDbWorker.test.ts
+++ b/core/backend/src/test/standalone/DgnDbWorker.test.ts
@@ -195,8 +195,8 @@ describe("DgnDbWorker", () => {
 
     // Clear the worker thread pool so the snap request (now canceled) can be processed.
     blockers.forEach((w) => w.setReady());
-    await Promise.all(blockers.map((w) => w.promise));
+    await Promise.all(blockers.map(async (w) => w.promise));
 
-    expect(snap).to.be.rejectedWith("aborted");
+    await expect(snap).to.be.rejectedWith("aborted");
   });
 });

--- a/core/backend/src/test/standalone/DgnDbWorker.test.ts
+++ b/core/backend/src/test/standalone/DgnDbWorker.test.ts
@@ -5,10 +5,12 @@
 
 import { expect } from "chai";
 import { BeDuration } from "@bentley/bentleyjs-core";
+import { Matrix4d } from "@bentley/geometry-core";
 import { IModelHost } from "../../IModelHost";
 import { StandaloneDb } from "../../IModelDb";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { IModelJsNative } from "@bentley/imodeljs-native";
+import { BackendRequestContext } from "../../BackendRequestContext";
 
 describe("DgnDbWorker", () => {
   let imodel: StandaloneDb;
@@ -174,5 +176,27 @@ describe("DgnDbWorker", () => {
     expect(resolve.isOk || resolve.isSkipped || resolve.isAborted).to.be.true;
     expect(reject.isError || reject.isSkipped).to.be.true;
     expect(workers.some((x) => x.isAborted)).to.be.true;
+  });
+
+  it("cancels a snap request", async () => {
+    // Block the worker thread pool with 4 workers so that our snap cannot complete before they complete.
+    const blockers = [new Worker(), new Worker(), new Worker(), new Worker()];
+    blockers.forEach((w) => w.queue());
+
+    const sessionId = "0x222";
+    const snap = imodel.requestSnap(new BackendRequestContext(), sessionId, {
+      testPoint: { x: 1, y: 2, z: 3 },
+      closePoint: { x: 1, y: 2, z: 3 },
+      id: "0x111",
+      worldToView: Matrix4d.createIdentity().toJSON(),
+    });
+
+    imodel.cancelSnap(sessionId);
+
+    // Clear the worker thread pool so the snap request (now canceled) can be processed.
+    blockers.forEach((w) => w.setReady());
+    await Promise.all(blockers.map((w) => w.promise));
+
+    expect(snap).to.be.rejectedWith("aborted");
   });
 });

--- a/full-stack-tests/rpc-interface/src/frontend/IModelConnection.test.ts
+++ b/full-stack-tests/rpc-interface/src/frontend/IModelConnection.test.ts
@@ -7,7 +7,7 @@ import { Id64, Id64Set } from "@bentley/bentleyjs-core";
 import { Matrix4d, Point3d, XYZProps, YawPitchRollAngles } from "@bentley/geometry-core";
 import {
   EcefLocation, GeoCoordStatus, IModelCoordinatesResponseProps, IModelReadRpcInterface, IModelVersion, MassPropertiesOperation,
-  MassPropertiesRequestProps, ModelQueryParams, SnapResponseProps,
+  MassPropertiesRequestProps, ModelQueryParams,
 } from "@bentley/imodeljs-common";
 import { CheckpointConnection, IModelApp, IModelConnection, SpatialModelState, ViewState } from "@bentley/imodeljs-frontend";
 import { AccessToken } from "@bentley/itwin-client";
@@ -369,15 +369,17 @@ describe("Snapping", () => {
       worldToView: worldToView.toJSON(),
     };
 
-    const requestSnapPromises: Array<Promise<SnapResponseProps>> = [];
-    requestSnapPromises.push(IModelReadRpcInterface.getClient().requestSnap(iModel.getRpcProps(), id, snapProps));
-    await IModelReadRpcInterface.getClient().cancelSnap(iModel.getRpcProps(), id);
-
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    const promise = IModelReadRpcInterface.getClient().requestSnap(iModel.getRpcProps(), id, snapProps);
     try {
-      const snaps = await Promise.all(requestSnapPromises);
-      expect(snaps[0].status).to.not.be.undefined; // This is what we expect if the snap is completed before the cancellation is processed.
+      await IModelReadRpcInterface.getClient().cancelSnap(iModel.getRpcProps(), id);
+      const snap = await promise;
+
+      // This is what we expect if the snap is completed before the cancellation is processed.
+      expect(snap.status).not.to.be.undefined;
     } catch (err) {
       // This is what we expect if the cancellation occurs in time to really cancel the snap.
+      expect(err.message).to.equal("aborted");
     }
   });
 });


### PR DESCRIPTION
With `cancelSnap` outside of the try-catch, there was a possibility it produces an uncaught exception, failing the test.
With `expect` inside the `try` block followed by an empty `catch`, any errors would have been silently swallowed.
With an empty `catch` block, no verification of cancellation behavior.
Usage of `Promise.all` unnecessary for a single promise.
[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/181138).