### PR TITLE
Install rejection handler before await to avoid PromiseRejectionHandledWarning in test.

### DIFF
--- a/common/changes/@bentley/imodeljs-backend/fix-async-promise-rejection_2021-08-30-13-01.json
+++ b/common/changes/@bentley/imodeljs-backend/fix-async-promise-rejection_2021-08-30-13-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-backend"
+}

--- a/core/backend/src/test/standalone/DgnDbWorker.test.ts
+++ b/core/backend/src/test/standalone/DgnDbWorker.test.ts
@@ -190,12 +190,13 @@ describe("DgnDbWorker", () => {
       worldToView: Matrix4d.createIdentity().toJSON(),
     });
 
+    const toBeRejected = expect(snap).to.be.rejectedWith("aborted");
     imodel.cancelSnap(sessionId);
 
     // Clear the worker thread pool so the snap request (now canceled) can be processed.
     blockers.forEach((w) => w.setReady());
     await Promise.all(blockers.map(async (w) => w.promise));
 
-    await expect(snap).to.be.rejectedWith("aborted");
+    await toBeRejected;
   });
 });


### PR DESCRIPTION
...by installing rejection handler before `await`ing.