### PR TITLE
UI: Avoid loading stale data from TreeDataProvider

### DIFF
--- a/common/changes/@bentley/ui-components/ui-components-tree-node-loader_2021-08-04-12-38.json
+++ b/common/changes/@bentley/ui-components/ui-components-tree-node-loader_2021-08-04-12-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components",
+  "email": "70327485+roluk@users.noreply.github.com"
+}


### PR DESCRIPTION
`TreeDataSource.requestItems` performs two async operations on the same `TreeDataProvider` instance, which is prone to race conditions. For example, `getNodesCount` result may not correlate with what `getNodes` will return when a presentation ruleset changes in between the calls (if there was no memoization involved, but that's just a `PresentationTreeDataProvider` implementation detail).

This change makes it so `TreeDataSource` does not call `getNodes` if there are no active subscribers, and also fixes `TreeNodeLoader` tests not setting up mocks for some `getNodeCount` calls.