### PR TITLE
Fix auth init called before its registered

### DIFF
--- a/common/changes/@bentley/mobile-manager/fix-auth-init-called-before-its-registered_2021-09-10-17-40.json
+++ b/common/changes/@bentley/mobile-manager/fix-auth-init-called-before-its-registered_2021-09-10-17-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/mobile-manager",
+      "comment": "fix timming issue with authInit() called during startup()",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/mobile-manager"
+}

--- a/core/mobile-manager/src/backend/AndroidHost.ts
+++ b/core/mobile-manager/src/backend/AndroidHost.ts
@@ -16,8 +16,6 @@ export class AndroidHost extends MobileHost {
    */
   public static override async startup(opt?: AndroidHostOpts): Promise<void> {
     const device = opt?.mobileHost?.device ?? new (MobileDevice as any)();
-    // The abstract functions of MobileDevice are implemented at runtime in native code.
-    (global as any).__iTwinJsNativeBridge = device; // for native side
     const socket = opt?.ipcHost?.socket ?? new IpcWebSocketBackend();
     return MobileHost.startup({ ...opt, mobileHost: { ...opt?.mobileHost, device }, ipcHost: { ...opt?.ipcHost, socket } });
   }

--- a/core/mobile-manager/src/backend/MobileHost.ts
+++ b/core/mobile-manager/src/backend/MobileHost.ts
@@ -149,8 +149,11 @@ export class MobileHost {
   /** Start the backend of a mobile app. */
   public static async startup(opt?: MobileHostOpts): Promise<void> {
     if (!this.isValid) {
-      setupMobileRpc();
       this._device = opt?.mobileHost?.device ?? new (MobileDevice as any)();
+      // set global device interface.
+      (global as any).__iTwinJsNativeBridge = this._device;
+      // following will provide impl for device specific api.
+      setupMobileRpc();
     }
 
     await NativeHost.startup(opt);

--- a/core/mobile-manager/src/backend/MobileRpcServer.ts
+++ b/core/mobile-manager/src/backend/MobileRpcServer.ts
@@ -12,6 +12,7 @@ import { ProcessDetector } from "@bentley/bentleyjs-core";
 
 interface MobileAddon {
   notifyListening: (port: number) => void;
+  registerDeviceImpl: () => void;
 }
 
 let addon: MobileAddon | undefined;
@@ -137,6 +138,7 @@ export function setupMobileRpc() {
 
   if (ProcessDetector.isMobileAppBackend) {
     addon = (process as any)._linkedBinding("iModelJsMobile");
+    addon?.registerDeviceImpl();
   }
 
   let server: MobileRpcServer | null = new MobileRpcServer();

--- a/core/mobile-manager/src/backend/iOSHost.ts
+++ b/core/mobile-manager/src/backend/iOSHost.ts
@@ -16,8 +16,6 @@ export class IOSHost extends MobileHost {
    */
   public static override async startup(opt?: IOSHostOpts): Promise<void> {
     const device = opt?.mobileHost?.device ?? new (MobileDevice as any)();
-    // The abstract functions of MobileDevice are implemented at runtime in native code.
-    (global as any).__iTwinJsNativeBridge = device; // for native side
     const socket = opt?.ipcHost?.socket ?? new IpcWebSocketBackend();
     return MobileHost.startup({ ...opt, mobileHost: { ...opt?.mobileHost, device }, ipcHost: { ...opt?.ipcHost, socket } });
   }


### PR DESCRIPTION
The issue happen when auth config is provided on backend and startup attempt to call authInit(). It does nothing as native device interface has not been registered yet.


imodel02: https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/192205