### PR TITLE
Fix reality data client changelog

### DIFF
--- a/clients/reality-data/CHANGELOG.json
+++ b/clients/reality-data/CHANGELOG.json
@@ -5,11 +5,13 @@
       "version": "2.19.4",
       "tag": "@bentley/reality-data-client_v2.19.4",
       "date": "Thu, 12 Aug 2021 13:09:26 GMT",
-      "none": [
-        {
-          "comment": "revert imodeljs#1574 to use contextshare url instead of apim"
-        }
-      ]
+      "comments": {
+        "none": [
+          {
+            "comment": "revert imodeljs#1574 to use contextshare url instead of apim"
+          }
+        ]
+      }
     },
     {
       "version": "2.19.3",

--- a/common/changes/@bentley/reality-data-client/2.18.4-changelog-fix_2021-08-13-21-18.json
+++ b/common/changes/@bentley/reality-data-client/2.18.4-changelog-fix_2021-08-13-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/reality-data-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/reality-data-client",
+  "email": "32379572+skirby1996@users.noreply.github.com"
+}


### PR DESCRIPTION
Made a mistake with the changelogs for 2.18.4 which was preventing rush from bumping versions. Fixing on 2.19 first to unblock 2.19.5 release then cherry picking into master with 2.19.5 changelogs.