### PR TITLE
Improve error messages for "editor project location save".

### DIFF
--- a/common/changes/@bentley/imodeljs-editor-frontend/project-loc-save-message_2021-08-11-13-11.json
+++ b/common/changes/@bentley/imodeljs-editor-frontend/project-loc-save-message_2021-08-11-13-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-editor-frontend",
+      "comment": "Improve error messages for \"editor project location save\".",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-editor-frontend",
+  "email": "65233531+bbastings@users.noreply.github.com"
+}

--- a/editor/frontend/src/ProjectLocation/ProjectExtentsDecoration.ts
+++ b/editor/frontend/src/ProjectLocation/ProjectExtentsDecoration.ts
@@ -978,15 +978,17 @@ export class ProjectLocationSaveTool extends Tool {
       return false;
     }
 
-    if (deco.iModel.isReadonly)
-      return false;
+    if (deco.iModel.isReadonly) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, translateMessage("Readonly")));
+      return true;
+    }
 
     const extents = deco.getModifiedExtents();
     const ecefLocation = deco.getModifiedEcefLocation();
 
     if (undefined === extents && undefined === ecefLocation) {
       IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, translateMessage("NoChanges")));
-      return false;
+      return true;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/editor/frontend/src/public/locales/en/Editor.json
+++ b/editor/frontend/src/public/locales/en/Editor.json
@@ -158,6 +158,7 @@
         "NotAllowed": "A valid geographic coordinate reference system already exists",
         "NotGeolocated": "Not geolocated",
         "NoChanges": "No changes to project extents or geolocation to save",
+        "Readonly": "iModel is read-only",
         "ProjectExtents": "Project Extents",
         "LargeProjectExtents": "Project Extents Too Large",
         "ModifyProjectExtents": "Modify Project Extents",


### PR DESCRIPTION
Don't return false when showing a more detailed error to avoid having toast message closed by default unable to run key-in message.