### PR TITLE
zoomToElements ignores 2d for 3d view and vice-versa

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -4620,7 +4620,7 @@ export namespace IModelConnection {
     export class Elements {
         // @internal
         constructor(_iModel: IModelConnection);
-        getPlacements(elementIds: Iterable<Id64String>): Promise<Array<Placement & {
+        getPlacements(elementIds: Iterable<Id64String>, options?: Readonly<GetPlacementsOptions>): Promise<Array<Placement & {
             elementId: Id64String;
         }>>;
         getProps(arg: Id64Arg): Promise<ElementProps[]>;
@@ -4628,6 +4628,9 @@ export namespace IModelConnection {
         queryIds(params: EntityQueryParams): Promise<Id64Set>;
         queryProps(params: EntityQueryParams): Promise<ElementProps[]>;
         get rootSubjectId(): Id64String;
+    }
+    export interface GetPlacementsOptions {
+        type?: "3d" | "2d";
     }
     export class Models implements Iterable<ModelState> {
         [Symbol.iterator](): Iterator<ModelState>;

--- a/common/changes/@bentley/imodeljs-frontend/query-2d-or-3d-placements_2021-07-28-18-21.json
+++ b/common/changes/@bentley/imodeljs-frontend/query-2d-or-3d-placements_2021-07-28-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Viewport.zoomToElements includes only 2d or 3d elements based on view type.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -1949,7 +1949,8 @@ export abstract class Viewport implements IDisposable {
    * @param options options that control how the view change works and whether to change view rotation.
    */
   public async zoomToElements(ids: Id64Arg, options?: ViewChangeOptions & ZoomToOptions): Promise<void> {
-    this.zoomToPlacements(await this.iModel.elements.getPlacements(ids), options);
+    const placements = await this.iModel.elements.getPlacements(ids, { type: this.view.is3d() ? "3d" : "2d" });
+    this.zoomToPlacements(placements, options);
   }
 
   /** Zoom the view to a volume of space in world coordinates.

--- a/core/frontend/src/tools/ClipViewTool.ts
+++ b/core/frontend/src/tools/ClipViewTool.ts
@@ -948,7 +948,7 @@ export class ViewClipByElementTool extends ViewClipTool {
 
   protected async doClipToElements(viewport: Viewport, ids: Id64Arg, alwaysUseRange: boolean = false): Promise<boolean> {
     try {
-      const placements = await viewport.iModel.elements.getPlacements(ids);
+      const placements = await viewport.iModel.elements.getPlacements(ids, { type: viewport.view.is3d() ? "3d" : "2d" });
       if (0 === placements.length)
         return false;
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -15,6 +15,13 @@ Some components in @bentley/ui-core were deprecated in favor of components in @i
 A few constructs were deprecated in @bentley/ui-core package with alternatives elsewhere.
 Some older deprecated components, enums and interfaces were removed. These also have alternatives.
 
+## Viewport.zoomToElements improvements
+
+[Viewport.zoomToElements]($frontend) accepts any number of element Ids and fits the viewport to the union of their [Placement]($common)s. A handful of shortcomings of the previous implementation have been addressed:
+
+* Previously, the element Ids were passed to [IModelConnection.Elements.getProps]($frontend), which returned **all** of the element's properties (potentially many megabytes of data), only to extract the [PlacementProps]($common) for each element and discard the rest. Now, it uses the new [IModelConnection.Elements.getPlacements]($frontend) function to query only the placements.
+* Previously, if a mix of 2d and 3d elements were specified, the viewport would attempt to union their 2d and 3d placements, typically causing it to fit incorrectly because 2d elements reside in a different coordinate space than 3d elements. Now, the viewport ignores 2d elements if it is viewing a 3d view, and vice-versa.
+
 ### Deprecated Several ui-core Components in Favor of iTwinUI-react Components
 
 Several UI components in the @bentley/ui-core package have been deprecated.

--- a/full-stack-tests/core/src/frontend/standalone/Elements.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/Elements.test.ts
@@ -73,6 +73,12 @@ describe("Elements", () => {
         expect(placement.calculateRange().isAlmostEqual(actual.calculateRange())).to.be.true;
       }
     }
+
+    const placements2d = await imodel.elements.getPlacements(ids, { type: "2d" });
+    expect(placements2d.map((x) => x.elementId).sort()).to.deep.equal(Array.from(ids2d).sort());
+
+    const placements3d = await imodel.elements.getPlacements(ids, { type: "3d" });
+    expect(placements3d.map((x) => x.elementId).sort()).to.deep.equal(Array.from(ids3d).sort());
   });
 
   it("queries individual placements", async () => {


### PR DESCRIPTION
See NextVersion.md for details.
Also, previous implementation used `isPlacement2dProps`. It checks if `props.angle` is defined, and while the Placement2dProps interface suggests that property is required, it is often null in the database and defaults to zero.