### PR TITLE
Correct display of map tiles with depth buffering off

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -5724,6 +5724,8 @@ export class MapTileTree extends RealityTileTree {
     // (undocumented)
     static minReprojectionDepth: number;
     // (undocumented)
+    get parentsAndChildrenExclusive(): boolean;
+    // (undocumented)
     pointAboveEllipsoid(point: Point3d): boolean;
     // (undocumented)
     sourceTilingScheme: MapTilingScheme;

--- a/common/changes/@bentley/imodeljs-frontend/Reduce-map-tile-occlusion-tolerance_2021-09-01-17-54.json
+++ b/common/changes/@bentley/imodeljs-frontend/Reduce-map-tile-occlusion-tolerance_2021-09-01-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Reduce ellipsoid occlusion tolerance to avoid misdisplayed tiles over horizon with depth off.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -17,6 +17,7 @@ import { GraphicBuilder } from "../render/GraphicBuilder";
 import { SceneContext } from "../ViewContext";
 import { GraphicsCollectorDrawArgs, MapTile, RealityTile, RealityTileDrawArgs, RealityTileLoader, RealityTileParams, Tile, TileDrawArgs, TileGraphicType, TileParams, TileTree, TileTreeParams } from "./internal";
 
+/** @internal */
 export class TraversalDetails {
   public queuedChildren = new Array<Tile>();
   public childrenLoading = false;

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -182,7 +182,7 @@ export class RealityTileTree extends TileTree {
     const graphicTypeBranches = new Map<TileGraphicType, GraphicBranch>();
 
     const selectedTiles = this.selectRealityTiles(args, displayedTileDescendants, preloadDebugBuilder);
-    if (!this.loader.parentsAndChildrenExclusive)
+    if (!this.parentsAndChildrenExclusive)
       selectedTiles.sort((a, b) => a.depth - b.depth);                    // If parent and child are not exclusive then display parents (low resolution) first.
 
     const classifier = args.context.planarClassifiers.get(this.modelId);

--- a/core/frontend/src/tile/map/MapTile.ts
+++ b/core/frontend/src/tile/map/MapTile.ts
@@ -284,7 +284,7 @@ export class MapTile extends RealityTile {
       for (const cornerNormal of this._cornerRays) {
         const eyeNormal = Vector3d.createStartEnd(viewingSpace.eyePoint, cornerNormal.origin, scratchNormal);
         eyeNormal.normalizeInPlace();
-        if (eyeNormal.dotProduct(cornerNormal.direction) < .1)
+        if (eyeNormal.dotProduct(cornerNormal.direction) < .01)
           return false;
       }
     } else {

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -111,6 +111,10 @@ export class MapTileTree extends RealityTileTree {
     this._rootTile = this.createGlobeChild({ contentId: quadId.contentId, maximumSize: 0, range }, quadId, range.corners(), globalRectangle, rootPatch, undefined);
 
   }
+
+  // If we are not depth buffering we force parents and exclusive to false to cause the map tiles to be sorted by depth so that painters algorithm will approximate correct depth display.
+  public override get parentsAndChildrenExclusive() { return this.useDepthBuffer ? this.loader.parentsAndChildrenExclusive : false; }
+
   public tileFromQuadId(quadId: QuadId): MapTile | undefined {
     return (this._rootTile as MapTile).tileFromQuadId(quadId);
   }


### PR DESCRIPTION
The logic for rejecting map tiles occluded by the ellipsoid was allowing tile beyond the horizon to be accepted.  With depth buffer turned off (the default) these tiles would display incorrectly.   