### PR TITLE
UI: Update VirtualizedPropertyGrid element spacing

### DIFF
--- a/common/changes/@bentley/ui-components/ui-components-property-grid-style_2021-09-02-11-20.json
+++ b/common/changes/@bentley/ui-components/ui-components-property-grid-style_2021-09-02-11-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components"
+}

--- a/ui/components/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -549,7 +549,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
 
         fireEvent.click(category);
         expect(baseElement.querySelector(".iui-expanded")).to.exist;
-        expect(node.style.height).to.be.equal("553px");
+        expect(node.style.height).to.be.equal("541px");
       });
 
       it("updates node height on collapse", async () => {
@@ -562,7 +562,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
 
         const category = await findByText("test_category");
         const node = baseElement.querySelector(".virtualized-grid-node") as HTMLElement;
-        expect(node.style.height).to.be.equal("553px");
+        expect(node.style.height).to.be.equal("541px");
 
         fireEvent.click(category);
         expect(node.style.height).to.be.equal("36px");
@@ -603,7 +603,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
       await findByText("Stub Component");
 
       const node = baseElement.querySelectorAll(".virtualized-grid-node")[1] as HTMLElement;
-      expect(node.style.height).to.be.equal("19px");
+      expect(node.style.height).to.be.equal("20px");
     });
 
     it("adds more height to dynamic nodes when orientation is vertical", async () => {
@@ -613,7 +613,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
       await findByText("Stub Component");
 
       const node = baseElement.querySelectorAll(".virtualized-grid-node")[1] as HTMLElement;
-      expect(node.style.height).to.be.equal("50px");
+      expect(node.style.height).to.be.equal("48px");
     });
   });
 

--- a/ui/components/src/test/propertygrid/component/internal/FlatPropertyRenderer.test.tsx
+++ b/ui/components/src/test/propertygrid/component/internal/FlatPropertyRenderer.test.tsx
@@ -298,7 +298,7 @@ describe("FlatPropertyRenderer", () => {
       const { rerender } = render(renderFlatPropertyRenderer(false, onHeightChanged));
       expect(onHeightChanged).to.have.not.been.called;
       rerender(renderFlatPropertyRenderer(true, onHeightChanged));
-      expect(onHeightChanged).to.have.been.calledOnceWith(28);
+      expect(onHeightChanged).to.have.been.calledOnceWith(27);
     });
 
     it("does not get called when component is mounted in editing state", () => {

--- a/ui/components/src/ui-components/properties/renderers/PropertyView.scss
+++ b/ui/components/src/ui-components/properties/renderers/PropertyView.scss
@@ -11,11 +11,11 @@ $text-font-color: $buic-text-color;
 .components-property-record--horizontal {
   height: 100%;
   display: grid;
+  padding: 0 8px;
 
   .components-property-record-label {
     font-size: $iui-font-size-small;
     color: $buic-foreground-muted;
-    margin-right: 5px;
   }
 
   .components-property-record-value {
@@ -28,23 +28,19 @@ $text-font-color: $buic-text-color;
 
 .components-property-record--vertical {
   height: 100%;
+  padding: 0 8px;
   display: grid;
+  align-content: center;
 
   .components-property-record-label {
     font-size: $iui-font-size-small;
     color: $buic-foreground-muted;
-    margin: 0 9px;
-    padding-top: 5px;
-    padding-bottom: 0px;
   }
 
   .components-property-record-value {
-    min-height: 24px;
+    min-height: 22px;
     font-size: $text-font-size;
     color: $text-font-color;
-    margin: 0 9px;
-    padding-top: 0px;
-    padding-bottom: 3px;
   }
 }
 

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -15,6 +15,7 @@
 
 .components-virtualized-property-grid {
   user-select: none;
+  padding: 0px 3px 3px 3px;
 
   @include small-itwinui-expandable-block;
 }
@@ -46,8 +47,8 @@
 
     &:not(.components--selected) {
       &:hover {
-        // Highlight the whole row in expandable block
-        margin: 0 -12px;
+        // Highlight the whole row of inner-most expandable block
+        margin: 0 -4px;
         // Compensate the negative margin by adding padding
         padding: 0 12px;
 
@@ -57,8 +58,8 @@
   }
 
   .components--selected {
-    // Highlight the whole row in expandable block
-    margin: 0 -12px;
+    // Highlight the whole row of inner-most expandable block
+    margin: 0 -4px;
     // Compensate the negative margin by adding padding (minus one for border)
     padding: 0px 11px;
 
@@ -82,6 +83,10 @@
 
 .virtualized-grid-node-custom-category {
   padding-top: 4px;
+
+  .iui-expandable-content > div {
+    padding: 0 4px 4px 4px;
+  }
 }
 
 .virtualized-grid-node-content {

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -231,8 +231,8 @@ export class VirtualizedPropertyGrid extends React.Component<VirtualizedProperty
     const categoryHeaderHeight = 32;
     const categoryHeaderPadding = 4;
     const categoryPropertyHeight = 27;
-    const bottomBorderPadding = 4;
-    const verticalPrimitivePropertyHeight = 59;
+    const bottomBorderPadding = 5;
+    const verticalPrimitivePropertyHeight = 55;
 
     return getPropertyHeight(this.state) + node.lastInNumberOfCategories * bottomBorderPadding;
 
@@ -244,7 +244,7 @@ export class VirtualizedPropertyGrid extends React.Component<VirtualizedProperty
             + (node.isExpanded ? dynamicHeight + bottomBorderPadding : 0);
         }
 
-        return dynamicHeight + (state.orientation === Orientation.Vertical ? 31 : 0);
+        return dynamicHeight + (state.orientation === Orientation.Vertical ? 28 : 0);
       }
 
       if (node.type === FlatGridItemType.Category) {
@@ -525,7 +525,7 @@ const CustomCategoryContent: React.FC<CustomCategoryContentProps> = (props) => {
     () => {
       assert(divRef.current !== null);
       const contentHeight = divRef.current.getBoundingClientRect().height;
-      onHeightChanged(contentHeight + 13);
+      onHeightChanged(contentHeight);
     },
     [props.gridContext.orientation, onHeightChanged],
   );

--- a/ui/components/src/ui-components/propertygrid/internal/flat-properties/FlatPropertyRenderer.tsx
+++ b/ui/components/src/ui-components/propertygrid/internal/flat-properties/FlatPropertyRenderer.tsx
@@ -170,7 +170,7 @@ function useResetHeightOnEdit(isEditing?: boolean, onHeightChanged?: (newHeight:
   const previousEditingStatusRef = React.useRef(isEditing);
   React.useEffect(() => {
     if (!previousEditingStatusRef.current && isEditing) {
-      onHeightChanged?.(28);
+      onHeightChanged?.(27);
     }
 
     previousEditingStatusRef.current = isEditing;


### PR DESCRIPTION
Some more adjustments to element positioning in VirtualizedPropertyGrid after migrating to @itwinui-react components. Notable changes: 

* Adds padding around the whole property grid to match previous look
* Simplifies some CSS rules
* Increases information density in vertical mode

Known issues:
* Expandable block chevrons are misaligned
* There is no top padding in expandable block content
* Editors cause properties to nudge slightly