### PR TITLE
UI: Make TreeRenderer keep the same imperative handle between renders

### DIFF
--- a/common/changes/@bentley/ui-components/master_2021-09-13-11-07.json
+++ b/common/changes/@bentley/ui-components/master_2021-09-13-11-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components"
+}

--- a/ui/components/src/ui-components/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components/src/ui-components/tree/controlled/component/TreeRenderer.tsx
@@ -399,14 +399,18 @@ function useTreeRendererAttributes(
   variableSizeListRef: React.RefObject<VariableSizeList>,
   visibleNodes: VisibleTreeNodes,
 ) {
+  const visibleNodesRef = React.useRef(visibleNodes);
+  visibleNodesRef.current = visibleNodes;
   React.useImperativeHandle(
     ref,
     () => ({
       scrollToNode: (nodeId, alignment) => {
         assert(variableSizeListRef.current !== null);
-        variableSizeListRef.current.scrollToItem(visibleNodes.getIndexOfNode(nodeId), alignment);
+        variableSizeListRef.current.scrollToItem(visibleNodesRef.current.getIndexOfNode(nodeId), alignment);
       },
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
   );
 }
 


### PR DESCRIPTION
There is a regression that is only present in 2.19.x releases which causes `TreeRenderer` to repeat the last `scrollToNode` call on each component render. It is caused by `TreeRenderer` ref being re-set because we do not specify a dependency list in  `useImperativeHandle` call.

After refactoring and simplifying `ControlledTree` component for the 3.0 release, we can no longer observe the effect of a missing dependency list, so there are no tests or changelog entry for this change. Instead, this PR will be backported to 2.19.x branch where tests and a changelog entry will be added.
