### PR TITLE
Problem in polygon booleans: recursive face visit failed whenever there

### DIFF
--- a/common/changes/@bentley/geometry-core/EDL_DisjointRegionBooleanSweepBug_2021-08-03-01-06.json
+++ b/common/changes/@bentley/geometry-core/EDL_DisjointRegionBooleanSweepBug_2021-08-03-01-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "Fix bug in polygon booleans when inputs are disjoint",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core",
+  "email": "69321059+EarlinLutz@users.noreply.github.com"
+}

--- a/core/geometry/src/curve/RegionOpsClassificationSweeps.ts
+++ b/core/geometry/src/curve/RegionOpsClassificationSweeps.ts
@@ -155,6 +155,7 @@ export class RegionOpsFaceToFaceSearch {
         facePathStack.push(mate);
         let faceNode = mate.faceSuccessor;
         mate.setMaskAroundFace(faceHasBeenVisited);
+        entryNode = mate;
         if (callbacks.enterFace(facePathStack, mate)) {
           for (; ;) {
             mate = faceNode.edgeMate;

--- a/core/geometry/src/test/topology/RegionOps.test.ts
+++ b/core/geometry/src/test/topology/RegionOps.test.ts
@@ -113,6 +113,7 @@ class PolygonBooleanTests {
     const range = Range3d.createArray(boundary0);
     const noisyDeltaX = range.xLength() * 1.25;
     let dx1 = noisyDeltaX;
+    const dx1Start = 2 * noisyDeltaX;
     let boolOp = "";
     const noisy = this.getNoisy();
     if (noisy !== 0)
@@ -138,7 +139,7 @@ class PolygonBooleanTests {
     this.y0 = 0.0;
     GeometryCoreTestIO.captureGeometry(this.allGeometry, LineString3d.create(boundary0), this.x0, this.y0);
     GeometryCoreTestIO.captureGeometry(this.allGeometry, LineString3d.create(boundary1), this.x0, this.y0);
-    this.y0 += yStep; dx1 = 0.0;
+    this.y0 += yStep; dx1 = dx1Start;
     boolOp = "Union";
     let unionArea;
     let differenceAreaBOnly;
@@ -149,7 +150,7 @@ class PolygonBooleanTests {
       unionArea = PolyfaceQuery.sumFacetAreas(unionRegion);
       GeometryCoreTestIO.captureGeometry(this.allGeometry, unionRegion, this.x0, this.y0);
     }
-    this.y0 += yStep; dx1 = 0.0;
+    this.y0 += yStep; dx1 = dx1Start;
 
     boolOp = "Intersection";
     const intersectionRegion = RegionOps.polygonXYAreaIntersectLoopsToPolyface(boundary0, boundary1);
@@ -157,7 +158,7 @@ class PolygonBooleanTests {
       intersectionArea = PolyfaceQuery.sumFacetAreas(intersectionRegion);
       GeometryCoreTestIO.captureGeometry(this.allGeometry, intersectionRegion, this.x0, this.y0);
     }
-    this.y0 += yStep; dx1 = 0.0;
+    this.y0 += yStep; dx1 = dx1Start;
 
     boolOp = "Difference";
     const differenceRegionAOnly = RegionOps.polygonXYAreaDifferenceLoopsToPolyface(boundary0, boundary1);
@@ -165,7 +166,7 @@ class PolygonBooleanTests {
       differenceAreaAOnly = PolyfaceQuery.sumFacetAreas(differenceRegionAOnly);
       GeometryCoreTestIO.captureGeometry(this.allGeometry, differenceRegionAOnly, this.x0, this.y0);
     }
-    this.y0 += yStep; dx1 = 0.0;
+    this.y0 += yStep; dx1 = dx1Start;
 
     boolOp = "Difference";
     const differenceRegionBOnly = RegionOps.polygonXYAreaDifferenceLoopsToPolyface(boundary1, boundary0);
@@ -175,7 +176,7 @@ class PolygonBooleanTests {
     }
 
     if (unionArea !== undefined && intersectionArea !== undefined && differenceAreaAOnly !== undefined && differenceAreaBOnly !== undefined) {
-      this.ck.testCoordinate(unionArea, differenceAreaAOnly + differenceAreaBOnly + intersectionArea);
+      this.ck.testCoordinate(unionArea, differenceAreaAOnly + differenceAreaBOnly + intersectionArea, "union = A1 + intersection + B1");
     }
     this.x0 += 2.0 * range.xLength() + dx1;
     this.y0 = 0.0;
@@ -199,6 +200,13 @@ describe("RegionOps", () => {
     expect(context.getNumErrors()).equals(0);
   });
 
+  it("BooleanDisjointRectangles", () => {
+    const context = new PolygonBooleanTests();
+    context.setDebugControls(10, 1);
+    context.testBooleans(Sample.createRectangleXY(0, 0, 5, 2), Sample.createRectangleXY(1, 4, 2, 3));
+    context.saveAndReset("RegionOps", "BooleanDisjointRectangles");
+    expect(context.getNumErrors()).equals(0);
+  });
   it.skip("BooleanFractalAB", () => {
     // EDL July 15 2019 This triggers euler problem
     const context = new PolygonBooleanTests();


### PR DESCRIPTION
 Problem in polygon booleans: recursive face visit failed whenever there
    were disjoint parts of of the inputs.
Correction:  Initiation of the "search from each outer loop node" stashed
    an outer loop node rather than inner, and the searches terminated
    without proper return-to-start.