### PR TITLE
fix broken link due to moving imodel-bridge

### DIFF
--- a/common/changes/@bentley/imodel-bridge/chickneas-bad-imodel-bridge-repo-url_2021-08-30-03-46.json
+++ b/common/changes/@bentley/imodel-bridge/chickneas-bad-imodel-bridge-repo-url_2021-08-30-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-bridge",
+      "comment": "point link for imodel-bridge to 2.x branch b/c it was removed in 3.x",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodel-bridge",
+  "email": "Jason.Chickneas@bentley.com"
+}

--- a/core/imodel-bridge/package.json
+++ b/core/imodel-bridge/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/imodeljs/imodeljs/tree/master/core/imodel-bridge"
+    "url": "https://github.com/imodeljs/imodeljs/tree/release/2.19.x/core/imodel-bridge"
   },
   "scripts": {
     "compile": "npm run build",


### PR DESCRIPTION
FutureOn were trying to access the bridge framework code through the repository link in NPM and found it broken.