### PR TITLE
Correct mistake of passing a single element Id as a string instead of an array

### DIFF
--- a/core/backend/src/test/standalone/TileTree.test.ts
+++ b/core/backend/src/test/standalone/TileTree.test.ts
@@ -232,7 +232,7 @@ describe("tile tree", () => {
     expect(tree.contentIdQualifier).not.to.be.undefined;
   });
 
-  it("should include checksum on schedule script contents", async () => {
+  it.only("should include checksum on schedule script contents", async () => {
     const treeId: PrimaryTileTreeId = {
       type: BatchType.Primary,
       edgesRequired: false,
@@ -265,7 +265,7 @@ describe("tile tree", () => {
     expect(tree.contentIdQualifier).to.equal(`${scriptChecksum}${extentsChecksum}`);
   });
 
-  it("should update checksum after purge when schedule script contents change", async () => {
+  it.only("should update checksum after purge when schedule script contents change", async () => {
     const treeId: PrimaryTileTreeId = {
       type: BatchType.Primary,
       edgesRequired: false,

--- a/core/backend/src/test/standalone/TileTree.test.ts
+++ b/core/backend/src/test/standalone/TileTree.test.ts
@@ -232,7 +232,7 @@ describe("tile tree", () => {
     expect(tree.contentIdQualifier).not.to.be.undefined;
   });
 
-  it.only("should include checksum on schedule script contents", async () => {
+  it("should include checksum on schedule script contents", async () => {
     const treeId: PrimaryTileTreeId = {
       type: BatchType.Primary,
       edgesRequired: false,
@@ -265,7 +265,7 @@ describe("tile tree", () => {
     expect(tree.contentIdQualifier).to.equal(`${scriptChecksum}${extentsChecksum}`);
   });
 
-  it.only("should update checksum after purge when schedule script contents change", async () => {
+  it("should update checksum after purge when schedule script contents change", async () => {
     const treeId: PrimaryTileTreeId = {
       type: BatchType.Primary,
       edgesRequired: false,

--- a/core/common/src/RenderSchedule.ts
+++ b/core/common/src/RenderSchedule.ts
@@ -1047,7 +1047,13 @@ export namespace RenderSchedule {
     public addElementTimeline(elementIds: CompressedId64Set | Iterable<Id64String>): ElementTimelineBuilder {
       const batchId = this._obtainNextBatchId();
       let ids: CompressedId64Set;
+
+      // It's far too easy to accidentally pass a single Id (compiler can't help).
+      if (typeof elementIds === "string" && Id64.isValidId64(elementIds))
+        elementIds = [elementIds];
+
       if (typeof elementIds === "string") {
+        // Already compressed.
         ids = elementIds;
       } else {
         const sorted = Array.from(elementIds);


### PR DESCRIPTION
`ModelTimelineBuilder` has this function: `addElementTimeline(elementIds: CompressedId64Set | Iterable<Id64String>)`
It is very easy to forget to put a single element Id inside of an array - `builder.addElementTimeline(0x123)` vs `builder.addElementTimeline([0x123])`
CompressedId64Set and Id64String are just typedefs for `string`, so the compiler is happy to accept this (also, a `string` is an `Iterable<string>`).
Help out callers by detecting this mistake and correcting it. Otherwise we end up trying (and failing) to parse the string as a CompressedId64Set.