### PR TITLE
Defer probe azcopy version for small files

### DIFF
--- a/common/changes/@bentley/backend-itwin-client/download_delay_on_small_files_2021-08-24-13-36.json
+++ b/common/changes/@bentley/backend-itwin-client/download_delay_on_small_files_2021-08-24-13-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/backend-itwin-client",
+      "comment": "disable azcopy probe when file size requirement are not meet.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/backend-itwin-client"
+}

--- a/common/changes/@bentley/imodeljs-common/download_delay_on_small_files_2021-08-24-13-36.json
+++ b/common/changes/@bentley/imodeljs-common/download_delay_on_small_files_2021-08-24-13-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "documentation fix",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common"
+}

--- a/core/backend-itwin-client/src/imodelhub/AzureFileHandler.ts
+++ b/core/backend-itwin-client/src/imodelhub/AzureFileHandler.ts
@@ -245,16 +245,14 @@ export class AzureFileHandler implements FileHandler {
    * @param fileSize size of the transferred file in bytes
    */
   private useAzCopyForFileTransfer(fileSize?: number): boolean {
-    let useAzcopy = AzCopy.isAvailable;
-
     // suppress azcopy for smaller file as it take longer to spawn and exit then it take Http downloader to download it.
-    if (useAzcopy && fileSize) {
+    if (fileSize) {
       const minFileSize = process.env.IMJS_AZ_MIN_FILESIZE_THRESHOLD ? Number(process.env.IMJS_AZ_MIN_FILESIZE_THRESHOLD) : 500 * 1024 * 1024 /** 500 Mb */;
       if (fileSize < minFileSize)
-        useAzcopy = false;
+        return false;
     }
 
-    return useAzcopy;
+    return AzCopy.isAvailable;
   }
 
   /**

--- a/core/common/src/Paging.ts
+++ b/core/common/src/Paging.ts
@@ -22,7 +22,7 @@ export interface QueryQuota {
 export interface QueryLimit {
   /** Maximum rows allowed to be returned */
   maxRowAllowed?: number;
-  /** It set number of rows to skip before returning results */
+  /** If set number of rows to skip before returning results */
   startRowOffset?: number;
 }
 

--- a/core/common/src/Paging.ts
+++ b/core/common/src/Paging.ts
@@ -20,9 +20,9 @@ export interface QueryQuota {
  * @public
  */
 export interface QueryLimit {
-  /** Maximum time in seconds after which query will be stopped */
+  /** Maximum rows allowed to be returned */
   maxRowAllowed?: number;
-  /** Maximum size of result in bytes after which query will be stopped */
+  /** It set number of rows to skip before returning results */
   startRowOffset?: number;
 }
 


### PR DESCRIPTION
This cause a performance hit when briefcase/checkpoint are smaller then 500Mb. The probe take 5-8 seconds which is added to startup time of backend.

There is unrelated documentation fix included in this change.