### PR TITLE
Revert copy-webpack-plugin version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,7 +101,7 @@ rush.json       @calebmshafer @pmconne @wgoehrig
 /common/**/ui-*/                                  @imodeljs/ui
 /common/**/webgl-compatibility.*                  @imodeljs/display @Ellord207
 /common/**/webgl-compatibility/                   @imodeljs/display @Ellord207
-/common/**/webpack-tools-core/                    @calebmshafer @wgoehrig
+/common/**/webpack-tools-core/                    @calebmshafer @wgoehrig @aruniverse
 
 /common/config/azure-pipelines  @calebmshafer @wgoehrig @ColinKerr
 

--- a/common/changes/@bentley/webpack-tools-core/bug-copy-version_2021-09-09-19-33.json
+++ b/common/changes/@bentley/webpack-tools-core/bug-copy-version_2021-09-09-19-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webpack-tools-core",
+      "comment": "Revert copy-webpack-plugin min version",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webpack-tools-core"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4225,7 +4225,7 @@ importers:
       chai-as-promised: ^7
       chai-jest-snapshot: ^2.0.0
       chalk: ^3.0.0
-      copy-webpack-plugin: ^9.0.1
+      copy-webpack-plugin: ^6.2.1
       cpx: ^1.5.0
       eslint: ^7.11.0
       file-loader: ^4.2.0
@@ -4245,7 +4245,7 @@ importers:
       webpack-sources: ^1.4.3
     dependencies:
       chalk: 3.0.0
-      copy-webpack-plugin: 9.0.1_webpack@4.42.0
+      copy-webpack-plugin: 6.4.1_webpack@4.42.0
       file-loader: 4.3.0_webpack@4.42.0
       findup: 0.1.5
       fs-extra: 8.1.0
@@ -13384,6 +13384,26 @@ packages:
     resolution: {integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=}
     engines: {node: '>=0.10.0'}
 
+  /copy-webpack-plugin/6.4.1_webpack@4.42.0:
+    resolution: {integrity: sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.37.0 || ^5.0.0
+    dependencies:
+      cacache: 15.2.0
+      fast-glob: 3.2.7
+      find-cache-dir: 3.3.1
+      glob-parent: 5.1.2
+      globby: 11.0.4
+      loader-utils: 2.0.0
+      normalize-path: 3.0.0
+      p-limit: 3.1.0
+      schema-utils: 3.1.1
+      serialize-javascript: 5.0.1
+      webpack: 4.42.0
+      webpack-sources: 1.4.3
+    dev: false
+
   /copy-webpack-plugin/6.4.1_webpack@4.44.2:
     resolution: {integrity: sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==}
     engines: {node: '>= 10.13.0'}
@@ -13403,22 +13423,6 @@ packages:
       webpack: 4.44.2
       webpack-sources: 1.4.3
     dev: true
-
-  /copy-webpack-plugin/9.0.1_webpack@4.42.0:
-    resolution: {integrity: sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^5.1.0
-    dependencies:
-      fast-glob: 3.2.7
-      glob-parent: 6.0.1
-      globby: 11.0.4
-      normalize-path: 3.0.0
-      p-limit: 3.1.0
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      webpack: 4.42.0
-    dev: false
 
   /core-js-compat/3.16.2:
     resolution: {integrity: sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==}
@@ -15781,13 +15785,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.1
-
-  /glob-parent/6.0.1:
-    resolution: {integrity: sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      is-glob: 4.0.1
-    dev: false
 
   /glob/7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -22588,12 +22585,6 @@ packages:
     resolution: {integrity: sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==}
     dependencies:
       randombytes: 2.1.0
-
-  /serialize-javascript/6.0.0:
-    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
-    dependencies:
-      randombytes: 2.1.0
-    dev: false
 
   /serve-handler/6.1.3:
     resolution: {integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==}

--- a/tools/webpack-core/package.json
+++ b/tools/webpack-core/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "chalk": "^3.0.0",
-    "copy-webpack-plugin": "^9.0.1",
+    "copy-webpack-plugin": "^6.2.1",
     "file-loader": "^4.2.0",
     "findup": "0.1.5",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
7+ requires Webpack 5, which we don't yet use:

https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v7.0.0