### PR TITLE
Update CI to Node 14.17.4

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -27,6 +27,6 @@ jobs:
   - template: jobs/ci-core.yaml
     parameters:
       name: Node_14
-      nodeVersion: 14.17.0
+      nodeVersion: 14.17.4
       pool:
         vmImage: $(OS)

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -8,14 +8,14 @@ pr:
   drafts: false
   branches:
     include:
-    - master
-    - release/*
+      - master
+      - release/*
 
 jobs:
   - template: ci-core.yaml
     parameters:
       name: Node_14
-      nodeVersion: 14.17.0
+      nodeVersion: 14.17.4
       pool:
         name: $(name)
         demands:


### PR DESCRIPTION
Upgrading the Node version used in the CI to 14.17.4.

Node 14.17.0 has a known, and fixed, issue that causes a crash within the NAPI during the destructor routines. The fix for this was first introduced in 14.17.4, all other Node versions prior to this version within 14.x could exhibit the crash.