### PR TITLE
Allow white-on-white reversal to be applied to non-white backgrounds

### DIFF
--- a/common/api/frontend-devtools.api.md
+++ b/common/api/frontend-devtools.api.md
@@ -2475,6 +2475,20 @@ export class VignetteEffect extends AddEffectTool {
     static toolId: string;
 }
 
+// @beta
+export class WoWIgnoreBackgroundTool extends DisplayStyleTool {
+    // (undocumented)
+    execute(vp: Viewport): boolean;
+    // (undocumented)
+    static get maxArgs(): number;
+    // (undocumented)
+    static get minArgs(): number;
+    // (undocumented)
+    parse(args: string[]): boolean;
+    // (undocumented)
+    static toolId: string;
+}
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -1969,6 +1969,7 @@ export class DisplayStyleSettings {
     readonly onThematicChanged: BeEvent<(newThematic: ThematicDisplay) => void>;
     readonly onTimePointChanged: BeEvent<(newTimePoint: number | undefined) => void>;
     readonly onViewFlagsChanged: BeEvent<(newFlags: Readonly<ViewFlags>) => void>;
+    readonly onWhiteOnWhiteReversalChanged: BeEvent<(newSettings: WhiteOnWhiteReversalSettings) => void>;
     overrideModelAppearance(modelId: Id64String, ovr: FeatureAppearance): void;
     overrideSubCategory(id: Id64String, ovr: SubCategoryOverride): void;
     get planarClipMasks(): Map<Id64String, PlanarClipMaskSettings>;
@@ -1987,6 +1988,8 @@ export class DisplayStyleSettings {
     toOverrides(options?: DisplayStyleOverridesOptions): DisplayStyleSettingsProps;
     get viewFlags(): ViewFlags;
     set viewFlags(flags: ViewFlags);
+    get whiteOnWhiteReversal(): WhiteOnWhiteReversalSettings;
+    set whiteOnWhiteReversal(settings: WhiteOnWhiteReversalSettings);
     }
 
 // @public
@@ -2016,6 +2019,7 @@ export interface DisplayStyleSettingsProps {
     timePoint?: number;
     // (undocumented)
     viewflags?: ViewFlagProps;
+    whiteOnWhiteReversal?: WhiteOnWhiteReversalProps;
 }
 
 // @public
@@ -8777,6 +8781,19 @@ export class WebAppRpcRequest extends RpcRequest {
     protected setHeader(name: string, value: string): void;
     protected supplyFetch(): typeof fetch;
     protected supplyRequest(): typeof Request;
+}
+
+// @public
+export interface WhiteOnWhiteReversalProps {
+    ignoreBackgroundColor?: boolean;
+}
+
+// @public
+export class WhiteOnWhiteReversalSettings {
+    equals(other: WhiteOnWhiteReversalSettings): boolean;
+    static fromJSON(props?: WhiteOnWhiteReversalProps): WhiteOnWhiteReversalSettings;
+    readonly ignoreBackgroundColor: boolean;
+    toJSON(): WhiteOnWhiteReversalProps | undefined;
 }
 
 // @internal

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -314,6 +314,7 @@ import { ViewStateProps } from '@bentley/imodeljs-common';
 import { WebGLContext } from '@bentley/webgl-compatibility';
 import { WebGLExtensionName } from '@bentley/webgl-compatibility';
 import { WebGLRenderCompatibilityInfo } from '@bentley/webgl-compatibility';
+import { WhiteOnWhiteReversalSettings } from '@bentley/imodeljs-common';
 import { XAndY } from '@bentley/geometry-core';
 import { XYAndZ } from '@bentley/geometry-core';
 import { XYZ } from '@bentley/geometry-core';
@@ -8073,6 +8074,8 @@ export interface RenderPlan {
     readonly upVector: Vector3d;
     // (undocumented)
     readonly viewFlags: ViewFlags;
+    // (undocumented)
+    readonly whiteOnWhiteReversal: WhiteOnWhiteReversalSettings;
 }
 
 // @internal

--- a/common/api/summary/frontend-devtools.exports.csv
+++ b/common/api/summary/frontend-devtools.exports.csv
@@ -221,3 +221,4 @@ beta;ViewportTileSizeModifierTool
 beta;class ViewportToggleTool 
 beta;VignetteConfig 
 beta;VignetteEffect 
+beta;WoWIgnoreBackgroundTool 

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -686,6 +686,8 @@ public;ViewStateProps
 internal;WEB_RPC_CONSTANTS:
 public;class WebAppRpcProtocol 
 public;WebAppRpcRequest 
+public;WhiteOnWhiteReversalProps
+public;WhiteOnWhiteReversalSettings
 internal;class WipRpcInterface 
 public;XyzRotation 
 public;XyzRotationProps

--- a/common/changes/@bentley/frontend-devtools/wow-ignore-background_2021-09-08-13-58.json
+++ b/common/changes/@bentley/frontend-devtools/wow-ignore-background_2021-09-08-13-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/frontend-devtools",
+      "comment": "Add tool to ignore background color for white-on-white reversal.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/frontend-devtools"
+}

--- a/common/changes/@bentley/imodeljs-common/wow-ignore-background_2021-09-08-13-58.json
+++ b/common/changes/@bentley/imodeljs-common/wow-ignore-background_2021-09-08-13-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Added WhiteOnWhiteReversalSettings to control whether background color must be white for white-on-white reversal to apply.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common"
+}

--- a/common/changes/@bentley/imodeljs-frontend/wow-ignore-background_2021-09-08-13-58.json
+++ b/common/changes/@bentley/imodeljs-frontend/wow-ignore-background_2021-09-08-13-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Allow white-on-white reversal to be applied regardless of background color.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/common/src/ViewFlags.ts
+++ b/core/common/src/ViewFlags.ts
@@ -104,7 +104,9 @@ export interface ViewFlagProps {
    * that logic does not execute, potentially improving performance for no degradation in visual quality. In some scenarios - such as wireframe views containing many planar regions with interior fill, or smooth views containing many coincident planar and non-planar surfaces - enabling this view flag improves display quality by forcing that logic to execute.
    */
   forceSurfaceDiscard?: boolean;
-  /** Disables the "white-on-white reversal" employed by some CAD applications. White-on-white reversal causes white geometry to be drawn as black if the view's background color is also white. */
+  /** Disables the "white-on-white reversal" employed by some CAD applications.
+   * @see [[ViewFlags.whiteOnWhiteReversal]].
+   */
   noWhiteOnWhiteReversal?: boolean;
 }
 
@@ -207,6 +209,7 @@ export class ViewFlags {
   public readonly forceSurfaceDiscard: boolean;
   /** Whether to apply white-on-white reversal.
    * Some CAD applications use this to cause white geometry to be drawn as black if the view's background color is white.
+   * When enabled, the [[DisplayStyleSettings]]' [[WhiteOnWhiteReversalSettings]] control how white-on-white reversal is applied.
    * Default: true.
    */
   public readonly whiteOnWhiteReversal: boolean;

--- a/core/common/src/WhiteOnWhiteReversalSettings.ts
+++ b/core/common/src/WhiteOnWhiteReversalSettings.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module DisplayStyles
+ */
+
+/** JSON representation of a [[WhiteOnWhiteReversalSettings]].
+ * @public
+ */
+export interface WhiteOnWhiteReversalProps {
+  /** Default: false.
+   * @see [[WhiteOnWhiteReversalSettings.ignoreBackgroundColor]].
+   */
+  ignoreBackgroundColor?: boolean;
+}
+
+/** As part of a [[DisplayStyleSettings]], controls how white-on-white reversal is applied to make white geometry more
+ * visible in the view.
+ * By default, pure white geometry is displayed as black instead if the [[DisplayStyleSettings.backgroundColor]] is also pure white.
+ * These settings are only applied if the display style's [[ViewFlags.whiteOnWhiteReversal]] flag is enabled.
+ * @see [[DisplayStyleSettings.whiteOnWhiteReversal]] to change these settings for a display style.
+ * @public
+ */
+export class WhiteOnWhiteReversalSettings {
+  /** If true, white-on-white reversal ignores the display style's background color; otherwise, white-on-white reversal applies only
+   * if the background color is pure white.
+   * @see [[DisplayStyleSettings.backgroundColor]] to change the background color.
+   */
+  public readonly ignoreBackgroundColor: boolean;
+
+  private constructor(ignoreBackground: boolean) {
+    this.ignoreBackgroundColor = ignoreBackground;
+  }
+
+  private static _noIgnore = new WhiteOnWhiteReversalSettings(true);
+  private static _ignore = new WhiteOnWhiteReversalSettings(false);
+
+  /** Create from JSON representation. */
+  public static fromJSON(props?: WhiteOnWhiteReversalProps): WhiteOnWhiteReversalSettings {
+    return props?.ignoreBackgroundColor ? this._noIgnore : this._ignore;
+  }
+
+  /** Convert to JSON representation. The JSON representation is `undefined` if these settings match the defaults. */
+  public toJSON(): WhiteOnWhiteReversalProps | undefined {
+    return this.ignoreBackgroundColor ? { ignoreBackgroundColor: true } : undefined;
+  }
+
+  /** Returns true if `this` is equivalent to `other`. */
+  public equals(other: WhiteOnWhiteReversalSettings): boolean {
+    return this === other;
+  }
+}

--- a/core/common/src/imodeljs-common.ts
+++ b/core/common/src/imodeljs-common.ts
@@ -139,6 +139,7 @@ export * from "./tile/IModelTileIO";
 export * from "./tile/PntsTileIO";
 export * from "./tile/TileIO";
 export * from "./tile/TileMetadata";
+export * from "./WhiteOnWhiteReversalSettings";
 
 /** @docs-package-description
  * The imodeljs-common package contains classes for working with iModels that can be used in both [frontend]($docs/learning/frontend/index.md) and [backend]($docs/learning/backend/index.md).

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -167,6 +167,7 @@ describe("DisplayStyleSettings", () => {
         const excludedIds = Array.from(settings.excludedElementIds);
         // eslint-disable-next-line deprecation/deprecation
         expect(settings.excludedElements.size).to.equal(excludedIds.length);
+        // eslint-disable-next-line deprecation/deprecation
         const set = OrderedId64Iterable.sortArray(Array.from(settings.excludedElements));
         expect(set).to.deep.equal(excludedIds);
       };
@@ -186,6 +187,7 @@ describe("DisplayStyleSettings", () => {
       test(undefined, (settings) => { settings.excludedElements.add("0x2"); settings.excludedElements.delete("0x2"); });
       // eslint-disable-next-line deprecation/deprecation
       test("+2", (settings) => { settings.excludedElements.add("0x1"); settings.excludedElements.add("0x2"); settings.excludedElements.delete("0x1"); });
+      // eslint-disable-next-line deprecation/deprecation
       test("+1", (settings) => { settings.addExcludedElements(["0x1", "0x2"]); settings.excludedElements.delete("0x2"); });
       // eslint-disable-next-line deprecation/deprecation
       test("+2", (settings) => { settings.excludedElements.add("0x1"); settings.addExcludedElements(["0x2", "0x3"]); settings.dropExcludedElement("0x3"); settings.excludedElements.delete("0x1"); });

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -17,11 +17,55 @@ import { ThematicDisplayMode } from "../ThematicDisplay";
 import { RenderMode, ViewFlags } from "../ViewFlags";
 import { PlanarClipMaskMode, PlanarClipMaskSettings } from "../PlanarClipMask";
 import { MapLayerSettings } from "../MapLayerSettings";
-
-/* eslint-disable deprecation/deprecation */
-//  - for DisplayStyleSettings.excludedElements.
+import { WhiteOnWhiteReversalProps, WhiteOnWhiteReversalSettings } from "../WhiteOnWhiteReversalSettings";
 
 describe("DisplayStyleSettings", () => {
+  describe("whiteOnWhiteReversal", () => {
+    it("round-trips through JSON", () => {
+      function test(props: WhiteOnWhiteReversalProps | undefined, newSettings: WhiteOnWhiteReversalSettings, expected?: WhiteOnWhiteReversalProps | "input"): void {
+        const styleProps = { styles: props ? { whiteOnWhiteReversal: props } : { } };
+        const style = new DisplayStyle3dSettings(styleProps);
+        style.whiteOnWhiteReversal = newSettings;
+        const result = style.toJSON();
+        expect(result.whiteOnWhiteReversal).to.deep.equal(expected === "input" ? props : expected);
+      }
+
+      const ignore = WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: true });
+      const defaults = WhiteOnWhiteReversalSettings.fromJSON();
+
+      test(undefined, defaults, "input");
+      test({ ignoreBackgroundColor: false }, defaults, "input");
+      test(undefined, ignore, { ignoreBackgroundColor: true });
+      test({ ignoreBackgroundColor: true }, ignore, "input");
+      test({ ignoreBackgroundColor: true }, defaults, undefined);
+    });
+
+    it("raises event", () => {
+      const style = new DisplayStyle3dSettings({ styles: { } });
+      function test(expectEvent: boolean, newSettings: WhiteOnWhiteReversalSettings): void {
+        let eventRaised = false;
+        const remove = style.onWhiteOnWhiteReversalChanged.addListener((s) => {
+          expect(eventRaised).to.be.false;
+          eventRaised = true;
+          expect(s).to.equal(newSettings);
+        });
+
+        style.whiteOnWhiteReversal = newSettings;
+        remove();
+
+        expect(style.whiteOnWhiteReversal).to.equal(newSettings);
+        expect(eventRaised).to.equal(expectEvent);
+      }
+
+      test(false, style.whiteOnWhiteReversal);
+      test(false, WhiteOnWhiteReversalSettings.fromJSON());
+      test(true, WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: true }));
+      test(false, style.whiteOnWhiteReversal);
+      test(false, WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: true }));
+      test(true, WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: false }));
+    });
+  });
+
   describe("plan projection settings", () => {
     interface SettingsMap { [modelId: string]: PlanProjectionSettingsProps }
 
@@ -116,10 +160,12 @@ describe("DisplayStyleSettings", () => {
         const settings = new DisplayStyleSettings({});
         func(settings);
 
+        // eslint-disable-next-line deprecation/deprecation
         expect(settings.toJSON().excludedElements).to.equal(expectedExcludedElements);
         expect(settings.compressedExcludedElementIds).to.equal(undefined === expectedExcludedElements ? "" : expectedExcludedElements);
 
         const excludedIds = Array.from(settings.excludedElementIds);
+        // eslint-disable-next-line deprecation/deprecation
         expect(settings.excludedElements.size).to.equal(excludedIds.length);
         const set = OrderedId64Iterable.sortArray(Array.from(settings.excludedElements));
         expect(set).to.deep.equal(excludedIds);
@@ -134,14 +180,20 @@ describe("DisplayStyleSettings", () => {
       test("+2", (settings) => { settings.addExcludedElements(["0x1", "0x2"]); settings.dropExcludedElement("0x1"); });
       test(undefined, (settings) => { settings.addExcludedElements(["0x1", "0x2"]); settings.dropExcludedElements(["0x2", "0x1"]); });
 
+      // eslint-disable-next-line deprecation/deprecation
       test("+3", (settings) => settings.excludedElements.add("0x3"));
+      // eslint-disable-next-line deprecation/deprecation
       test(undefined, (settings) => { settings.excludedElements.add("0x2"); settings.excludedElements.delete("0x2"); });
+      // eslint-disable-next-line deprecation/deprecation
       test("+2", (settings) => { settings.excludedElements.add("0x1"); settings.excludedElements.add("0x2"); settings.excludedElements.delete("0x1"); });
       test("+1", (settings) => { settings.addExcludedElements(["0x1", "0x2"]); settings.excludedElements.delete("0x2"); });
+      // eslint-disable-next-line deprecation/deprecation
       test("+2", (settings) => { settings.excludedElements.add("0x1"); settings.addExcludedElements(["0x2", "0x3"]); settings.dropExcludedElement("0x3"); settings.excludedElements.delete("0x1"); });
 
+      // eslint-disable-next-line deprecation/deprecation
       test(undefined, (settings) => { settings.addExcludedElements(["0x1", "0x2"]); settings.excludedElements.clear(); });
 
+      // eslint-disable-next-line deprecation/deprecation
       test(undefined, (settings) => { settings.addExcludedElements(["0x1", "0x2"]); settings.excludedElements.add("0x3"); settings.clearExcludedElements(); });
     });
   });
@@ -284,6 +336,7 @@ describe("DisplayStyleSettings overrides", () => {
     backgroundColor: ColorByName.aquamarine,
     monochromeColor: ColorByName.cyan,
     monochromeMode: MonochromeMode.Scaled,
+    whiteOnWhiteReversal: { ignoreBackgroundColor: false },
     environment: {
       sky: {
         display: true,
@@ -402,6 +455,7 @@ describe("DisplayStyleSettings overrides", () => {
       nonLocatable: true,
       emphasized: true,
     }],
+    // eslint-disable-next-line deprecation/deprecation
     excludedElements: CompressedId64Set.compressIds(["0x4", "0x8", "0x10"]),
     contextRealityModels: [{
       tilesetUrl: "google.com",
@@ -573,6 +627,7 @@ describe("DisplayStyleSettings overrides", () => {
       }],
     });
 
+    // eslint-disable-next-line deprecation/deprecation
     test({ viewflags, excludedElements: CompressedId64Set.compressIds(["0xbaadf00d", "0xdeadbeef"]) });
 
     test({
@@ -651,5 +706,7 @@ describe("DisplayStyleSettings overrides", () => {
         "0x8": { elevation: 2, transparency: 0.25, overlay: true, enforceDisplayPriority: true },
       },
     });
+
+    test({ viewflags, whiteOnWhiteReversal: { ignoreBackgroundColor: true } });
   });
 });

--- a/core/common/src/test/WhiteOnWhiteReversalSettings.test.ts
+++ b/core/common/src/test/WhiteOnWhiteReversalSettings.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { WhiteOnWhiteReversalProps, WhiteOnWhiteReversalSettings } from "../WhiteOnWhiteReversalSettings";
+
+describe("WhiteOnWhiteReversalSettings", () => {
+  it("round-trips through JSON", () => {
+    function test(props?: WhiteOnWhiteReversalProps, expected?: WhiteOnWhiteReversalProps | "input"): void {
+      const settings = WhiteOnWhiteReversalSettings.fromJSON(props);
+      const actual = settings.toJSON();
+      expect(actual).to.deep.equal("input" === expected ? props : expected);
+    }
+
+    test(undefined, undefined);
+    test({ ignoreBackgroundColor: true }, "input");
+    test({ ignoreBackgroundColor: false }, undefined);
+  });
+
+  it("compares", () => {
+    function test(expectEqual: boolean, x: WhiteOnWhiteReversalSettings, y: WhiteOnWhiteReversalSettings): void {
+      expect(x.equals(y)).to.equal(expectEqual);
+      expect(x === y).to.equal(expectEqual);
+    }
+
+    const a = WhiteOnWhiteReversalSettings.fromJSON();
+    const b = WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: false });
+    const c = WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: true });
+    const d = WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: true });
+
+    test(true, a, b);
+    test(true, c, d);
+    test(false, a, c);
+    test(false, d, b);
+  });
+});

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -78,6 +78,7 @@ The key-ins below enable, disable, or toggle a specific feature. They take at mo
 * `fdt toggle reality logging` - Toggle the logging of reality tile loading and selection diagnostics to the console.
 * `fdt toggle reality bounds` - Toggle the display of bounding boxes for reality tiles.
 * `fdt set building display` Toggle the display of the worldwide OpenStreetMap worldwide buildingslayer by attaching or displaying as a reality model in the current viewport.  The OSM buildings are aggregated and supplied from Cesium Ion <https://cesium.com/content/cesium-osm-buildings/>. The first argument is required on|off - the second optional argument is a value for transparency between 0 and 1.
+* `fdt wow ignore background` Toggle whether the background color needs to be white for white-on-white reversal to apply.
 
 ### Screen-space effect key-ins
 

--- a/core/frontend-devtools/public/locales/en/FrontendDevTools.json
+++ b/core/frontend-devtools/public/locales/en/FrontendDevTools.json
@@ -441,6 +441,9 @@
       "Prompts": {
         "IdentifyMaskSubCategory": "Identify mask subCategory"
       }
+    },
+    "WoWIgnoreBackground": {
+      "keyin": "fdt wow ignore background"
     }
   }
 }

--- a/core/frontend-devtools/src/FrontEndDevTools.ts
+++ b/core/frontend-devtools/src/FrontEndDevTools.ts
@@ -20,7 +20,9 @@ import { ChangeCameraTool, ChangeEmphasisSettingsTool, ChangeFlashSettingsTool, 
 import { AnimationIntervalTool } from "./tools/AnimationIntervalTool";
 import { ChangeUnitsTool } from "./tools/ChangeUnitsTool";
 import { ClipColorTool, TestClipStyleTool, ToggleSectionCutTool } from "./tools/ClipTools";
-import { ApplyRenderingStyleTool, ChangeViewFlagsTool, OverrideSubCategoryTool, SaveRenderingStyleTool, ToggleSkyboxTool } from "./tools/DisplayStyleTools";
+import {
+  ApplyRenderingStyleTool, ChangeViewFlagsTool, OverrideSubCategoryTool, SaveRenderingStyleTool, ToggleSkyboxTool, WoWIgnoreBackgroundTool,
+} from "./tools/DisplayStyleTools";
 import {
   ClearEmphasizedElementsTool, ClearIsolatedElementsTool, EmphasizeSelectedElementsTool, EmphasizeVisibleElementsTool, IsolateSelectedElementsTool,
 } from "./tools/EmphasizeElementsTool";
@@ -209,6 +211,7 @@ export class FrontendDevTools {
       MaskBackgroundMapByElementTool,
       MaskBackgroundMapByExcludedElementTool,
       UnmaskMapTool,
+      WoWIgnoreBackgroundTool,
     ];
 
     for (const tool of tools)

--- a/core/frontend-devtools/src/tools/DisplayStyleTools.ts
+++ b/core/frontend-devtools/src/tools/DisplayStyleTools.ts
@@ -9,12 +9,14 @@
 
 import {
   DisplayStyle3dSettingsProps, DisplayStyleOverridesOptions, RenderMode, SubCategoryAppearance, SubCategoryOverride, ViewFlags, ViewFlagsProperties,
+  WhiteOnWhiteReversalSettings,
 } from "@bentley/imodeljs-common";
 import {
   DisplayStyle3dState, Environment, IModelApp, NotifyMessageDetails, OutputMessagePriority, Tool, Viewport,
 } from "@bentley/imodeljs-frontend";
 import { copyStringToClipboard } from "../ClipboardUtilities";
 import { parseArgs } from "./parseArgs";
+import { parseToggle } from "./parseToggle";
 
 type BooleanFlagName =
   "dimensions" | "patterns" | "weights" | "styles" | "transparency" | "fill" | "textures" | "materials" | "acsTriad" | "grid" | "visibleEdges" |
@@ -255,6 +257,32 @@ export class OverrideSubCategoryTool extends DisplayStyleTool {
     for (const id of this._subcategoryIds)
       vp.displayStyle.overrideSubCategory(id, ovr);
 
+    return true;
+  }
+}
+
+/** Set whether background color is ignored when applying white-on-white reversal.
+ * @beta
+ */
+export class WoWIgnoreBackgroundTool extends DisplayStyleTool {
+  private _ignore?: boolean;
+
+  public static override toolId = "WoWIgnoreBackground";
+  public static override get minArgs() { return 0; }
+  public static override get maxArgs() { return 1; }
+
+  public parse(args: string[]): boolean {
+    const ignore = parseToggle(args[0]);
+    if (typeof ignore === "string")
+      return false;
+
+    this._ignore = ignore;
+    return true;
+  }
+
+  public execute(vp: Viewport): boolean {
+    const ignoreBackgroundColor = this._ignore ?? !vp.displayStyle.settings.whiteOnWhiteReversal.ignoreBackgroundColor;
+    vp.displayStyle.settings.whiteOnWhiteReversal = WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor });
     return true;
   }
 }

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -1017,6 +1017,7 @@ export abstract class Viewport implements IDisposable {
     removals.push(settings.onMonochromeModeChanged.addListener(displayStyleChanged));
     removals.push(settings.onClipStyleChanged.addListener(styleAndOverridesChanged));
     removals.push(settings.onPlanarClipMaskChanged.addListener(displayStyleChanged));
+    removals.push(settings.onWhiteOnWhiteReversalChanged.addListener(displayStyleChanged));
     removals.push(settings.contextRealityModels.onPlanarClipMaskChanged.addListener(displayStyleChanged));
     removals.push(settings.contextRealityModels.onAppearanceOverridesChanged.addListener(displayStyleChanged));
     removals.push(settings.contextRealityModels.onChanged.addListener(displayStyleChanged));

--- a/core/frontend/src/render/RenderPlan.ts
+++ b/core/frontend/src/render/RenderPlan.ts
@@ -9,7 +9,7 @@
 import { ClipVector, Point3d, Vector3d } from "@bentley/geometry-core";
 import {
   AmbientOcclusion, AnalysisStyle, ClipStyle, ColorDef, Frustum, GlobeMode, HiddenLine, Hilite, LightSettings, MonochromeMode, Npc, RenderTexture,
-  ThematicDisplay, ViewFlags,
+  ThematicDisplay, ViewFlags, WhiteOnWhiteReversalSettings,
 } from "@bentley/imodeljs-common";
 import { FlashSettings } from "../FlashSettings";
 import { Viewport } from "../Viewport";
@@ -45,6 +45,7 @@ export interface RenderPlan {
   readonly backgroundMapOn: boolean;
   readonly upVector: Vector3d;
   readonly lights?: LightSettings;
+  readonly whiteOnWhiteReversal: WhiteOnWhiteReversalSettings;
 }
 
 /** @internal */
@@ -66,6 +67,7 @@ export function createEmptyRenderPlan(): RenderPlan {
     isGlobeMode3D: false,
     backgroundMapOn: false,
     upVector: Vector3d.unitZ(),
+    whiteOnWhiteReversal: WhiteOnWhiteReversalSettings.fromJSON(),
   };
 }
 
@@ -138,5 +140,6 @@ export function createRenderPlanFromViewport(vp: Viewport): RenderPlan {
     backgroundMapOn,
     upVector,
     lights,
+    whiteOnWhiteReversal: vp.displayStyle.settings.whiteOnWhiteReversal,
   };
 }

--- a/core/frontend/src/render/webgl/StyleUniforms.ts
+++ b/core/frontend/src/render/webgl/StyleUniforms.ts
@@ -6,7 +6,7 @@
  * @module WebGL
  */
 
-import { ColorDef } from "@bentley/imodeljs-common";
+import { ColorDef, WhiteOnWhiteReversalSettings } from "@bentley/imodeljs-common";
 import { RenderPlan } from "../RenderPlan";
 import { ColorInfo } from "./ColorInfo";
 import { FloatRgb, FloatRgba } from "./FloatRGBA";
@@ -22,18 +22,20 @@ export class StyleUniforms {
   private readonly _bgRgb = FloatRgb.fromColorDef(this._bgColor);
   private _monoColor = ColorDef.white;
   private readonly _monoRgb = FloatRgb.fromColorDef(this._monoColor);
-  private _isWhiteBackground = true;
+  private _wantWoWReversal = true;
+  private _wowReversalSettings = WhiteOnWhiteReversalSettings.fromJSON();
 
   public syncKey = 0;
 
   public update(plan: RenderPlan): void {
-    if (this._bgColor.equals(plan.bgColor) && this._monoColor.equals(plan.monoColor))
+    if (this._bgColor.equals(plan.bgColor) && this._monoColor.equals(plan.monoColor) && this._wowReversalSettings.equals(plan.whiteOnWhiteReversal))
       return;
 
     desync(this);
 
     this._monoColor = plan.monoColor;
     this._monoRgb.setColorDef(plan.monoColor);
+    this._wowReversalSettings = plan.whiteOnWhiteReversal;
 
     this.updateBackgroundColor(plan.bgColor);
   }
@@ -42,7 +44,7 @@ export class StyleUniforms {
     this._bgColor = bgColor;
     this._bgRgba.setColorDef(bgColor);
     this._bgRgb.setColorDef(bgColor);
-    this._isWhiteBackground = this._bgRgb.isWhite;
+    this._wantWoWReversal = this._wowReversalSettings.ignoreBackgroundColor || this._bgRgb.isWhite;
   }
 
   public changeBackgroundColor(bgColor: ColorDef): void {
@@ -91,8 +93,8 @@ export class StyleUniforms {
     this._bgRgba.clone(result);
   }
 
-  public get isWhiteBackground(): boolean {
-    return this._isWhiteBackground;
+  public get wantWoWReversal(): boolean {
+    return this._wantWoWReversal;
   }
 
   public get backgroundColorInfo(): ColorInfo {

--- a/core/frontend/src/render/webgl/glsl/Fragment.ts
+++ b/core/frontend/src/render/webgl/glsl/Fragment.ts
@@ -26,8 +26,8 @@ export function addWindowToTexCoords(frag: FragmentShaderBuilder) {
 export function addWhiteOnWhiteReversal(frag: FragmentShaderBuilder) {
   frag.addUniform("u_reverseWhiteOnWhite", VariableType.Boolean, (prog) => {
     prog.addGraphicUniform("u_reverseWhiteOnWhite", (uniform, params) => {
-      const isWhite = params.target.uniforms.style.isWhiteBackground;
-      const doReversal = (isWhite && params.geometry.wantWoWReversal(params.programParams)) ? 1 : 0;
+      const wantWoW = params.target.uniforms.style.wantWoWReversal;
+      const doReversal = (wantWoW && params.geometry.wantWoWReversal(params.programParams)) ? 1 : 0;
       uniform.setUniform1i(doReversal);
     });
   });

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,12 +8,23 @@ publish: false
 Removed TSLint support from `@bentley/build-tools`. If you're still using it, please switch to ESLint.
 Also removed legacy `.eslintrc.js` file from the same package. Instead, use `@bentley/eslint-plugin` and the `imodeljs-recommended` config included in it.
 
-## `Viewport.zoomToElements` improvements
+## Viewport.zoomToElements improvements
 
 [Viewport.zoomToElements]($frontend) accepts any number of element Ids and fits the viewport to the union of their [Placement]($common)s. A handful of shortcomings of the previous implementation have been addressed:
 
 * Previously, the element Ids were passed to [IModelConnection.Elements.getProps]($frontend), which returned **all** of the element's properties (potentially many megabytes of data), only to extract the [PlacementProps]($common) for each element and discard the rest. Now, it uses the new [IModelConnection.Elements.getPlacements]($frontend) function to query only the placements.
 * Previously, if a mix of 2d and 3d elements were specified, the viewport would attempt to union their 2d and 3d placements, typically causing it to fit incorrectly because 2d elements reside in a different coordinate space than 3d elements. Now, the viewport ignores 2d elements if it is viewing a 3d view, and vice-versa.
+
+## White-on-white reversal for non-white backgrounds
+
+White-on-white reversal causes pure white geometry to be displayed as black when drawn onto a pure white background, where it would otherwise be invisible. However, on light-colored (but not pure white) backgrounds, white geometry can be very difficult to discern. [DisplayStyleSettings.whiteOnWhiteReversal]($common) now provides an option to draw white geometry as black regardless of the background color. The following code demonstrates how to enable this behavior for a [DisplayStyleState]($frontend):
+
+```ts
+  // Specify that white-on-white reversal should apply regardless of background color.
+  displayStyle.settings.whiteOnWhiteReversal = WhiteOnWhiteReversal.fromJSON({ ignoreBackgroundColor: true });
+  // Ensure white-on-white reversal is enabled.
+  displayStyle.viewFlags = displayStyle.viewFlags.with("whiteOnWhiteReversal", true);
+```
 
 ## Breaking changes
 

--- a/full-stack-tests/core/src/frontend/standalone/WhiteOnWhiteReversal.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/WhiteOnWhiteReversal.test.ts
@@ -77,8 +77,9 @@ describe("White-on-white reversal", async () => {
       return vf.with("whiteOnWhiteReversal", false);
     });
 
-    await test([white], (vp, vf) => {
+    await test([white, red], (vp, vf) => {
       ignoreBackground(vp);
+      vp.displayStyle.backgroundColor = ColorDef.red;
       return vf.with("whiteOnWhiteReversal", false);
     });
   });

--- a/full-stack-tests/core/src/frontend/standalone/WhiteOnWhiteReversal.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/WhiteOnWhiteReversal.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Point3d } from "@bentley/geometry-core";
-import { ColorDef, FeatureAppearance, RenderMode, ViewFlags } from "@bentley/imodeljs-common";
+import { ColorDef, FeatureAppearance, RenderMode, ViewFlags, WhiteOnWhiteReversalSettings } from "@bentley/imodeljs-common";
 import {
   DecorateContext, FeatureSymbology, GraphicType, IModelApp, IModelConnection, SnapshotConnection, Viewport,
 } from "@bentley/imodeljs-frontend";
@@ -52,6 +52,18 @@ describe("White-on-white reversal", async () => {
     });
   });
 
+  function ignoreBackground(vp: Viewport): void {
+    vp.displayStyle.settings.whiteOnWhiteReversal = WhiteOnWhiteReversalSettings.fromJSON({ ignoreBackgroundColor: true });
+  }
+
+  it("should apply to non-white background if background color is ignored", async () => {
+    await test([red, black], (vp) => {
+      vp.displayStyle.backgroundColor = ColorDef.red;
+      ignoreBackground(vp);
+      return undefined;
+    });
+  });
+
   it("should apply if background is white and geometry is white", async () => {
     await test([black, white], (vp, _vf) => {
       vp.displayStyle.backgroundColor = ColorDef.white;
@@ -64,18 +76,30 @@ describe("White-on-white reversal", async () => {
       vp.displayStyle.backgroundColor = ColorDef.white;
       return vf.with("whiteOnWhiteReversal", false);
     });
+
+    await test([white], (vp, vf) => {
+      ignoreBackground(vp);
+      return vf.with("whiteOnWhiteReversal", false);
+    });
   });
 
   it("should not apply if geometry is not white", async () => {
-    await test([white, blue], (vp, _vf) => {
-      class ColorOverride {
-        public addFeatureOverrides(ovrs: FeatureSymbology.Overrides, _viewport: Viewport): void {
-          ovrs.setDefaultOverrides(FeatureAppearance.fromRgb(ColorDef.blue));
-        }
+    class ColorOverride {
+      public addFeatureOverrides(ovrs: FeatureSymbology.Overrides, _viewport: Viewport): void {
+        ovrs.setDefaultOverrides(FeatureAppearance.fromRgb(ColorDef.blue));
       }
+    }
 
+    await test([white, blue], (vp, _vf) => {
       vp.displayStyle.backgroundColor = ColorDef.white;
       vp.addFeatureOverrideProvider(new ColorOverride());
+      return undefined;
+    });
+
+    await test([white, blue], (vp, _vf) => {
+      vp.displayStyle.backgroundColor = ColorDef.white;
+      vp.addFeatureOverrideProvider(new ColorOverride());
+      ignoreBackground(vp);
       return undefined;
     });
   });


### PR DESCRIPTION
As requested by SYNCHRO Field, who want white lines to be displayed as black on their light grey background.
Introduces DisplayStyleSettings.whiteOnWhiteReversal.
Currently it has a single boolean flag indicating whether to ignore the background color. In future we may add other options to it to handle more general cases like "light color on light background", "dark color on dark background", and/or "similar color to background color".