### PR TITLE
Add `queryV2Checkpoint` to `BackendHubAccess` interface

### DIFF
--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -659,7 +659,7 @@ export interface CheckpointProps {
     readonly expectV2?: boolean;
     readonly iModelId: GuidString;
     // (undocumented)
-    readonly requestContext: AuthorizedClientRequestContext;
+    readonly requestContext?: AuthorizedClientRequestContext;
 }
 
 // @public

--- a/common/api/imodeljs-backend.api.md
+++ b/common/api/imodeljs-backend.api.md
@@ -308,46 +308,47 @@ export class AzureBlobStorage extends CloudStorageService {
 
 // @internal
 export interface BackendHubAccess {
-    acquireLocks: (arg: BriefcaseDbArg & {
+    acquireLocks(arg: BriefcaseDbArg & {
         locks: LockProps[];
-    }) => Promise<void>;
-    acquireNewBriefcaseId: (arg: IModelIdArg) => Promise<number>;
-    acquireSchemaLock: (arg: BriefcaseDbArg) => Promise<void>;
-    createIModel: (arg: IModelNameArg & {
+    }): Promise<void>;
+    acquireNewBriefcaseId(arg: IModelIdArg): Promise<number>;
+    acquireSchemaLock(arg: BriefcaseDbArg): Promise<void>;
+    createIModel(arg: IModelNameArg & {
         description?: string;
         revision0?: LocalFileName;
-    }) => Promise<GuidString>;
-    deleteIModel: (arg: IModelIdArg & {
+    }): Promise<GuidString>;
+    deleteIModel(arg: IModelIdArg & {
         contextId: GuidString;
-    }) => Promise<void>;
-    downloadChangeset: (arg: ChangesetArg & {
+    }): Promise<void>;
+    downloadChangeset(arg: ChangesetArg & {
         targetDir: LocalDirName;
-    }) => Promise<ChangesetFileProps>;
-    downloadChangesets: (arg: ChangesetRangeArg & {
+    }): Promise<ChangesetFileProps>;
+    downloadChangesets(arg: ChangesetRangeArg & {
         targetDir: LocalDirName;
-    }) => Promise<ChangesetFileProps[]>;
-    downloadV1Checkpoint: (arg: CheckPointArg) => Promise<ChangesetId>;
-    downloadV2Checkpoint: (arg: CheckPointArg) => Promise<ChangesetId>;
-    getChangesetFromNamedVersion: (arg: IModelIdArg & {
+    }): Promise<ChangesetFileProps[]>;
+    downloadV1Checkpoint(arg: CheckPointArg): Promise<ChangesetId>;
+    downloadV2Checkpoint(arg: CheckPointArg): Promise<ChangesetId>;
+    getChangesetFromNamedVersion(arg: IModelIdArg & {
         versionName: string;
-    }) => Promise<ChangesetProps>;
-    getChangesetFromVersion: (arg: IModelIdArg & {
+    }): Promise<ChangesetProps>;
+    getChangesetFromVersion(arg: IModelIdArg & {
         version: IModelVersion;
-    }) => Promise<ChangesetProps>;
-    getLatestChangeset: (arg: IModelIdArg) => Promise<ChangesetProps>;
-    getMyBriefcaseIds: (arg: IModelIdArg) => Promise<number[]>;
-    pushChangeset: (arg: IModelIdArg & {
+    }): Promise<ChangesetProps>;
+    getLatestChangeset(arg: IModelIdArg): Promise<ChangesetProps>;
+    getMyBriefcaseIds(arg: IModelIdArg): Promise<number[]>;
+    pushChangeset(arg: IModelIdArg & {
         changesetProps: ChangesetFileProps;
-    }) => Promise<ChangesetIndex>;
-    queryAllCodes: (arg: BriefcaseDbArg) => Promise<CodeProps[]>;
-    queryAllLocks: (arg: BriefcaseDbArg) => Promise<LockProps[]>;
-    queryChangeset: (arg: ChangesetArg) => Promise<ChangesetProps>;
-    queryChangesets: (arg: ChangesetRangeArg) => Promise<ChangesetProps[]>;
-    queryIModelByName: (arg: IModelNameArg) => Promise<GuidString | undefined>;
-    querySchemaLock: (arg: IModelIdArg) => Promise<boolean>;
-    releaseAllCodes: (arg: BriefcaseDbArg) => Promise<void>;
-    releaseAllLocks: (arg: BriefcaseDbArg) => Promise<void>;
-    releaseBriefcase: (arg: BriefcaseIdArg) => Promise<void>;
+    }): Promise<ChangesetIndex>;
+    queryAllCodes(arg: BriefcaseDbArg): Promise<CodeProps[]>;
+    queryAllLocks(arg: BriefcaseDbArg): Promise<LockProps[]>;
+    queryChangeset(arg: ChangesetArg): Promise<ChangesetProps>;
+    queryChangesets(arg: ChangesetRangeArg): Promise<ChangesetProps[]>;
+    queryIModelByName(arg: IModelNameArg): Promise<GuidString | undefined>;
+    querySchemaLock(arg: IModelIdArg): Promise<boolean>;
+    queryV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined>;
+    releaseAllCodes(arg: BriefcaseDbArg): Promise<void>;
+    releaseAllLocks(arg: BriefcaseDbArg): Promise<void>;
+    releaseBriefcase(arg: BriefcaseIdArg): Promise<void>;
 }
 
 // @public
@@ -2849,6 +2850,8 @@ export class IModelHubBackend {
     // (undocumented)
     static querySchemaLock(arg: IModelIdArg): Promise<boolean>;
     // (undocumented)
+    static queryV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined>;
+    // (undocumented)
     static releaseAllCodes(arg: BriefcaseDbArg): Promise<void>;
     // (undocumented)
     static releaseAllLocks(arg: BriefcaseDbArg): Promise<void>;
@@ -4549,6 +4552,20 @@ export class V1CheckpointManager {
     // (undocumented)
     static getFolder(iModelId: GuidString): string;
     }
+
+// @beta
+export interface V2CheckpointAccessProps {
+    // (undocumented)
+    auth: string;
+    // (undocumented)
+    container: string;
+    // (undocumented)
+    dbAlias: string;
+    // (undocumented)
+    storageType: string;
+    // (undocumented)
+    user: string;
+}
 
 // @internal
 export class V2CheckpointManager {

--- a/common/api/summary/imodeljs-backend.exports.csv
+++ b/common/api/summary/imodeljs-backend.exports.csv
@@ -329,6 +329,7 @@ public;class TypeDefinitionElement
 public;UpdateModelOptions 
 public;UrlLink 
 internal;V1CheckpointManager
+beta;V2CheckpointAccessProps
 internal;V2CheckpointManager
 public;ValidationError
 public;ViewAttachment 

--- a/common/changes/@bentley/imodeljs-backend/add-queryv2checkpoint-to-hubaccess_2021-08-18-14-47.json
+++ b/common/changes/@bentley/imodeljs-backend/add-queryv2checkpoint-to-hubaccess_2021-08-18-14-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "add queryV2Checkpoint to BackendHubAccess",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend",
+  "email": "33296803+kabentley@users.noreply.github.com"
+}

--- a/core/backend/src/BackendHubAccess.ts
+++ b/core/backend/src/BackendHubAccess.ts
@@ -8,12 +8,12 @@
 
 import { GuidString, Id64String } from "@bentley/bentleyjs-core";
 import {
-  ChangesetFileProps, ChangesetId, ChangesetIdWithIndex, ChangesetIndex, ChangesetIndexOrId, ChangesetProps, ChangesetRange, CodeProps, IModelVersion, LocalDirName,
-  LocalFileName,
+  ChangesetFileProps, ChangesetId, ChangesetIdWithIndex, ChangesetIndex, ChangesetIndexOrId, ChangesetProps, ChangesetRange, CodeProps, IModelVersion,
+  LocalDirName, LocalFileName,
 } from "@bentley/imodeljs-common";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
 import { BriefcaseId } from "./BriefcaseManager";
-import { DownloadRequest } from "./CheckpointManager";
+import { CheckpointProps, DownloadRequest } from "./CheckpointManager";
 
 /** The scope of a lock.
  * @public
@@ -25,6 +25,18 @@ export enum LockScope {
   Shared,
   /** A Lock that blocks other users from making modifications to an entity. */
   Exclusive,
+}
+
+/**
+ * The properties to access a V2 checkpoint through a daemon.
+ * @beta
+ */
+export interface V2CheckpointAccessProps {
+  container: string;
+  auth: string;
+  user: string;
+  dbAlias: string;
+  storageType: string;
 }
 
 /**
@@ -103,60 +115,63 @@ export type CheckPointArg = DownloadRequest;
  */
 export interface BackendHubAccess {
   /** Download all the changesets in the specified range. */
-  downloadChangesets: (arg: ChangesetRangeArg & { targetDir: LocalDirName }) => Promise<ChangesetFileProps[]>;
+  downloadChangesets(arg: ChangesetRangeArg & { targetDir: LocalDirName }): Promise<ChangesetFileProps[]>;
   /** Download a single changeset. */
-  downloadChangeset: (arg: ChangesetArg & { targetDir: LocalDirName }) => Promise<ChangesetFileProps>;
+  downloadChangeset(arg: ChangesetArg & { targetDir: LocalDirName }): Promise<ChangesetFileProps>;
   /** Query the changeset properties given a ChangesetIndex  */
-  queryChangeset: (arg: ChangesetArg) => Promise<ChangesetProps>;
+  queryChangeset(arg: ChangesetArg): Promise<ChangesetProps>;
   /** Query an array of changeset properties given a range of ChangesetIndexes  */
-  queryChangesets: (arg: ChangesetRangeArg) => Promise<ChangesetProps[]>;
+  queryChangesets(arg: ChangesetRangeArg): Promise<ChangesetProps[]>;
   /** push a changeset to iMOdelHub. Returns the newly pushed changeSet's index */
-  pushChangeset: (arg: IModelIdArg & { changesetProps: ChangesetFileProps }) => Promise<ChangesetIndex>;
+  pushChangeset(arg: IModelIdArg & { changesetProps: ChangesetFileProps }): Promise<ChangesetIndex>;
   /** Get the ChangesetProps of the most recent changeset */
-  getLatestChangeset: (arg: IModelIdArg) => Promise<ChangesetProps>;
+  getLatestChangeset(arg: IModelIdArg): Promise<ChangesetProps>;
   /** Get the ChangesetProps for an IModelVersion */
-  getChangesetFromVersion: (arg: IModelIdArg & { version: IModelVersion }) => Promise<ChangesetProps>;
+  getChangesetFromVersion(arg: IModelIdArg & { version: IModelVersion }): Promise<ChangesetProps>;
   /** Get the ChangesetProps for a named version */
-  getChangesetFromNamedVersion: (arg: IModelIdArg & { versionName: string }) => Promise<ChangesetProps>;
+  getChangesetFromNamedVersion(arg: IModelIdArg & { versionName: string }): Promise<ChangesetProps>;
 
   /** Acquire a new briefcaseId for the supplied iModelId
      * @note usually there should only be one briefcase per iModel per user.
      */
-  acquireNewBriefcaseId: (arg: IModelIdArg) => Promise<number>;
+  acquireNewBriefcaseId(arg: IModelIdArg): Promise<number>;
   /** Release a briefcaseId. After this call it is illegal to generate changesets for the released briefcaseId. */
-  releaseBriefcase: (arg: BriefcaseIdArg) => Promise<void>;
+  releaseBriefcase(arg: BriefcaseIdArg): Promise<void>;
 
   /** get an array of the briefcases assigned to the current user. */
-  getMyBriefcaseIds: (arg: IModelIdArg) => Promise<number[]>;
+  getMyBriefcaseIds(arg: IModelIdArg): Promise<number[]>;
 
   /** download a v1 checkpoint */
-  downloadV1Checkpoint: (arg: CheckPointArg) => Promise<ChangesetId>;
+  downloadV1Checkpoint(arg: CheckPointArg): Promise<ChangesetId>;
+
+  /** get the access props for a V2 checkpoint. Returns undefined if no V2 checkpoint exists. */
+  queryV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined>;
   /** download a v2 checkpoint */
-  downloadV2Checkpoint: (arg: CheckPointArg) => Promise<ChangesetId>;
+  downloadV2Checkpoint(arg: CheckPointArg): Promise<ChangesetId>;
 
   /** acquire a list of locks. Throws if unsuccessful */
-  acquireLocks: (arg: BriefcaseDbArg & { locks: LockProps[] }) => Promise<void>;
+  acquireLocks(arg: BriefcaseDbArg & { locks: LockProps[] }): Promise<void>;
   /** acquire the schema lock. Throws if unsuccessful */
-  acquireSchemaLock: (arg: BriefcaseDbArg) => Promise<void>;
+  acquireSchemaLock(arg: BriefcaseDbArg): Promise<void>;
 
   /** determine whether the schema lock is currently held */
-  querySchemaLock: (arg: IModelIdArg) => Promise<boolean>;
+  querySchemaLock(arg: IModelIdArg): Promise<boolean>;
   /** get the full list of held locks for a briefcase */
-  queryAllLocks: (arg: BriefcaseDbArg) => Promise<LockProps[]>;
+  queryAllLocks(arg: BriefcaseDbArg): Promise<LockProps[]>;
 
   /** release all currently held locks */
-  releaseAllLocks: (arg: BriefcaseDbArg) => Promise<void>;
+  releaseAllLocks(arg: BriefcaseDbArg): Promise<void>;
 
   /** Query codes */
-  queryAllCodes: (arg: BriefcaseDbArg) => Promise<CodeProps[]>;
+  queryAllCodes(arg: BriefcaseDbArg): Promise<CodeProps[]>;
   /** release codes */
-  releaseAllCodes: (arg: BriefcaseDbArg) => Promise<void>;
+  releaseAllCodes(arg: BriefcaseDbArg): Promise<void>;
 
   /** get the iModelId of an iModel by name. Undefined if no iModel with that name exists.  */
-  queryIModelByName: (arg: IModelNameArg) => Promise<GuidString | undefined>;
+  queryIModelByName(arg: IModelNameArg): Promise<GuidString | undefined>;
   /** create a new iModel. Returns the Guid of the newly created iModel */
-  createIModel: (arg: IModelNameArg & { description?: string, revision0?: LocalFileName }) => Promise<GuidString>;
+  createIModel(arg: IModelNameArg & { description?: string, revision0?: LocalFileName }): Promise<GuidString>;
   /** delete an iModel  */
-  deleteIModel: (arg: IModelIdArg & { contextId: GuidString }) => Promise<void>;
+  deleteIModel(arg: IModelIdArg & { contextId: GuidString }): Promise<void>;
 }
 

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -10,7 +10,6 @@
 
 import * as path from "path";
 import { BeEvent, ChangeSetStatus, DbResult, Guid, GuidString, IModelStatus, Logger, OpenMode } from "@bentley/bentleyjs-core";
-import { CheckpointV2Query } from "@bentley/imodelhub-client";
 import { BriefcaseIdValue, ChangesetId, ChangesetIdWithIndex, IModelError } from "@bentley/imodeljs-common";
 import { BlobDaemon, BlobDaemonCommandArg, IModelJsNative } from "@bentley/imodeljs-native";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
@@ -18,7 +17,6 @@ import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { BriefcaseManager } from "./BriefcaseManager";
 import { SnapshotDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
-import { IModelHubBackend } from "./IModelHubBackend";
 import { IModelJsFs } from "./IModelJsFs";
 
 const loggerCategory = BackendLoggerCategory.IModelDb;
@@ -110,29 +108,12 @@ export class Downloads {
 */
 export class V2CheckpointManager {
   private static async getCommandArgs(checkpoint: CheckpointProps): Promise<BlobDaemonCommandArg> {
-    const { requestContext, iModelId, changeset } = checkpoint;
-
     try {
-      requestContext.enter();
-      const checkpointQuery = new CheckpointV2Query().byChangeSetId(changeset.id).selectContainerAccessKey();
-      const checkpoints = await IModelHubBackend.iModelClient.checkpointsV2.get(requestContext, iModelId, checkpointQuery);
-      requestContext.enter();
-      if (checkpoints.length < 1)
+      const v2props = await IModelHost.hubAccess.queryV2Checkpoint(checkpoint);
+      if (!v2props)
         throw new Error("no checkpoint");
 
-      const { containerAccessKeyContainer, containerAccessKeySAS, containerAccessKeyAccount, containerAccessKeyDbName } = checkpoints[0];
-      if (!containerAccessKeyContainer || !containerAccessKeySAS || !containerAccessKeyAccount || !containerAccessKeyDbName)
-        throw new Error("Invalid checkpoint in iModelHub");
-
-      return {
-        container: containerAccessKeyContainer,
-        auth: containerAccessKeySAS,
-        daemonDir: process.env.BLOCKCACHE_DIR,
-        storageType: "azure?sas=1",
-        user: containerAccessKeyAccount,
-        dbAlias: containerAccessKeyDbName,
-        writeable: false,
-      };
+      return { ...v2props, daemonDir: process.env.BLOCKCACHE_DIR, writeable: false };
     } catch (err) {
       throw new IModelError(IModelStatus.NotFound, `V2 checkpoint not found: err: ${err.message}`);
     }
@@ -227,7 +208,6 @@ export class CheckpointManager {
 
       throw (error); // most likely, was aborted
     }
-
   }
 
   public static async updateToRequestedVersion(request: DownloadRequest) {

--- a/core/backend/src/IModelHubBackend.ts
+++ b/core/backend/src/IModelHubBackend.ts
@@ -13,13 +13,16 @@ import {
   BriefcaseQuery, ChangeSet, ChangeSetQuery, ChangesType, CheckpointQuery, CheckpointV2, CheckpointV2Query, CodeQuery, IModelBankClient, IModelClient,
   IModelHubClient, IModelQuery, Lock, LockLevel, LockQuery, LockType, VersionQuery,
 } from "@bentley/imodelhub-client";
-import { ChangesetFileProps, ChangesetId, ChangesetIndex, ChangesetProps, CodeProps, IModelError, IModelVersion, LocalDirName } from "@bentley/imodeljs-common";
+import {
+  ChangesetFileProps, ChangesetId, ChangesetIndex, ChangesetProps, CodeProps, IModelError, IModelVersion, LocalDirName,
+} from "@bentley/imodeljs-common";
 import { AuthorizedClientRequestContext, ProgressCallback, UserCancelledError } from "@bentley/itwin-client";
 import {
-  BriefcaseDbArg, BriefcaseIdArg, ChangesetArg, ChangesetRangeArg, CheckPointArg, IModelIdArg, LockProps,
+  BriefcaseDbArg, BriefcaseIdArg, ChangesetArg, ChangesetRangeArg, CheckPointArg, IModelIdArg, LockProps, V2CheckpointAccessProps,
 } from "./BackendHubAccess";
 import { AuthorizedBackendRequestContext } from "./BackendRequestContext";
 import { BriefcaseManager } from "./BriefcaseManager";
+import { CheckpointProps } from "./CheckpointManager";
 import { ConcurrencyControl } from "./ConcurrencyControl";
 import { IModelHost } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
@@ -274,6 +277,26 @@ export class IModelHubBackend {
 
     await this.iModelClient.checkpoints.download(requestContext, checkpoints[0], arg.localFile, progressCallback, cancelRequest);
     return checkpoints[0].mergedChangeSetId!;
+  }
+
+  public static async queryV2Checkpoint(arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
+    const checkpointQuery = new CheckpointV2Query().byChangeSetId(arg.changeset.id).selectContainerAccessKey();
+    const requestContext = arg.requestContext ?? await AuthorizedBackendRequestContext.create();
+    const checkpoints = await this.iModelClient.checkpointsV2.get(requestContext, arg.iModelId, checkpointQuery);
+    if (checkpoints.length < 1)
+      return undefined;
+
+    const { containerAccessKeyContainer, containerAccessKeySAS, containerAccessKeyAccount, containerAccessKeyDbName } = checkpoints[0];
+    if (!containerAccessKeyContainer || !containerAccessKeySAS || !containerAccessKeyAccount || !containerAccessKeyDbName)
+      throw new Error("Invalid V2 checkpoint in iModelHub");
+
+    return {
+      container: containerAccessKeyContainer,
+      auth: containerAccessKeySAS,
+      user: containerAccessKeyAccount,
+      dbAlias: containerAccessKeyDbName,
+      storageType: "azure?sas=1",
+    };
   }
 
   public static async downloadV2Checkpoint(arg: CheckPointArg): Promise<ChangesetId> {

--- a/core/backend/src/test/HubMock.ts
+++ b/core/backend/src/test/HubMock.ts
@@ -6,12 +6,15 @@
 import { join } from "path";
 import * as sinon from "sinon";
 import { Guid, GuidString } from "@bentley/bentleyjs-core";
-import { ChangesetFileProps, ChangesetId, ChangesetIndex, ChangesetProps, ChangesetRange, CodeProps, IModelVersion, LocalDirName, LocalFileName } from "@bentley/imodeljs-common";
+import {
+  ChangesetFileProps, ChangesetId, ChangesetIndex, ChangesetProps, ChangesetRange, CodeProps, IModelVersion, LocalDirName, LocalFileName,
+} from "@bentley/imodeljs-common";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
 import {
-  BackendHubAccess, BriefcaseDbArg, BriefcaseIdArg, ChangesetArg, ChangesetRangeArg, CheckPointArg, IModelIdArg, LockProps,
+  BackendHubAccess, BriefcaseDbArg, BriefcaseIdArg, ChangesetArg, ChangesetRangeArg, CheckPointArg, IModelIdArg, LockProps, V2CheckpointAccessProps,
 } from "../BackendHubAccess";
 import { AuthorizedBackendRequestContext } from "../BackendRequestContext";
+import { CheckpointProps } from "../CheckpointManager";
 import { SnapshotDb } from "../IModelDb";
 import { IModelHost } from "../IModelHost";
 import { IModelHubBackend } from "../IModelHubBackend";
@@ -190,6 +193,10 @@ export class HubMock {
 
   public static async pushChangeset(arg: IModelIdArg & { changesetProps: ChangesetFileProps }): Promise<ChangesetIndex> {
     return this.findLocalHub(arg.iModelId).addChangeset(arg.changesetProps);
+  }
+
+  public static async queryV2Checkpoint(_arg: CheckpointProps): Promise<V2CheckpointAccessProps | undefined> {
+    return undefined;
   }
 
   public static async downloadV2Checkpoint(arg: CheckPointArg): Promise<ChangesetId> {


### PR DESCRIPTION
Allows IModelBank to support V2 checkpoints (or not).