### PR TITLE
make colin kerr the secondary for imodel transformer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -167,7 +167,7 @@ rush.json       @calebmshafer @pmconne @wgoehrig
 /test-apps/imodel-from-geojson              @mgooding @pmconne
 /test-apps/imodel-from-orbitgt              @imodeljs/display
 /test-apps/imodel-from-reality-model        @imodeljs/display
-/test-apps/imodel-transformer               @MichaelBelousov @mgooding
+/test-apps/imodel-transformer               @MichaelBelousov @ColinKerr
 /test-apps/ninezone-test-app                @imodeljs/ui
 /test-apps/presentation-test-app            @imodeljs/presentation
 /test-apps/synchro-schedule-importer        @RBBentley @pmconne


### PR DESCRIPTION
make Colin Kerr the secondary owner of the imodel transformer