### PR TITLE
Do not throw exception in BriefcaseManager.downloadBriefcase when the local file already exists AND the briefcase id is unassigned (pull only)

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/remove-exception-for-existing-bim_2021-07-30-15-17.json
+++ b/common/changes/@bentley/imodeljs-backend/remove-exception-for-existing-bim_2021-07-30-15-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "Remove exception in BriefcaseManager.downloadBriefcase when local file already exists to avoid changing behavior during 2.x generation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "33028649+ColinKerr@users.noreply.github.com"
+}

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -205,9 +205,6 @@ export class BriefcaseManager {
     const briefcaseId = request.briefcaseId ?? await this.acquireNewBriefcaseId(requestContext, request.iModelId);
     const fileName = request.fileName ?? this.getFileName({ briefcaseId, iModelId: request.iModelId });
 
-    if (IModelJsFs.existsSync(fileName))
-      throw new IModelError(IModelStatus.FileAlreadyExists, `Briefcase "${fileName}" already exists`);
-
     const asOf = request.asOf ?? IModelVersion.latest().toJSON();
     const changeset = await this.changesetFromVersion(requestContext, IModelVersion.fromJSON(asOf), request.iModelId);
 

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -205,6 +205,9 @@ export class BriefcaseManager {
     const briefcaseId = request.briefcaseId ?? await this.acquireNewBriefcaseId(requestContext, request.iModelId);
     const fileName = request.fileName ?? this.getFileName({ briefcaseId, iModelId: request.iModelId });
 
+    if (IModelJsFs.existsSync(fileName) && briefcaseId !== BriefcaseIdValue.Unassigned)
+      throw new IModelError(IModelStatus.FileAlreadyExists, `Briefcase "${fileName}" already exists`);
+
     const asOf = request.asOf ?? IModelVersion.latest().toJSON();
     const changeset = await this.changesetFromVersion(requestContext, IModelVersion.fromJSON(asOf), request.iModelId);
 


### PR DESCRIPTION
This change will keep us from changing the behavior of the briefcase manager right at the end of the 2.x generation.  I am limiting this to the 2.19 branch because it makes sense to have users check to see if a local copy of the iModel exists before calling download briefcase.  So for 3.x adding the exception is a reasonable change.