### PR TITLE
display-test-app supports briefcases

### DIFF
--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -180,6 +180,7 @@ display-test-app has access to all key-ins defined in the imodeljs-frontend and 
 * `dta incident markers` - toggle incident marker demo in the selected viewport.
 * `dta path decoration` - toggle drawing a small path decoration in the selected viewport for testing purposes.
 * `dta markup` - toggle markup on the selected viewport.
+* `dta signin` - sign in to use Bentley services like iModelHub and reality data.
 * `dta output shaders` - output debug information for compiled shaders. Requires SVT_DEBUG_SHADERS to have been set. Accepts 0-2 arguments:
   * `d=output\directory\` - directory into which to put the output files.
   * filter string: a combination of the following characters to filter the output (e.g., `gu` outputs all used glsl shaders, both fragment and vertex):

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -230,3 +230,5 @@ display-test-app has access to all key-ins defined in the imodeljs-editor-fronte
 
 * `dta edit` - begin a new editing scope, or end the current editing scope. The title of the window or browser tab will update to reflect the current state: "[R/W]" indicating no current editing scope, or "[EDIT]" indicating an active editing scope.
 * `dta place line string` - start placing a line string. Each data point defines another point in the string; a reset (right mouse button) finishes. The element is placed into the first spatial model and spatial category in the viewport's model and category selectors.
+* `dta push` - push local changes to iModelHub. Takes an optional description of the changes. You must be signed in.
+* `dta pull` - pull and merge changes from iModelHub into the local briefcase. You must be signed in.

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -39,7 +39,7 @@ npm run start:servers
 
 ## Using display-test-app
 
-Currently, display-test-app only supports opening snapshot iModels from the local disk. If you define the `SVT_STANDALONE_FILENAME` environment variable to contain the absolute path to an existing iModel file on your machine, then upon startup, a viewport displaying the contents of this iModel will be displayed. Otherwise, on startup the toolbar will have a button allowing you to select an iModel to open.
+Currently, display-test-app only supports opening snapshot iModels from the local disk. If you define the `SVT_STANDALONE_FILENAME` environment variable to contain the absolute path to an existing iModel file on your machine, then upon startup, a viewport displaying the contents of this iModel will be displayed. Otherwise, on startup the toolbar will have a button allowing you to select an iModel to open. If the file opened from disk is a briefcase that retains its link to iModelHub (as opposed to a snapshot) and is opened in read-write mode, it can push and pull changesets.
 
 display-test-app's UI consists of:
 
@@ -99,11 +99,11 @@ You can use these environment variables to alter the default behavior of various
 * SVT_STANDALONE_FILENAME
   * Absolute path to an iModel to be opened on start-up.
 * SVT_STANDALONE_FILEPATH (browser only)
-  * Allows SVT running in the browser to assume a common base path for ALL local standalone iModels. This enables the use of a file open dialog. Within that dialog you must navigate to the exact path and select a file residing inside that directory - not in any subdirectory thereof.
+  * Allows SVT running in the browser to assume a common base path for ALL local iModels. This enables the use of a file open dialog. Within that dialog you must navigate to the exact path and select a file residing inside that directory - not in any subdirectory thereof.
 * SVT_STANDALONE_VIEWNAME
   * The name of a view to open by default within an iModel.
 * SVT_STANDALONE_SIGNIN
-  * If defined (value does not matter), the user will be required to sign in. This enables access to content stored on the reality data service. As a side effect, you may observe a harmless "failed to fetch" dialog on startup, which can be safely dismissed.
+  * If defined (value does not matter), the user will be required to sign in at startup. This enables access to content stored on the reality data service. As a side effect, you may observe a harmless "failed to fetch" dialog on startup, which can be safely dismissed.
 * SVT_NO_MAXIMIZE_WINDOW
   * If defined, don't maximize the electron window on startup
 * SVT_NO_DEV_TOOLS
@@ -215,7 +215,7 @@ display-test-app has access to all key-ins defined in the imodeljs-frontend and 
 display-test-app supplies minimal features for editing the contents of an iModel, strictly for testing purposes. To use it:
 
 * Set SVT_READ_WRITE=1 in the environment.
-* Open an editable standalone iModel.
+* Open a briefcase or an editable standalone iModel.
 * Use the key-ins below to make changes; typically:
   * `dta edit` to begin an editing scope;
   * key-ins to delete/move/insert elements and undo/redo those changes;

--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -70,6 +70,15 @@
     "ShutDown": {
       "keyin": "dta shutdown"
     },
+    "SignIn": {
+      "keyin": "dta signin"
+    },
+    "PushChanges": {
+      "keyin": "dta push"
+    },
+    "PullChanges": {
+      "keyin": "dta pull"
+    },
     "ToggleShadowMapTiles": {
       "keyin": "dta shadow tiles"
     },

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -12,9 +12,8 @@ import {
 } from "@bentley/imodeljs-common";
 import { EditTools } from "@bentley/imodeljs-editor-frontend";
 import {
-  AccuDrawHintBuilder,
-  AccuDrawShortcuts, AccuSnap, AsyncMethodsOf, ExternalServerExtensionLoader, IModelApp, IpcApp, LocalhostIpcApp, PromiseReturnType, RenderSystem,
-  SelectionTool, SnapMode, TileAdmin, Tool, ToolAdmin,
+  AccuDrawHintBuilder, AccuDrawShortcuts, AccuSnap, AsyncMethodsOf, BriefcaseConnection, ExternalServerExtensionLoader, IModelApp,
+  IpcApp, LocalhostIpcApp, PromiseReturnType, RenderSystem, SelectionTool, SnapMode, TileAdmin, Tool, ToolAdmin,
 } from "@bentley/imodeljs-frontend";
 import { AndroidApp, IOSApp } from "@bentley/mobile-manager/lib/MobileFrontend";
 import { DtaConfiguration } from "../common/DtaConfiguration";
@@ -43,6 +42,7 @@ import { MarkupTool, ModelClipTool, SaveImageTool, ZoomToSelectedElementsTool } 
 import { ApplyModelDisplayScaleTool } from "./DisplayScale";
 import { SyncViewportsTool } from "./SyncViewportsTool";
 import { FrameStatsTool } from "./FrameStatsTool";
+import { signIn } from "./signIn";
 
 class DisplayTestAppAccuSnap extends AccuSnap {
   private readonly _activeSnaps: SnapMode[] = [SnapMode.NearestKeypoint];
@@ -72,6 +72,41 @@ class SVTSelectionTool extends SelectionTool {
 
     // ###TODO Want to do this only if version comparison enabled, but meh.
     IModelApp.locateManager.options.allowExternalIModels = true;
+  }
+}
+
+class SignInTool extends Tool {
+  public static override toolId = "SignIn";
+  public override run(): boolean {
+    signIn(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    return true;
+  }
+}
+
+abstract class PushPullChangesTool extends Tool {
+  protected abstract execute(bc: BriefcaseConnection, arg?: string): Promise<void>;
+
+  public override run(arg?: string): boolean {
+    const imodel = IModelApp.viewManager.selectedView?.iModel;
+    if (!imodel || !imodel.isBriefcaseConnection())
+      return false;
+
+    this.execute(imodel, arg); // eslint-disable-line @typescript-eslint/no-floating-promises
+    return true;
+  }
+}
+
+class PushChangesTool extends PushPullChangesTool {
+  public static override toolId = "PushChanges";
+  protected override async execute(bc: BriefcaseConnection, description?: string): Promise<void> {
+    await bc.pushChanges(description ?? "display-test-app");
+  }
+}
+
+class PullChangesTool extends PushPullChangesTool {
+  public static override toolId = "PullChanges";
+  protected override async execute(bc: BriefcaseConnection): Promise<void> {
+    return bc.pullAndMergeChanges();
   }
 }
 
@@ -220,6 +255,8 @@ export class DisplayTestApp {
       OpenIModelTool,
       OutputShadersTool,
       PlaceLineStringTool,
+      PullChangesTool,
+      PushChangesTool,
       PurgeTileTreesTool,
       RecordFpsTool,
       RefreshTilesTool,
@@ -228,6 +265,7 @@ export class DisplayTestApp {
       RestoreWindowTool,
       SaveImageTool,
       ShutDownTool,
+      SignInTool,
       SVTSelectionTool,
       SyncViewportsTool,
       ToggleAspectRatioSkewDecoratorTool,

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -84,6 +84,8 @@ class SignInTool extends Tool {
 }
 
 abstract class PushPullChangesTool extends Tool {
+  public static override get maxArgs() { return 1; }
+
   protected abstract execute(bc: BriefcaseConnection, arg?: string): Promise<void>;
 
   public override run(arg?: string): boolean {
@@ -98,6 +100,7 @@ abstract class PushPullChangesTool extends Tool {
 
 class PushChangesTool extends PushPullChangesTool {
   public static override toolId = "PushChanges";
+
   protected override async execute(bc: BriefcaseConnection, description?: string): Promise<void> {
     await bc.pushChanges(description ?? "display-test-app");
   }
@@ -105,6 +108,7 @@ class PushChangesTool extends PushPullChangesTool {
 
 class PullChangesTool extends PushPullChangesTool {
   public static override toolId = "PullChanges";
+
   protected override async execute(bc: BriefcaseConnection): Promise<void> {
     return bc.pullAndMergeChanges();
   }

--- a/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
+++ b/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
@@ -3,14 +3,13 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { ProcessDetector } from "@bentley/bentleyjs-core";
-import { BrowserAuthorizationCallbackHandler } from "@bentley/frontend-authorization-client";
 import { CloudStorageContainerUrl, CloudStorageTileCache, RpcConfiguration, TileContentIdentifier } from "@bentley/imodeljs-common";
-import { IModelApp, IModelConnection, NativeApp, RenderDiagnostics, RenderSystem } from "@bentley/imodeljs-frontend";
-import { AccessToken } from "@bentley/itwin-client";
+import { IModelApp, IModelConnection, RenderDiagnostics, RenderSystem } from "@bentley/imodeljs-frontend";
 import { WebGLExtensionName } from "@bentley/webgl-compatibility";
 import { DtaConfiguration } from "../common/DtaConfiguration";
 import { DisplayTestApp } from "./App";
 import { openIModel } from "./openIModel";
+import { signIn } from "./signIn";
 import { Surface } from "./Surface";
 import { setTitle } from "./Title";
 import { showStatus } from "./Utils";
@@ -55,23 +54,6 @@ async function openFile(filename: string, writable: boolean): Promise<IModelConn
   const iModelConnection = await openIModel(filename, writable);
   configuration.iModelName = iModelConnection.name;
   return iModelConnection;
-}
-
-// Wraps the signIn process
-// @return Promise that resolves to true after signIn is complete
-async function signIn(): Promise<boolean> {
-  if (!NativeApp.isValid) // for browser, frontend handles redirect. For native apps, backend handles it
-    await BrowserAuthorizationCallbackHandler.handleSigninCallback("http://localhost:3000/signin-callback");
-
-  const auth = IModelApp.authorizationClient!;
-  if (auth.isAuthorized)
-    return true;
-
-  return new Promise<boolean>((resolve, reject) => {
-    auth.onUserStateChanged.addOnce((token?: AccessToken) =>
-      resolve(token !== undefined));
-    auth.signIn().catch((err) => reject(err));
-  });
 }
 
 class FakeTileCache extends CloudStorageTileCache {

--- a/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
+++ b/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
@@ -10,7 +10,7 @@ import { AccessToken } from "@bentley/itwin-client";
 import { WebGLExtensionName } from "@bentley/webgl-compatibility";
 import { DtaConfiguration } from "../common/DtaConfiguration";
 import { DisplayTestApp } from "./App";
-import { openStandaloneIModel } from "./openStandaloneIModel";
+import { openIModel } from "./openIModel";
 import { Surface } from "./Surface";
 import { setTitle } from "./Title";
 import { showStatus } from "./Utils";
@@ -50,9 +50,9 @@ async function retrieveConfiguration(): Promise<void> {
   });
 }
 
-async function openIModel(filename: string, writable: boolean): Promise<IModelConnection> {
+async function openFile(filename: string, writable: boolean): Promise<IModelConnection> {
   configuration.standalone = true;
-  const iModelConnection = await openStandaloneIModel(filename, writable);
+  const iModelConnection = await openIModel(filename, writable);
   configuration.iModelName = iModelConnection.name;
   return iModelConnection;
 }
@@ -166,7 +166,7 @@ const dtaFrontendMain = async () => {
     const iModelName = configuration.iModelName;
     if (undefined !== iModelName) {
       const writable = configuration.openReadWrite ?? false;
-      iModel = await openIModel(iModelName, writable);
+      iModel = await openFile(iModelName, writable);
       setTitle(iModel);
     }
 

--- a/test-apps/display-test-app/src/frontend/Surface.ts
+++ b/test-apps/display-test-app/src/frontend/Surface.ts
@@ -15,7 +15,7 @@ import { TileLoadIndicator } from "./TileLoadIndicator";
 import { createToolButton, ToolBar } from "./ToolBar";
 import { Viewer, ViewerProps } from "./Viewer";
 import { Dock, NamedWindow, NamedWindowProps, Window, WindowProps } from "./Window";
-import { openStandaloneIModel } from "./openStandaloneIModel";
+import { openIModel } from "./openIModel";
 import { setTitle } from "./Title";
 import { openAnalysisStyleExample } from "./AnalysisStyleExample";
 import { openDecorationGeometryExample } from "./DecorationGeometryExample";
@@ -181,7 +181,7 @@ export class Surface {
     }
 
     try {
-      const iModel = await openStandaloneIModel(filename, this.openReadWrite);
+      const iModel = await openIModel(filename, this.openReadWrite);
       setTitle(iModel);
       const viewer = await this.createViewer({ iModel });
       viewer.dock(Dock.Full);

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -24,7 +24,7 @@ import { createImageButton, createToolButton, ToolBar } from "./ToolBar";
 import { ViewAttributesPanel } from "./ViewAttributes";
 import { ViewList, ViewPicker } from "./ViewPicker";
 import { Window } from "./Window";
-import { openStandaloneIModel } from "./openStandaloneIModel";
+import { openIModel } from "./openIModel";
 
 // cspell:ignore savedata topdiv savedview viewtop
 
@@ -432,7 +432,7 @@ export class Viewer extends Window {
     const sameFile = filename === this._imodel.key;
     if (!sameFile) {
       try {
-        newIModel = await openStandaloneIModel(filename, this.surface.openReadWrite);
+        newIModel = await openIModel(filename, this.surface.openReadWrite);
       } catch (err) {
         alert(err.toString());
         return;
@@ -445,7 +445,7 @@ export class Viewer extends Window {
     await this.clearViews();
 
     if (sameFile)
-      newIModel = await openStandaloneIModel(filename, this.surface.openReadWrite);
+      newIModel = await openIModel(filename, this.surface.openReadWrite);
 
     this._imodel = newIModel!;
     await this.buildViewList();

--- a/test-apps/display-test-app/src/frontend/openIModel.ts
+++ b/test-apps/display-test-app/src/frontend/openIModel.ts
@@ -2,13 +2,13 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { IModelStatus, OpenMode } from "@bentley/bentleyjs-core";
+import { IModelStatus } from "@bentley/bentleyjs-core";
 import { IModelError } from "@bentley/imodeljs-common";
 import { BriefcaseConnection, IModelConnection, SnapshotConnection } from "@bentley/imodeljs-frontend";
 
 export async function openIModel(fileName: string, writable: boolean,): Promise<IModelConnection> {
   try {
-    return await BriefcaseConnection.openFile({ fileName, readonly: !writable, key: fileName })
+    return await BriefcaseConnection.openFile({ fileName, readonly: !writable, key: fileName });
   } catch (err) {
     if (writable && err instanceof IModelError && err.errorNumber === IModelStatus.ReadOnly)
       return SnapshotConnection.openFile(fileName);

--- a/test-apps/display-test-app/src/frontend/openIModel.ts
+++ b/test-apps/display-test-app/src/frontend/openIModel.ts
@@ -6,12 +6,12 @@ import { IModelStatus, OpenMode } from "@bentley/bentleyjs-core";
 import { IModelError } from "@bentley/imodeljs-common";
 import { BriefcaseConnection, IModelConnection, SnapshotConnection } from "@bentley/imodeljs-frontend";
 
-export async function openStandaloneIModel(filename: string, writable: boolean,): Promise<IModelConnection> {
+export async function openIModel(fileName: string, writable: boolean,): Promise<IModelConnection> {
   try {
-    return await BriefcaseConnection.openStandalone(filename, writable ? OpenMode.ReadWrite : OpenMode.Readonly, { key: filename });
+    return await BriefcaseConnection.openFile({ fileName, readonly: !writable, key: fileName })
   } catch (err) {
     if (writable && err instanceof IModelError && err.errorNumber === IModelStatus.ReadOnly)
-      return SnapshotConnection.openFile(filename);
+      return SnapshotConnection.openFile(fileName);
     else
       throw err;
   }

--- a/test-apps/display-test-app/src/frontend/signIn.ts
+++ b/test-apps/display-test-app/src/frontend/signIn.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { IModelApp, NativeApp } from "@bentley/imodeljs-frontend";
+import { BrowserAuthorizationCallbackHandler } from "@bentley/frontend-authorization-client";
+import { AccessToken } from "@bentley/itwin-client";
+
+// Wraps the signIn process
+// @return Promise that resolves to true after signIn is complete
+export async function signIn(): Promise<boolean> {
+  // for browser, frontend handles redirect. For native apps, backend handles it
+  if (!NativeApp.isValid)
+    await BrowserAuthorizationCallbackHandler.handleSigninCallback("http://localhost:3000/signin-callback");
+
+  const auth = IModelApp.authorizationClient!;
+  if (auth.isAuthorized)
+    return true;
+
+  return new Promise<boolean>((resolve, reject) => {
+    auth.onUserStateChanged.addOnce((token?: AccessToken) => resolve(token !== undefined));
+    auth.signIn().catch((err) => reject(err));
+  });
+}


### PR DESCRIPTION
User must download the briefcase first using whatever method they choose - no UI or keyins are supplied for choosing a project and iModel within display-test-app.
Adds keyins for pushing and pulling changes and for signing in.
The primary purpose is to enable testing/debugging editing workflows involving pushing and pulling changes.