### PR TITLE
Fix graphicbuilder transform part 2

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-graphicbuilder-xform-2_2021-09-01-12-06.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-graphicbuilder-xform-2_2021-09-01-12-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "The previous fix to the graphicbuilder transform problem actually resulted in some graphicbuilder primitives being transformed twice because they already had the transform applied to them. This fixes that issue by moving the transformation only to primitives that were missing it. This also adds code to ensure that GeometryAccumulator does not mutate the graphicbuilder's transform in-place.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -60,10 +60,11 @@ export class GeometryAccumulator {
   }
 
   private calculateTransform(transform: Transform, range: Range3d): Transform {
-    const xform = this.haveTransform ? transform : transform.clone();
-    if (this.haveTransform) this._transform.multiplyTransformTransform(xform, xform);
-    xform.multiplyRange(range, range);
-    return xform;
+    if (this.haveTransform)
+      transform = this._transform.multiplyTransformTransform(transform);
+
+    transform.multiplyRange(range, range);
+    return transform;
   }
 
   public addLoop(loop: Loop, displayParams: DisplayParams, transform: Transform, disjoint: boolean): boolean {

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -59,9 +59,11 @@ export class GeometryAccumulator {
     return range.isNull ? undefined : range;
   }
 
-  private calculateTransform(transform: Transform, range: Range3d): void {
-    if (this.haveTransform) this._transform.multiplyTransformTransform(transform, transform);
-    transform.multiplyRange(range, range);
+  private calculateTransform(transform: Transform, range: Range3d): Transform {
+    const xform = transform.clone();
+    if (this.haveTransform) this._transform.multiplyTransformTransform(xform, xform);
+    xform.multiplyRange(range, range);
+    return xform;
   }
 
   public addLoop(loop: Loop, displayParams: DisplayParams, transform: Transform, disjoint: boolean): boolean {
@@ -69,8 +71,8 @@ export class GeometryAccumulator {
     if (!range)
       return false;
 
-    this.calculateTransform(transform, range);
-    return this.addGeometry(Geometry.createFromLoop(loop, transform, range, displayParams, disjoint));
+    const xform = this.calculateTransform(transform, range);
+    return this.addGeometry(Geometry.createFromLoop(loop, xform, range, displayParams, disjoint));
   }
 
   public addLineString(pts: Point3d[], displayParams: DisplayParams, transform: Transform): boolean {
@@ -80,8 +82,8 @@ export class GeometryAccumulator {
     if (range.isNull)
       return false;
 
-    this.calculateTransform(transform, range);
-    return this.addGeometry(Geometry.createFromLineString(pts, transform, range, displayParams));
+    const xform = this.calculateTransform(transform, range);
+    return this.addGeometry(Geometry.createFromLineString(pts, xform, range, displayParams));
   }
 
   public addPointString(pts: Point3d[], displayParams: DisplayParams, transform: Transform): boolean {
@@ -91,8 +93,8 @@ export class GeometryAccumulator {
     if (range.isNull)
       return false;
 
-    this.calculateTransform(transform, range);
-    return this.addGeometry(Geometry.createFromPointString(pts, transform, range, displayParams));
+    const xform = this.calculateTransform(transform, range);
+    return this.addGeometry(Geometry.createFromPointString(pts, xform, range, displayParams));
   }
 
   public addPath(path: Path, displayParams: DisplayParams, transform: Transform, disjoint: boolean): boolean {
@@ -100,8 +102,8 @@ export class GeometryAccumulator {
     if (!range)
       return false;
 
-    this.calculateTransform(transform, range);
-    return this.addGeometry(Geometry.createFromPath(path, transform, range, displayParams, disjoint));
+    const xform = this.calculateTransform(transform, range);
+    return this.addGeometry(Geometry.createFromPath(path, xform, range, displayParams, disjoint));
   }
 
   public addPolyface(pf: IndexedPolyface, displayParams: DisplayParams, transform: Transform): boolean {
@@ -124,8 +126,8 @@ export class GeometryAccumulator {
     if (!range && !(range = this.getPrimitiveRange(pf)))
       return false;
 
-    this.calculateTransform(transform, range);
-    return this.addGeometry(Geometry.createFromPolyface(pf, transform, range, displayParams));
+    const xform = this.calculateTransform(transform, range);
+    return this.addGeometry(Geometry.createFromPolyface(pf, xform, range, displayParams));
   }
 
   public addSolidPrimitive(primitive: SolidPrimitive, displayParams: DisplayParams, transform: Transform): boolean {
@@ -133,8 +135,8 @@ export class GeometryAccumulator {
     if (!range)
       return false;
 
-    this.calculateTransform(transform, range);
-    return this.addGeometry(Geometry.createFromSolidPrimitive(primitive, transform, range, displayParams));
+    const xform = this.calculateTransform(transform, range);
+    return this.addGeometry(Geometry.createFromSolidPrimitive(primitive, xform, range, displayParams));
   }
 
   public addGeometry(geom: Geometry): boolean { this.geometries.push(geom); return true; }

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -60,7 +60,7 @@ export class GeometryAccumulator {
   }
 
   private calculateTransform(transform: Transform, range: Range3d): Transform {
-    const xform = transform.clone();
+    const xform = this.haveTransform ? transform : transform.clone();
     if (this.haveTransform) this._transform.multiplyTransformTransform(xform, xform);
     xform.multiplyRange(range, range);
     return xform;

--- a/core/frontend/src/render/primitives/geometry/GeometryPrimitives.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryPrimitives.ts
@@ -252,7 +252,8 @@ class SolidPrimitiveGeometry extends Geometry {
 
   public constructor(primitive: SolidPrimitive, tf: Transform, range: Range3d, params: DisplayParams) {
     super(tf, range, params);
-    this._primitive = primitive;
+    const xformPrim = tf.isIdentity ? primitive : primitive.cloneTransformed(tf);
+    this._primitive = xformPrim !== undefined ? xformPrim as SolidPrimitive : primitive;
   }
 
   protected _getStrokes() { return undefined; }
@@ -260,9 +261,6 @@ class SolidPrimitiveGeometry extends Geometry {
   protected _getPolyfaces(opts: StrokeOptions): PolyfacePrimitiveList {
     const builder = PolyfaceBuilder.create(opts);
     builder.addGeometryQuery(this._primitive);
-    const pf = builder.claimPolyface();
-    if (!this.transform.isIdentity)
-      pf.tryTransformInPlace(this.transform);
-    return new PolyfacePrimitiveList(PolyfacePrimitive.create(this.displayParams, pf));
+    return new PolyfacePrimitiveList(PolyfacePrimitive.create(this.displayParams, builder.claimPolyface()));
   }
 }

--- a/core/frontend/src/render/primitives/geometry/GeometryPrimitives.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryPrimitives.ts
@@ -65,23 +65,13 @@ export abstract class Geometry {
     if (!this.displayParams.ignoreLighting) // ###TODO don't generate normals for 2d views.
       facetOptions.needNormals = true;
 
-    const polyfaceList = this._getPolyfaces(facetOptions);
-    if (undefined !== polyfaceList && !this.transform.isIdentity)
-      polyfaceList.forEach((polyface: PolyfacePrimitive) => {
-        polyface.transform(this.transform);
-      });
-    return polyfaceList;
+    return this._getPolyfaces(facetOptions);
   }
 
   public getStrokes(tolerance: number): StrokesPrimitiveList | undefined {
     const strokeOptions = StrokeOptions.createForCurves();
     strokeOptions.chordTol = tolerance;
-    const strokesList = this._getStrokes(strokeOptions);
-    if (undefined !== strokesList && !this.transform.isIdentity)
-      strokesList.forEach((stroke: StrokesPrimitive) => {
-        stroke.transform(this.transform);
-      });
-    return strokesList;
+    return this._getStrokes(strokeOptions);
   }
 
   public get hasTexture() { return this.displayParams.isTextured; }
@@ -229,7 +219,7 @@ export class PrimitivePolyfaceGeometry extends Geometry {
 
   public constructor(polyface: IndexedPolyface, tf: Transform, range: Range3d, params: DisplayParams) {
     super(tf, range, params);
-    this.polyface = polyface;
+    this.polyface = tf.isIdentity ? polyface : polyface.cloneTransformed(tf);
   }
 
   protected _getPolyfaces(facetOptions: StrokeOptions): PolyfacePrimitiveList | undefined {
@@ -270,6 +260,9 @@ class SolidPrimitiveGeometry extends Geometry {
   protected _getPolyfaces(opts: StrokeOptions): PolyfacePrimitiveList {
     const builder = PolyfaceBuilder.create(opts);
     builder.addGeometryQuery(this._primitive);
-    return new PolyfacePrimitiveList(PolyfacePrimitive.create(this.displayParams, builder.claimPolyface()));
+    const pf = builder.claimPolyface();
+    if (!this.transform.isIdentity)
+      pf.tryTransformInPlace(this.transform);
+    return new PolyfacePrimitiveList(PolyfacePrimitive.create(this.displayParams, pf));
   }
 }

--- a/core/frontend/src/test/TestDecorators.ts
+++ b/core/frontend/src/test/TestDecorators.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { ColorDef } from "@bentley/imodeljs-common";
-import { Point3d, Transform } from "@bentley/geometry-core";
+import { Point3d, Sphere, Transform } from "@bentley/geometry-core";
 import { IModelApp } from "../IModelApp";
 import { DecorateContext } from "../ViewContext";
 import { ScreenViewport } from "../Viewport";
@@ -16,6 +16,10 @@ import { GraphicType, PickableGraphicOptions } from "../render/GraphicBuilder";
 export class BoxDecorator {
   public constructor(public readonly vp: ScreenViewport, public readonly color: ColorDef, public readonly pickable?: PickableGraphicOptions, public readonly placement?: Transform, private _shapePoints?: Point3d[]) {
     IModelApp.viewManager.addDecorator(this);
+  }
+
+  public drop() {
+    IModelApp.viewManager.dropDecorator(this);
   }
 
   public decorate(context: DecorateContext): void {
@@ -40,6 +44,32 @@ export class BoxDecorator {
 
     builder.setSymbology(this.color, this.color, 1);
     builder.addShape(this._shapePoints);
+    context.addDecorationFromBuilder(builder);
+  }
+}
+
+/** A simple configurable sphere decorator for tests.
+ * @internal
+ */
+export class SphereDecorator {
+  public constructor(public readonly vp: ScreenViewport, public readonly color: ColorDef, public readonly pickable?: PickableGraphicOptions, public readonly placement?: Transform, private _center: Point3d = new Point3d(), private _radius: number = 1) {
+    IModelApp.viewManager.addDecorator(this);
+  }
+
+  public drop() {
+    IModelApp.viewManager.dropDecorator(this);
+  }
+
+  public decorate(context: DecorateContext): void {
+    const builder = context.createGraphic({
+      placement: this.placement,
+      type: GraphicType.Scene,
+      pickable: this.pickable,
+    });
+
+    builder.setSymbology(this.color, this.color, 1);
+    const sphere = Sphere.createCenterRadius(this._center, this._radius);
+    builder.addSolidPrimitive(sphere);
     context.addDecorationFromBuilder(builder);
   }
 }

--- a/core/frontend/src/test/render/webgl/Decorations.test.ts
+++ b/core/frontend/src/test/render/webgl/Decorations.test.ts
@@ -9,7 +9,7 @@ import { ScreenViewport } from "../../../Viewport";
 import { IModelApp } from "../../../IModelApp";
 import { SpatialViewState } from "../../../SpatialViewState";
 import { createBlankConnection } from "../../createBlankConnection";
-import { BoxDecorator } from "../../BoxDecorator";
+import { BoxDecorator, SphereDecorator } from "../../TestDecorators";
 import { expectColors } from "../../ExpectColors";
 import { ViewRect } from "../../../ViewRect";
 
@@ -18,8 +18,8 @@ describe("Decorations", () => {
   let viewport: ScreenViewport;
   let width = 0;
   let height = 0;
-  let decLocRect: ViewRect;
-  let decLocRect2: ViewRect;
+  let boxDecLocRect: ViewRect;
+  let sphereDecBgLocRect: ViewRect;
 
   const w = 0.5;
   const h = 0.5;
@@ -52,8 +52,8 @@ describe("Decorations", () => {
     viewport = ScreenViewport.create(div, view);
     width = viewport.viewRect.width;
     height = viewport.viewRect.height;
-    decLocRect = new ViewRect(0, 0, 1, 1);
-    decLocRect2 = new ViewRect(width / 2 - 1, height / 2 - 1, width / 2, height / 2);
+    boxDecLocRect = new ViewRect(0, 0, 1, 1);
+    sphereDecBgLocRect = new ViewRect(width - 2, height / 2 + 128, width - 2 + 1, height / 2 + 128 + 1);
   });
 
   afterEach(() => {
@@ -68,17 +68,31 @@ describe("Decorations", () => {
     document.body.removeChild(div);
   });
 
-  it("draws decoration in expected location", () => {
+  it("draws box decoration in expected location", () => {
     const dec = new BoxDecorator(viewport, ColorDef.red, undefined, undefined, shapePoints);
     expectColors(viewport, [dec.color, viewport.view.displayStyle.backgroundColor]); // are both the decorator and background rendering?
-    expectColors(viewport, [dec.color], decLocRect); // is decorator rendering at expected location?
-    expectColors(viewport, [dec.color], decLocRect2); // is decorator rendering at expected location?
+    expectColors(viewport, [dec.color], boxDecLocRect); // is decorator rendering at expected location?
+    dec.drop();
   }).timeout(20000); // macOS is slow.
 
-  it("draws decoration in graphic-builder-transformed location", () => {
+  it("draws box decoration in graphic-builder-transformed location", () => {
     const dec = new BoxDecorator(viewport, ColorDef.red, undefined, Transform.createTranslationXYZ(0.25, 0.25), shapePoints);
     expectColors(viewport, [dec.color, viewport.view.displayStyle.backgroundColor]); // are both the decorator and background rendering?
-    expectColors(viewport, [viewport.view.displayStyle.backgroundColor], decLocRect); // background should render where the decorator would have been without transform.
-    expectColors(viewport, [viewport.view.displayStyle.backgroundColor], decLocRect2); // background should render where the decorator would have been without transform.
+    expectColors(viewport, [viewport.view.displayStyle.backgroundColor], boxDecLocRect); // background should render where the decorator would have been without transform.
+    dec.drop();
+  }).timeout(20000); // macOS is slow.
+
+  it("draws sphere decoration in expected location", () => {
+    const dec = new SphereDecorator(viewport, ColorDef.red, undefined, undefined, new Point3d(), 1.0);
+    expectColors(viewport, [dec.color, viewport.view.displayStyle.backgroundColor]); // are both the decorator and background rendering?
+    expectColors(viewport, [viewport.view.displayStyle.backgroundColor], sphereDecBgLocRect); // when sphere is untransformed, this location should be the background
+    dec.drop();
+  }).timeout(20000); // macOS is slow.
+
+  it("draws sphere decoration in graphic-builder-transformed location", () => {
+    const dec = new SphereDecorator(viewport, ColorDef.red, undefined, Transform.createTranslationXYZ(0.25, 0), new Point3d(), 1.0);
+    expectColors(viewport, [dec.color, viewport.view.displayStyle.backgroundColor]); // are both the decorator and background rendering?
+    expectColors(viewport, [dec.color], sphereDecBgLocRect); // when sphere is transformed, this location should contain the sphere
+    dec.drop();
   }).timeout(20000); // macOS is slow.
 });

--- a/core/frontend/src/test/render/webgl/PickableGraphics.test.ts
+++ b/core/frontend/src/test/render/webgl/PickableGraphics.test.ts
@@ -10,7 +10,7 @@ import { ScreenViewport } from "../../../Viewport";
 import { IModelApp } from "../../../IModelApp";
 import { SpatialViewState } from "../../../SpatialViewState";
 import { createBlankConnection } from "../../createBlankConnection";
-import { BoxDecorator } from "../../BoxDecorator";
+import { BoxDecorator } from "../../TestDecorators";
 import { expectColors } from "../../ExpectColors";
 
 describe("Pickable graphic", () => {
@@ -65,16 +65,16 @@ describe("Pickable graphic", () => {
   }
 
   it("is pickable", () => {
-    const dec = new BoxDecorator(viewport, ColorDef.red, {id: "0x123", locateOnly: false});
+    const dec = new BoxDecorator(viewport, ColorDef.red, { id: "0x123", locateOnly: false });
     expectColors(viewport, [dec.color, viewport.view.displayStyle.backgroundColor]);
-    expect (dec.pickable).to.not.be.undefined;
+    expect(dec.pickable).to.not.be.undefined;
     expectIds([dec.pickable!.id]);
   }).timeout(20000); // macOS is slow.
 
   it("optionally draws only for pick", () => {
-    const dec = new BoxDecorator(viewport, ColorDef.blue, {id: "0x456", locateOnly: true});
+    const dec = new BoxDecorator(viewport, ColorDef.blue, { id: "0x456", locateOnly: true });
     expectColors(viewport, [viewport.view.displayStyle.backgroundColor]);
-    expect (dec.pickable).to.not.be.undefined;
+    expect(dec.pickable).to.not.be.undefined;
     expectIds([dec.pickable!.id]);
   }).timeout(20000); // macOS is slow.
 });


### PR DESCRIPTION
The previous fix to the graphicbuilder transform problem actually resulted in some graphicbuilder primitives being transformed twice because they already had the transform applied to them. This fixes that issue by moving the transformation only to primitives that were missing it. This also adds code to ensure that GeometryAccumulator does not mutate the graphicbuilder's transform in-place.