### PR TITLE
use cacheDir for temp files when opening V2 checkpoints

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -7549,6 +7549,8 @@ export interface SnapshotOpenOptions extends IModelEncryptionProps, OpenDbKey {
     autoUploadBlocks?: boolean;
     // @internal (undocumented)
     lazyBlockCache?: boolean;
+    // @internal (undocumented)
+    tempFileBase?: string;
 }
 
 // @public

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -7549,7 +7549,7 @@ export interface SnapshotOpenOptions extends IModelEncryptionProps, OpenDbKey {
     autoUploadBlocks?: boolean;
     // @internal (undocumented)
     lazyBlockCache?: boolean;
-    // @internal (undocumented)
+    // @internal
     tempFileBase?: string;
 }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -25,6 +25,7 @@ import {
 } from "@bentley/imodeljs-common";
 import { IModelJsNative } from "@bentley/imodeljs-native";
 import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
+import { join } from "path";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { BriefcaseId, BriefcaseManager } from "./BriefcaseManager";
 import { CheckpointManager, CheckpointProps, V2CheckpointManager } from "./CheckpointManager";
@@ -2528,7 +2529,9 @@ export class SnapshotDb extends IModelDb {
    */
   public static async openCheckpointV2(checkpoint: CheckpointProps): Promise<SnapshotDb> {
     const { filePath, expiryTimestamp } = await V2CheckpointManager.attach(checkpoint);
-    const snapshot = SnapshotDb.openFile(filePath, { lazyBlockCache: true, key: CheckpointManager.getKey(checkpoint) });
+    const key = CheckpointManager.getKey(checkpoint);
+    const tempFileBase = join(IModelHost.cacheDir, key); // temp files for this checkpoint should go in the cacheDir.
+    const snapshot = SnapshotDb.openFile(filePath, { lazyBlockCache: true, key, tempFileBase });
     snapshot._contextId = checkpoint.contextId;
     try {
       CheckpointManager.validateCheckpointGuids(checkpoint, snapshot.nativeDb);

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2530,7 +2530,8 @@ export class SnapshotDb extends IModelDb {
   public static async openCheckpointV2(checkpoint: CheckpointProps): Promise<SnapshotDb> {
     const { filePath, expiryTimestamp } = await V2CheckpointManager.attach(checkpoint);
     const key = CheckpointManager.getKey(checkpoint);
-    const tempFileBase = join(IModelHost.cacheDir, key); // temp files for this checkpoint should go in the cacheDir.
+    // NOTE: Currently the key contains a ':' which can not be part of a filename on windows, so it can not be used as the tempFileBase.
+    const tempFileBase = join(IModelHost.cacheDir, `${checkpoint.iModelId}\$${checkpoint.changeset.id}`); // temp files for this checkpoint should go in the cacheDir.
     const snapshot = SnapshotDb.openFile(filePath, { lazyBlockCache: true, key, tempFileBase });
     snapshot._contextId = checkpoint.contextId;
     try {

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -425,6 +425,7 @@ export class IModelHost {
 
   private static setupCacheDirs(configuration: IModelHostConfiguration) {
     this._cacheDir = configuration.cacheDir ? path.normalize(configuration.cacheDir) : NativeLibrary.defaultCacheDir;
+    IModelJsFs.recursiveMkDirSync(this._cacheDir); // make sure the directory for cacheDir exists.
     this._briefcaseCacheDir = path.join(this._cacheDir, "imodels");
   }
 

--- a/core/backend/src/test/integration/TileUpload.test.ts
+++ b/core/backend/src/test/integration/TileUpload.test.ts
@@ -21,7 +21,7 @@ interface TileContentRequestProps {
 }
 
 // Goes through models in imodel until it finds a root tile for a non empty model, returns tile content request props for that tile
-async function getTileProps(iModel: IModelDb, requestContext: AuthorizedBackendRequestContext): Promise<TileContentRequestProps | undefined> {
+export async function getTileProps(iModel: IModelDb, requestContext: AuthorizedBackendRequestContext): Promise<TileContentRequestProps | undefined> {
   const queryParams = { from: GeometricModel3d.classFullName, limit: IModelDb.maxLimit };
   for (const modelId of iModel.queryEntityIds(queryParams)) {
     let model;

--- a/core/backend/src/test/standalone/TileCache.test.ts
+++ b/core/backend/src/test/standalone/TileCache.test.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { assert } from "chai";
+import { ClientRequestContext, DbResult, Guid } from "@bentley/bentleyjs-core";
+import { IModelTileRpcInterface, RpcManager, RpcRegistry } from "@bentley/imodeljs-common";
+import { SnapshotDb } from "../../IModelDb";
+import { IModelHost, IModelHostConfiguration } from "../../imodeljs-backend";
+import { IModelTestUtils } from "../IModelTestUtils";
+import * as path from "path";
+import { IModelJsFs } from "../../IModelJsFs";
+import { IModelHubBackend } from "../../IModelHubBackend";
+import { AuthorizedClientRequestContext } from "@bentley/itwin-client";
+import { BlobDaemon } from "@bentley/imodeljs-native";
+import { getTileProps } from "../integration/TileUpload.test";
+import { CheckpointV2 } from "@bentley/imodelhub-client";
+import sinon = require("sinon");
+
+describe("TileCache open v1", () => {
+  let tileRpcInterface: IModelTileRpcInterface;
+
+  before(async () => {
+
+  });
+  const verifyTileCache = async (dbPath: string) => {
+    RpcManager.initializeInterface(IModelTileRpcInterface);
+    tileRpcInterface = RpcRegistry.instance.getImplForInterface<IModelTileRpcInterface>(IModelTileRpcInterface);
+
+    const iModel = SnapshotDb.openFile(dbPath);
+    assert.isDefined(iModel);
+    const requestContext = ClientRequestContext.current as AuthorizedClientRequestContext;
+    // Generate tile
+    // eslint-disable-next-line deprecation/deprecation
+    const tileProps = await getTileProps(iModel, requestContext);
+    assert.isDefined(tileProps);
+    await tileRpcInterface.requestTileContent(iModel.getRpcProps(), tileProps!.treeId, tileProps!.contentId, undefined, tileProps!.guid); // eslint-disable-line deprecation/deprecation
+
+    const tilesCache = `${iModel.pathName}.Tiles`;
+    assert.isTrue(IModelJsFs.existsSync(tilesCache));
+
+    iModel.close();
+  };
+  it("should create .tiles file next to .bim with default cacheDir", async () => {
+    // Shutdown IModelHost to allow this test to use it.
+    await IModelTestUtils.shutdownBackend();
+    const config = new IModelHostConfiguration();
+    await IModelTestUtils.startBackend(config);
+
+    const dbPath = IModelTestUtils.prepareOutputFile("IModel", "mirukuru.ibim");
+    const snapshot = IModelTestUtils.createSnapshotFromSeed(dbPath, IModelTestUtils.resolveAssetFile("mirukuru.ibim"));
+    snapshot.close();
+    await verifyTileCache(dbPath);
+
+  });
+  it("should create .tiles file next to .bim with set cacheDir", async () => {
+    // Shutdown IModelHost to allow this test to use it.
+    await IModelTestUtils.shutdownBackend();
+    const config = new IModelHostConfiguration();
+    config.cacheDir = path.join(__dirname, ".cache");
+    await IModelTestUtils.startBackend(config);
+
+    const dbPath = IModelTestUtils.prepareOutputFile("IModel", "mirukuru.ibim");
+    const snapshot = IModelTestUtils.createSnapshotFromSeed(dbPath, IModelTestUtils.resolveAssetFile("mirukuru.ibim"));
+    snapshot.close();
+
+    await verifyTileCache(dbPath);
+  });
+});
+describe("TileCache, open v2", async () => {
+  it("should place .Tiles in cacheDir", async () => {
+    const dbPath = IModelTestUtils.prepareOutputFile("IModel", "mirukuru.ibim");
+    const snapshot = IModelTestUtils.createSnapshotFromSeed(dbPath, IModelTestUtils.resolveAssetFile("mirukuru.ibim"));
+    const iModelId = snapshot.getGuid();
+    const contextId = Guid.createValue();
+    const changeset = IModelTestUtils.generateChangeSetId();
+    snapshot.nativeDb.saveProjectGuid(Guid.normalize(contextId));
+    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id); // even fake checkpoints need a changeSetId!
+    snapshot.saveChanges();
+    snapshot.close();
+    // Mock iModelHub
+    const mockCheckpointV2: CheckpointV2 = {
+      wsgId: "INVALID",
+      ecId: "INVALID",
+      changeset,
+      containerAccessKeyAccount: "testAccount",
+      containerAccessKeyContainer: `imodelblocks-${iModelId}`,
+      containerAccessKeySAS: "testSAS",
+      containerAccessKeyDbName: "testDb",
+    };
+
+    RpcManager.initializeInterface(IModelTileRpcInterface);
+    const tileRpcInterface = RpcRegistry.instance.getImplForInterface<IModelTileRpcInterface>(IModelTileRpcInterface);
+
+    const checkpointsV2Handler = IModelHubBackend.iModelClient.checkpointsV2;
+    sinon.stub(checkpointsV2Handler, "get").callsFake(async () => [mockCheckpointV2]);
+    sinon.stub(IModelHubBackend.iModelClient, "checkpointsV2").get(() => checkpointsV2Handler);
+    const daemonSuccessResult = { result: DbResult.BE_SQLITE_OK, errMsg: "" };
+    sinon.stub(BlobDaemon, "command").callsFake(async () => daemonSuccessResult);
+    // Mock blockcacheVFS daemon
+    sinon.stub(BlobDaemon, "getDbFileName").callsFake(() => dbPath);
+
+    process.env.BLOCKCACHE_DIR = "/foo/";
+    const ctx = ClientRequestContext.current as AuthorizedClientRequestContext;
+    const checkpointProps = { requestContext: ctx, contextId, iModelId, changeset };
+    const checkpoint = await SnapshotDb.openCheckpointV2(checkpointProps);
+
+    // Generate tile
+    // eslint-disable-next-line deprecation/deprecation
+    const tileProps = await getTileProps(checkpoint, ctx);
+    assert.isDefined(tileProps);
+    await tileRpcInterface.requestTileContent(checkpoint.getRpcProps(), tileProps!.treeId, tileProps!.contentId, undefined, tileProps!.guid); // eslint-disable-line deprecation/deprecation
+
+    // Make sure .Tiles exists in the cacheDir. This was enforced by opening it as a V2 Checkpoint which passes as part of its open params a tempFileBasename.
+    const tempFileBase = path.join(IModelHost.cacheDir, `${checkpointProps.iModelId}\$${checkpointProps.changeset.id}`);
+    assert.isTrue(IModelJsFs.existsSync(`${tempFileBase}.Tiles`));
+    checkpoint.close();
+  });
+});

--- a/core/common/src/IModel.ts
+++ b/core/common/src/IModel.ts
@@ -135,6 +135,8 @@ export interface SnapshotOpenOptions extends IModelEncryptionProps, OpenDbKey {
   lazyBlockCache?: boolean;
   /** @internal */
   autoUploadBlocks?: boolean;
+  /** @internal */
+  tempFileBase?: string;
 }
 
 /** Options to open a [StandaloneDb]($backend) via [StandaloneDb.openFile]($backend) from the backend,

--- a/core/common/src/IModel.ts
+++ b/core/common/src/IModel.ts
@@ -135,7 +135,13 @@ export interface SnapshotOpenOptions extends IModelEncryptionProps, OpenDbKey {
   lazyBlockCache?: boolean;
   /** @internal */
   autoUploadBlocks?: boolean;
-  /** @internal */
+  /**
+   * The "base" name that can be used for creating temporary files related to this Db.
+   * The string should be a name related to the current Db filename using some known pattern so that all files named "baseName*" can be deleted externally during cleanup.
+   * It must be the name of a file (that may or may not exist) in a writable directory.
+   * If not present, the baseName will default to the database's file name (including the path).
+   * @internal
+   */
   tempFileBase?: string;
 }
 


### PR DESCRIPTION
The directory where the checkpoint files are stored is protected.