### PR TITLE
Presentation: Correctly handle merged values under nested content field

### DIFF
--- a/common/changes/@bentley/presentation-common/presentation-fix_nested_merged_content_2021-09-09-12-44.json
+++ b/common/changes/@bentley/presentation-common/presentation-fix_nested_merged_content_2021-09-09-12-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Fixed processing of merged content values under nested content field.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common"
+}

--- a/presentation/common/src/presentation-common/content/ContentTraverser.ts
+++ b/presentation/common/src/presentation-common/content/ContentTraverser.ts
@@ -230,30 +230,30 @@ function traverseContentItemField(visitor: IContentVisitor, fieldHierarchy: Fiel
       };
     }
 
-    traverseContentItemFieldValue(visitor, fieldHierarchy, fieldHierarchy.field.type, namePrefix, item.values[fieldHierarchy.field.name], item.displayValues[fieldHierarchy.field.name]);
+    traverseContentItemFieldValue(visitor, fieldHierarchy, item.mergedFieldNames, fieldHierarchy.field.type, namePrefix, item.values[fieldHierarchy.field.name], item.displayValues[fieldHierarchy.field.name]);
 
   } finally {
     visitor.finishField();
   }
 }
 
-function traverseContentItemFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, valueType: TypeDescription, namePrefix: string | undefined, rawValue: Value, displayValue: DisplayValue) {
+function traverseContentItemFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, mergedFieldNames: string[], valueType: TypeDescription, namePrefix: string | undefined, rawValue: Value, displayValue: DisplayValue) {
   if (rawValue !== undefined) {
     if (valueType.valueFormat === PropertyValueFormat.Array) {
       assert(Value.isArray(rawValue));
       assert(DisplayValue.isArray(displayValue));
-      return traverseContentItemArrayFieldValue(visitor, fieldHierarchy, valueType, namePrefix, rawValue, displayValue);
+      return traverseContentItemArrayFieldValue(visitor, fieldHierarchy, mergedFieldNames, valueType, namePrefix, rawValue, displayValue);
     }
     if (valueType.valueFormat === PropertyValueFormat.Struct) {
       assert(Value.isMap(rawValue));
       assert(DisplayValue.isMap(displayValue));
-      return traverseContentItemStructFieldValue(visitor, fieldHierarchy, valueType, namePrefix, rawValue, displayValue);
+      return traverseContentItemStructFieldValue(visitor, fieldHierarchy, mergedFieldNames, valueType, namePrefix, rawValue, displayValue);
     }
   }
-  traverseContentItemPrimitiveFieldValue(visitor, fieldHierarchy, valueType, namePrefix, rawValue, displayValue);
+  traverseContentItemPrimitiveFieldValue(visitor, fieldHierarchy, mergedFieldNames, valueType, namePrefix, rawValue, displayValue);
 }
 
-function traverseContentItemArrayFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, valueType: TypeDescription, namePrefix: string | undefined, rawValues: ValuesArray, displayValues: DisplayValuesArray) {
+function traverseContentItemArrayFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, mergedFieldNames: string[], valueType: TypeDescription, namePrefix: string | undefined, rawValues: ValuesArray, displayValues: DisplayValuesArray) {
   assert(rawValues.length === displayValues.length);
   assert(valueType.valueFormat === PropertyValueFormat.Array);
   if (!visitor.startArray({ hierarchy: fieldHierarchy, valueType, namePrefix, rawValues, displayValues }))
@@ -262,14 +262,14 @@ function traverseContentItemArrayFieldValue(visitor: IContentVisitor, fieldHiera
   try {
     const itemType = valueType.memberType;
     rawValues.forEach((_, i) => {
-      traverseContentItemFieldValue(visitor, fieldHierarchy, itemType, namePrefix, rawValues[i], displayValues[i]);
+      traverseContentItemFieldValue(visitor, fieldHierarchy, mergedFieldNames, itemType, namePrefix, rawValues[i], displayValues[i]);
     });
   } finally {
     visitor.finishArray();
   }
 }
 
-function traverseContentItemStructFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, valueType: TypeDescription, namePrefix: string | undefined, rawValues: ValuesMap, displayValues: DisplayValuesMap) {
+function traverseContentItemStructFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, mergedFieldNames: string[], valueType: TypeDescription, namePrefix: string | undefined, rawValues: ValuesMap, displayValues: DisplayValuesMap) {
   assert(valueType.valueFormat === PropertyValueFormat.Struct);
   if (!visitor.startStruct({ hierarchy: fieldHierarchy, valueType, namePrefix, rawValues, displayValues }))
     return;
@@ -288,14 +288,19 @@ function traverseContentItemStructFieldValue(visitor: IContentVisitor, fieldHier
           childFields: [],
         };
       }
-      traverseContentItemFieldValue(visitor, memberField, memberDescription.type, namePrefix, rawValues[memberDescription.name], displayValues[memberDescription.name]);
+      traverseContentItemFieldValue(visitor, memberField, mergedFieldNames, memberDescription.type, namePrefix, rawValues[memberDescription.name], displayValues[memberDescription.name]);
     });
   } finally {
     visitor.finishStruct();
   }
 }
 
-function traverseContentItemPrimitiveFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, valueType: TypeDescription, namePrefix: string | undefined, rawValue: Value, displayValue: DisplayValue) {
+function traverseContentItemPrimitiveFieldValue(visitor: IContentVisitor, fieldHierarchy: FieldHierarchy, mergedFieldNames: string[], valueType: TypeDescription, namePrefix: string | undefined, rawValue: Value, displayValue: DisplayValue) {
+  if (-1 !== mergedFieldNames.indexOf(fieldHierarchy.field.name)) {
+    visitor.processMergedValue({ mergedField: fieldHierarchy.field, requestedField: fieldHierarchy.field, namePrefix });
+    return;
+  }
+
   visitor.processPrimitiveValue({ field: fieldHierarchy.field, valueType, namePrefix, rawValue, displayValue });
 }
 
@@ -484,22 +489,28 @@ function convertNestedContentFieldHierarchyToStructArrayHierarchy(fieldHierarchy
 }
 
 function convertNestedContentValuesToStructArrayValuesRecursive(fieldHierarchy: FieldHierarchy, ncvs: ReadonlyArray<NestedContentValue>) {
-  const result: { raw: ValuesArray, display: DisplayValuesArray } = { raw: [], display: [] };
+  const result: { raw: ValuesArray, display: DisplayValuesArray, mergedFieldNames: string[] } = { raw: [], display: [], mergedFieldNames: [] };
   ncvs.forEach((ncv) => {
     const values: ValuesMap = { ...ncv.values };
     const displayValues: DisplayValuesMap = { ...ncv.displayValues };
+    const mergedFieldNames: string[] = [...ncv.mergedFieldNames];
     fieldHierarchy.childFields.forEach((childFieldHierarchy) => {
       const childFieldName = childFieldHierarchy.field.name;
+      if (-1 !== ncv.mergedFieldNames.indexOf(childFieldName)) {
+        return;
+      }
       if (childFieldHierarchy.field.isNestedContentField()) {
         const value = values[childFieldName];
         assert(Value.isNestedContent(value));
         const convertedValues = convertNestedContentValuesToStructArrayValuesRecursive(childFieldHierarchy, value);
         values[childFieldName] = convertedValues.raw;
         displayValues[childFieldName] = convertedValues.display;
+        mergedFieldNames.push(...convertedValues.mergedFieldNames);
       }
     });
     result.raw.push(values);
     result.display.push(displayValues);
+    result.mergedFieldNames.push(...mergedFieldNames);
   });
   return result;
 }
@@ -509,5 +520,5 @@ function convertNestedContentFieldHierarchyItemToStructArrayItem(item: Readonly<
   const rawValue = item.values[fieldName];
   assert(Value.isNestedContent(rawValue));
   const converted = convertNestedContentValuesToStructArrayValuesRecursive(fieldHierarchy, rawValue);
-  return new Item(item.primaryKeys, item.label, item.imageId, item.classInfo, { [fieldName]: converted.raw }, { [fieldName]: converted.display }, item.mergedFieldNames, item.extendedData);
+  return new Item(item.primaryKeys, item.label, item.imageId, item.classInfo, { [fieldName]: converted.raw }, { [fieldName]: converted.display }, converted.mergedFieldNames, item.extendedData);
 }


### PR DESCRIPTION
Fixed `traverseContentItem` to correctly handle merged values that are nested under nested content field.