### PR TITLE
Separate OnViewExtentsError from ViewChangeOptions

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -5874,6 +5874,11 @@ export abstract class MapTilingScheme {
 }
 
 // @public
+export interface MarginOptions {
+    marginPercent?: MarginPercent;
+}
+
+// @public
 export class MarginPercent {
     constructor(left: number, top: number, right: number, bottom: number);
     // (undocumented)
@@ -8643,7 +8648,7 @@ export class ScreenViewport extends Viewport {
     // @internal
     static setToParentSize(div: HTMLElement): void;
     // @internal (undocumented)
-    synchWithView(options?: ViewChangeOptions | boolean): void;
+    synchWithView(options?: ViewChangeOptions): void;
     readonly toolTipDiv: HTMLDivElement;
     // @internal (undocumented)
     protected validateRenderPlan(): void;
@@ -11206,10 +11211,9 @@ export interface ViewAnimationOptions {
 }
 
 // @public
-export interface ViewChangeOptions extends ViewAnimationOptions {
+export interface ViewChangeOptions extends OnViewExtentsError, ViewAnimationOptions {
     animateFrustumChange?: boolean;
     globalAlignment?: GlobalAlignmentOptions;
-    marginPercent?: MarginPercent;
     noSaveInUndo?: boolean;
 }
 
@@ -12379,7 +12383,7 @@ export abstract class Viewport implements IDisposable {
     get solarShadowSettings(): SolarShadowSettings | undefined;
     // @internal (undocumented)
     readonly subcategories: SubCategoriesCache.Queue;
-    synchWithView(_options?: ViewChangeOptions | boolean): void;
+    synchWithView(_options?: ViewChangeOptions): void;
     // @internal (undocumented)
     get target(): RenderTarget;
     get tiledGraphicsProviders(): Iterable<TiledGraphicsProvider>;
@@ -12693,8 +12697,8 @@ export abstract class ViewState extends ElementState {
     // @internal (undocumented)
     isSubCategoryVisible(id: Id64String): boolean;
     load(): Promise<void>;
-    lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: ViewChangeOptions & OnViewExtentsError): void;
-    lookAtVolume(volume: LowAndHighXYZ | LowAndHighXY, aspect?: number, options?: ViewChangeOptions): void;
+    lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: MarginOptions & OnViewExtentsError): void;
+    lookAtVolume(volume: LowAndHighXYZ | LowAndHighXY, aspect?: number, options?: MarginOptions & OnViewExtentsError): void;
     // @internal
     get maxGlobalScopeFactor(): number;
     // @beta
@@ -12730,7 +12734,7 @@ export abstract class ViewState extends ElementState {
     setRotationAboutPoint(rotation: Matrix3d, point?: Point3d): void;
     setStandardGlobalRotation(id: StandardViewId): void;
     setStandardRotation(id: StandardViewId): void;
-    setupFromFrustum(inFrustum: Frustum, opts?: ViewChangeOptions & OnViewExtentsError): ViewStatus;
+    setupFromFrustum(inFrustum: Frustum, opts?: OnViewExtentsError): ViewStatus;
     setViewClip(clip?: ClipVector): void;
     toJSON(): ViewDefinitionProps;
     toProps(): ViewStateProps;
@@ -12913,7 +12917,7 @@ export abstract class ViewState3d extends ViewState {
     // (undocumented)
     setRotation(rot: Matrix3d): void;
     // (undocumented)
-    setupFromFrustum(frustum: Frustum, opts?: ViewChangeOptions): ViewStatus;
+    setupFromFrustum(frustum: Frustum, opts?: OnViewExtentsError): ViewStatus;
     // (undocumented)
     supportsCamera(): boolean;
     // (undocumented)

--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -5085,7 +5085,7 @@ export interface LookAtArgs {
     readonly eyePoint: XYAndZ;
     readonly frontDistance?: number;
     readonly newExtents?: XAndY;
-    readonly opts?: ViewChangeOptions;
+    readonly opts?: OnViewExtentsError;
     readonly upVector: Vector3d;
 }
 
@@ -6841,6 +6841,11 @@ export class OnScreenTarget extends Target {
     // (undocumented)
     updateViewRect(): boolean;
     }
+
+// @public
+export interface OnViewExtentsError {
+    onExtentsError?: (status: ViewStatus) => ViewStatus;
+}
 
 // @beta
 export function openImageDataUrlInNewWindow(url: string, title?: string): void;
@@ -11206,7 +11211,6 @@ export interface ViewChangeOptions extends ViewAnimationOptions {
     globalAlignment?: GlobalAlignmentOptions;
     marginPercent?: MarginPercent;
     noSaveInUndo?: boolean;
-    onExtentsError?: (status: ViewStatus) => ViewStatus;
 }
 
 // @public
@@ -12429,7 +12433,7 @@ export abstract class Viewport implements IDisposable {
     worldToView4dArray(worldPts: Point3d[], viewPts: Point4d[]): void;
     worldToViewArray(pts: Point3d[]): void;
     get worldToViewMap(): Map4d;
-    zoom(newCenter: Point3d | undefined, factor: number, options?: ViewChangeOptions): ViewStatus;
+    zoom(newCenter: Point3d | undefined, factor: number, options?: ViewChangeOptions & OnViewExtentsError): ViewStatus;
     zoomToElementProps(elementProps: ElementProps[], options?: ViewChangeOptions & ZoomToOptions): void;
     zoomToElements(ids: Id64Arg, options?: ViewChangeOptions & ZoomToOptions): Promise<void>;
     zoomToPlacementProps(placementProps: PlacementProps[], options?: ViewChangeOptions & ZoomToOptions): void;
@@ -12586,7 +12590,7 @@ export abstract class ViewState extends ElementState {
     protected constructor(props: ViewDefinitionProps, iModel: IModelConnection, categoryOrClone: CategorySelectorState, displayStyle: DisplayStyleState);
     adjustAspectRatio(aspect: number): void;
     // @internal (undocumented)
-    adjustViewDelta(delta: Vector3d, origin: XYZ, rot: Matrix3d, aspect?: number, opts?: ViewChangeOptions): ViewStatus;
+    adjustViewDelta(delta: Vector3d, origin: XYZ, rot: Matrix3d, aspect?: number, opts?: OnViewExtentsError): ViewStatus;
     abstract allow3dManipulations(): boolean;
     get analysisStyle(): AnalysisStyle | undefined;
     // @internal (undocumented)
@@ -12689,7 +12693,7 @@ export abstract class ViewState extends ElementState {
     // @internal (undocumented)
     isSubCategoryVisible(id: Id64String): boolean;
     load(): Promise<void>;
-    lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: ViewChangeOptions): void;
+    lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: ViewChangeOptions & OnViewExtentsError): void;
     lookAtVolume(volume: LowAndHighXYZ | LowAndHighXY, aspect?: number, options?: ViewChangeOptions): void;
     // @internal
     get maxGlobalScopeFactor(): number;
@@ -12726,7 +12730,7 @@ export abstract class ViewState extends ElementState {
     setRotationAboutPoint(rotation: Matrix3d, point?: Point3d): void;
     setStandardGlobalRotation(id: StandardViewId): void;
     setStandardRotation(id: StandardViewId): void;
-    setupFromFrustum(inFrustum: Frustum, opts?: ViewChangeOptions): ViewStatus;
+    setupFromFrustum(inFrustum: Frustum, opts?: ViewChangeOptions & OnViewExtentsError): ViewStatus;
     setViewClip(clip?: ClipVector): void;
     toJSON(): ViewDefinitionProps;
     toProps(): ViewStateProps;

--- a/common/api/summary/imodeljs-frontend.exports.csv
+++ b/common/api/summary/imodeljs-frontend.exports.csv
@@ -388,6 +388,7 @@ public;OffScreenViewportOptions
 public;OnFlashedIdChangedEventArgs =
 alpha;OnFrameStatsReadyEvent = BeEvent
 internal;OnScreenTarget 
+public;OnViewExtentsError
 beta;openImageDataUrlInNewWindow(url: string, title?: string): void
 internal;OrbitGtTileTree 
 internal;OrbitGtTileTree

--- a/common/api/summary/imodeljs-frontend.exports.csv
+++ b/common/api/summary/imodeljs-frontend.exports.csv
@@ -346,6 +346,7 @@ internal;class MapTileProjection
 internal;MapTileTree 
 internal;MapTileTreeReference 
 internal;class MapTilingScheme
+public;MarginOptions
 public;MarginPercent
 public;Marker 
 public;MarkerFillStyle = string | CanvasGradient | CanvasPattern

--- a/common/changes/@bentley/imodeljs-common/OnViewExtentsError_2021-09-14-12-11.json
+++ b/common/changes/@bentley/imodeljs-common/OnViewExtentsError_2021-09-14-12-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common"
+}

--- a/common/changes/@bentley/imodeljs-frontend/OnViewExtentsError_2021-09-13-20-27.json
+++ b/common/changes/@bentley/imodeljs-frontend/OnViewExtentsError_2021-09-13-20-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "separate OnViewExtentsError from ViewChangeOptions ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/common/src/Frustum.ts
+++ b/core/common/src/Frustum.ts
@@ -99,7 +99,7 @@ export class Frustum {
   /** Set the points of this Frustum to be copies of the points in another Frustum. */
   public setFrom(other: Frustum) { this.setFromCorners(other.points); }
   /** Set the points of this frustum from array of corner points in NPC order. */
-  public setFromCorners(corners: Point3d[]) { for (let i = 0; i < 8; ++i) this.points[i].setFrom(corners[i]);  }
+  public setFromCorners(corners: Point3d[]) { for (let i = 0; i < 8; ++i) this.points[i].setFrom(corners[i]); }
   /** Scale this Frustum, in place, about its center by a scale factor. */
   public scaleAboutCenter(scale: number): void {
     const orig = this.clone();
@@ -113,10 +113,10 @@ export class Frustum {
     orig.points[Npc._100].interpolate(f, orig.points[Npc._011], this.points[Npc._011]);
     orig.points[Npc._000].interpolate(f, orig.points[Npc._111], this.points[Npc._111]);
   }
-  /** Get the front center point */
+  /** The point at the center of the front face of this frustum */
   public get frontCenter() { return this.getCorner(Npc.LeftBottomFront).interpolate(.5, this.getCorner(Npc.RightTopFront)); }
 
-  /** Get the front center point */
+  /** The point at the center of the rear face of this frustum */
   public get rearCenter() { return this.getCorner(Npc.LeftBottomRear).interpolate(.5, this.getCorner(Npc.RightTopRear)); }
 
   /** Scale this frustum's XY (viewing) plane about its center */

--- a/core/frontend/src/ViewAnimation.ts
+++ b/core/frontend/src/ViewAnimation.ts
@@ -52,6 +52,14 @@ export interface GlobalAlignmentOptions {
   transition?: boolean;
 }
 
+/** A method to be called if an error occurs while adjusting a ViewState's extents
+ * @public
+ */
+export interface OnViewExtentsError {
+  /** Function to be called when the extents are adjusted due to a limits error (view too larger or too small) */
+  onExtentsError?: (status: ViewStatus) => ViewStatus;
+}
+
 /** Options that control how operations that change a viewport behave.
  * @public
  */
@@ -62,8 +70,6 @@ export interface ViewChangeOptions extends ViewAnimationOptions {
   animateFrustumChange?: boolean;
   /** The percentage of the view to leave blank around the edges. */
   marginPercent?: MarginPercent;
-  /** Function to be called when the extents are adjusted due to a limits error (view too larger or too small) */
-  onExtentsError?: (status: ViewStatus) => ViewStatus;
   /** If defined the controls how the view will be aligned with the globe */
   globalAlignment?: GlobalAlignmentOptions;
 }

--- a/core/frontend/src/ViewAnimation.ts
+++ b/core/frontend/src/ViewAnimation.ts
@@ -60,16 +60,22 @@ export interface OnViewExtentsError {
   onExtentsError?: (status: ViewStatus) => ViewStatus;
 }
 
+/** Options that control the margin around the edges of a volume for lookAt and Fit view operations
+ * @public
+ */
+export interface MarginOptions {
+  /** The percentage of the view to leave blank around the edges. */
+  marginPercent?: MarginPercent;
+}
+
 /** Options that control how operations that change a viewport behave.
  * @public
  */
-export interface ViewChangeOptions extends ViewAnimationOptions {
+export interface ViewChangeOptions extends OnViewExtentsError, ViewAnimationOptions {
   /** Whether to save the result of this change into the view undo stack. Default is to save in undo. */
   noSaveInUndo?: boolean;
   /** Whether the change should be animated or not. Default is to not animate frustum change. */
   animateFrustumChange?: boolean;
-  /** The percentage of the view to leave blank around the edges. */
-  marginPercent?: MarginPercent;
   /** If defined the controls how the view will be aligned with the globe */
   globalAlignment?: GlobalAlignmentOptions;
 }

--- a/core/frontend/src/ViewGlobalLocation.ts
+++ b/core/frontend/src/ViewGlobalLocation.ts
@@ -161,7 +161,7 @@ export function viewGlobalLocation(viewport: ScreenViewport, doAnimate: boolean,
   const view3d = viewport.view;
 
   const transitionDistance = view3d.lookAtGlobalLocation(eyeHeight, pitchAngleRadians, location);
-  viewport.synchWithView(true);
+  viewport.synchWithView();
 
   if (doAnimate)
     viewport.animateToCurrent(before, { animationTime: metersToRange(transitionDistance) });

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -8,14 +8,14 @@
 
 import { assert, BeEvent, Id64, Id64Arg, Id64String, JsonUtils } from "@bentley/bentleyjs-core";
 import {
-  Angle, AxisOrder, ClipVector, Constant, Geometry, LongitudeLatitudeNumber, LowAndHighXY, LowAndHighXYZ, Map4d, Matrix3d, Plane3dByOriginAndUnitNormal, Point2d, Point3d,
-  PolyfaceBuilder, Range2d, Range3d, Ray3d, StrokeOptions, Transform, Vector2d, Vector3d, XAndY, XYAndZ, XYZ, YawPitchRollAngles,
+  Angle, AxisOrder, ClipVector, Constant, Geometry, LongitudeLatitudeNumber, LowAndHighXY, LowAndHighXYZ, Map4d, Matrix3d,
+  Plane3dByOriginAndUnitNormal, Point2d, Point3d, PolyfaceBuilder, Range2d, Range3d, Ray3d, StrokeOptions, Transform, Vector2d, Vector3d, XAndY,
+  XYAndZ, XYZ, YawPitchRollAngles,
 } from "@bentley/geometry-core";
 import {
-  AnalysisStyle, AxisAlignedBox3d, Camera, Cartographic, ColorDef,
-  FeatureAppearance, Frustum, GlobeMode, GraphicParams, GridOrientationType, ModelClipGroups, Npc, RenderMaterial, RenderSchedule,
-  SubCategoryOverride, TextureMapping, ViewDefinition2dProps, ViewDefinition3dProps, ViewDefinitionProps, ViewDetails,
-  ViewDetails3d, ViewFlags, ViewStateProps,
+  AnalysisStyle, AxisAlignedBox3d, Camera, Cartographic, ColorDef, FeatureAppearance, Frustum, GlobeMode, GraphicParams, GridOrientationType,
+  ModelClipGroups, Npc, RenderMaterial, RenderSchedule, SubCategoryOverride, TextureMapping, ViewDefinition2dProps, ViewDefinition3dProps,
+  ViewDefinitionProps, ViewDetails, ViewDetails3d, ViewFlags, ViewStateProps,
 } from "@bentley/imodeljs-common";
 import { AuxCoordSystem2dState, AuxCoordSystem3dState, AuxCoordSystemState } from "./AuxCoordSys";
 import { CategorySelectorState } from "./CategorySelectorState";
@@ -35,7 +35,7 @@ import { SheetViewState } from "./SheetViewState";
 import { SpatialViewState } from "./SpatialViewState";
 import { StandardView, StandardViewId } from "./StandardView";
 import { DisclosedTileTreeSet, TileTreeReference } from "./tile/internal";
-import { OnViewExtentsError, ViewChangeOptions } from "./ViewAnimation";
+import { MarginOptions, OnViewExtentsError } from "./ViewAnimation";
 import { DecorateContext, SceneContext } from "./ViewContext";
 import { areaToEyeHeight, areaToEyeHeightFromGcs, GlobalLocation } from "./ViewGlobalLocation";
 import { ViewingSpace } from "./ViewingSpace";
@@ -641,7 +641,7 @@ export abstract class ViewState extends ElementState {
    * @param opts for providing onExtentsError
    * @return Success if the frustum was successfully updated, or an appropriate error code.
    */
-  public setupFromFrustum(inFrustum: Frustum, opts?: ViewChangeOptions & OnViewExtentsError): ViewStatus {
+  public setupFromFrustum(inFrustum: Frustum, opts?: OnViewExtentsError): ViewStatus {
     const frustum = inFrustum.clone(); // make sure we don't modify input frustum
     frustum.fixPointOrder();
     const frustPts = frustum.points;
@@ -936,7 +936,7 @@ export abstract class ViewState extends ElementState {
    * @param options for providing MarginPercent and onExtentsError
    * @note for 2d views, only the X and Y values of volume are used.
    */
-  public lookAtVolume(volume: LowAndHighXYZ | LowAndHighXY, aspect?: number, options?: ViewChangeOptions) {
+  public lookAtVolume(volume: LowAndHighXYZ | LowAndHighXY, aspect?: number, options?: MarginOptions & OnViewExtentsError) {
     const rangeBox = Frustum.fromRange(volume).points;
     this.getRotation().multiplyVectorArrayInPlace(rangeBox);
     return this.lookAtViewAlignedVolume(Range3d.createArray(rangeBox), aspect, options);
@@ -949,7 +949,7 @@ export abstract class ViewState extends ElementState {
    * @param options for providing MarginPercent and onExtentsError
    * @see lookAtVolume
    */
-  public lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: ViewChangeOptions & OnViewExtentsError) {
+  public lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: MarginOptions & OnViewExtentsError) {
     if (volume.isNull) // make sure volume is valid
       return;
 
@@ -1533,7 +1533,7 @@ export abstract class ViewState3d extends ViewState {
     return backgroundMapGeometry ? backgroundMapGeometry.cartographicToDbFromGcs(cartographic, result) : undefined;
   }
 
-  public override setupFromFrustum(frustum: Frustum, opts?: ViewChangeOptions): ViewStatus {
+  public override setupFromFrustum(frustum: Frustum, opts?: OnViewExtentsError): ViewStatus {
     const stat = super.setupFromFrustum(frustum, opts);
     if (ViewStatus.Success !== stat)
       return stat;

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -35,7 +35,7 @@ import { SheetViewState } from "./SheetViewState";
 import { SpatialViewState } from "./SpatialViewState";
 import { StandardView, StandardViewId } from "./StandardView";
 import { DisclosedTileTreeSet, TileTreeReference } from "./tile/internal";
-import { ViewChangeOptions } from "./ViewAnimation";
+import { OnViewExtentsError, ViewChangeOptions } from "./ViewAnimation";
 import { DecorateContext, SceneContext } from "./ViewContext";
 import { areaToEyeHeight, areaToEyeHeightFromGcs, GlobalLocation } from "./ViewGlobalLocation";
 import { ViewingSpace } from "./ViewingSpace";
@@ -78,7 +78,7 @@ export interface LookAtArgs {
   /** The distance from the eyePoint to the back plane. If undefined, the existing back distance is used. */
   readonly backDistance?: number;
   /** Used for providing onExtentsError. */
-  readonly opts?: ViewChangeOptions;
+  readonly opts?: OnViewExtentsError;
 }
 
 /** Arguments to [[ViewState3d.lookAt]] to set up a perspective view
@@ -641,7 +641,7 @@ export abstract class ViewState extends ElementState {
    * @param opts for providing onExtentsError
    * @return Success if the frustum was successfully updated, or an appropriate error code.
    */
-  public setupFromFrustum(inFrustum: Frustum, opts?: ViewChangeOptions): ViewStatus {
+  public setupFromFrustum(inFrustum: Frustum, opts?: ViewChangeOptions & OnViewExtentsError): ViewStatus {
     const frustum = inFrustum.clone(); // make sure we don't modify input frustum
     frustum.fixPointOrder();
     const frustPts = frustum.points;
@@ -740,7 +740,7 @@ export abstract class ViewState extends ElementState {
   }
 
   /** @internal */
-  public adjustViewDelta(delta: Vector3d, origin: XYZ, rot: Matrix3d, aspect?: number, opts?: ViewChangeOptions): ViewStatus {
+  public adjustViewDelta(delta: Vector3d, origin: XYZ, rot: Matrix3d, aspect?: number, opts?: OnViewExtentsError): ViewStatus {
     const origDelta = delta.clone();
 
     let status = ViewStatus.Success;
@@ -949,7 +949,7 @@ export abstract class ViewState extends ElementState {
    * @param options for providing MarginPercent and onExtentsError
    * @see lookAtVolume
    */
-  public lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: ViewChangeOptions) {
+  public lookAtViewAlignedVolume(volume: Range3d, aspect?: number, options?: ViewChangeOptions & OnViewExtentsError) {
     if (volume.isNull) // make sure volume is valid
       return;
 

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -51,7 +51,7 @@ import { SubCategoriesCache } from "./SubCategoriesCache";
 import { DisclosedTileTreeSet, MapLayerImageryProvider, MapTiledGraphicsProvider, MapTileTreeReference, TileBoundingBoxes, TiledGraphicsProvider, TileTreeReference } from "./tile/internal";
 import { EventController } from "./tools/EventController";
 import { ToolSettings } from "./tools/ToolSettings";
-import { Animator, ViewAnimationOptions, ViewChangeOptions } from "./ViewAnimation";
+import { Animator, OnViewExtentsError, ViewAnimationOptions, ViewChangeOptions } from "./ViewAnimation";
 import { DecorateContext, SceneContext } from "./ViewContext";
 import { GlobalLocation } from "./ViewGlobalLocation";
 import { ViewingSpace } from "./ViewingSpace";
@@ -1649,7 +1649,7 @@ export abstract class Viewport implements IDisposable {
 
     let status;
     if (view.isCameraOn) {
-      status = view.lookAt({ eyePoint: view.getEyePoint(), targetPoint: view.getTargetPoint(), upVector: view.getYVector(),  lensAngle });
+      status = view.lookAt({ eyePoint: view.getEyePoint(), targetPoint: view.getTargetPoint(), upVector: view.getYVector(), lensAngle });
     } else {
       // We need to figure out a new camera target. To do that, we need to know where the geometry is in the view.
       // We use the depth of the center of the view for that.
@@ -1671,7 +1671,7 @@ export abstract class Viewport implements IDisposable {
       const targetPoint = corners[0].interpolate(0.5, corners[1]); // middle of halfway plane
       const backDistance = eyePoint.distance(targetPoint) * 2.0;
       const frontDistance = view.minimumFrontDistance();
-      status = view.lookAt({ eyePoint, targetPoint, upVector: view.getYVector(),  lensAngle, frontDistance, backDistance });
+      status = view.lookAt({ eyePoint, targetPoint, upVector: view.getYVector(), lensAngle, frontDistance, backDistance });
     }
 
     if (ViewStatus.Success === status)
@@ -1834,7 +1834,7 @@ export abstract class Viewport implements IDisposable {
    * @param factor the zoom factor.
    * @param options options for behavior of view change
    */
-  public zoom(newCenter: Point3d | undefined, factor: number, options?: ViewChangeOptions): ViewStatus {
+  public zoom(newCenter: Point3d | undefined, factor: number, options?: ViewChangeOptions & OnViewExtentsError): ViewStatus {
     const view = this.view;
     if (undefined === view)
       return ViewStatus.InvalidViewport;
@@ -1916,7 +1916,7 @@ export abstract class Viewport implements IDisposable {
     for (const placement of placements)
       viewRange.extendArray(placement.getWorldCorners(frust).points, viewTransform);
 
-    const ignoreError: ViewChangeOptions = {
+    const ignoreError: ViewChangeOptions & OnViewExtentsError = {
       ...options,
       onExtentsError: () => ViewStatus.Success,
     };

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -1024,7 +1024,7 @@ export abstract class Viewport implements IDisposable {
 
     removals.push(style.onOSMBuildingDisplayChanged.addListener(() => {
       displayStyleChanged();
-      this.synchWithView(false); // May change frustum depth.
+      this.synchWithView({ noSaveInUndo: true }); // May change frustum depth.
     }));
 
     const analysisChanged = () => {
@@ -1719,9 +1719,8 @@ export abstract class Viewport implements IDisposable {
 
   /** Call [[setupFromView]] on this Viewport and then apply optional behavior.
    * @param options _options for behavior of view change. If undefined, all options have their default values (see [[ViewChangeOptions]] for details.)
-   * @note In previous versions, the argument was a boolean `saveInUndo`. For backwards compatibility, if `_options` is a boolean, it is interpreted as "{ noSaveInUndo: !_options }"
    */
-  public synchWithView(_options?: ViewChangeOptions | boolean): void { this.setupFromView(); }
+  public synchWithView(_options?: ViewChangeOptions): void { this.setupFromView(); }
 
   /** Convert an array of points from CoordSystem.View to CoordSystem.Npc */
   public viewToNpcArray(pts: Point3d[]): void { this._viewingSpace.viewToNpcArray(pts); }
@@ -3039,9 +3038,8 @@ export class ScreenViewport extends Viewport {
   }
 
   /** @internal */
-  public override synchWithView(options?: ViewChangeOptions | boolean): void {
-    options = (undefined === options) ? {} :
-      (typeof options !== "boolean") ? options : { noSaveInUndo: !options }; // for backwards compatibility, was "saveInUndo"
+  public override synchWithView(options?: ViewChangeOptions): void {
+    options = options ?? {};
 
     if (this.view.is3d() && options?.globalAlignment)
       this.view.alignToGlobe(options.globalAlignment.target, options.globalAlignment.transition);
@@ -3070,8 +3068,7 @@ export class ScreenViewport extends Viewport {
 
     this.setAnimator(undefined); // make sure we clear any active animators before we change views.
 
-    if (opts === undefined)
-      opts = { animationTime: ScreenViewport.animation.time.slow.milliseconds };
+    opts = opts ?? { animationTime: ScreenViewport.animation.time.slow.milliseconds };
 
     // determined whether we can animate this ViewState change
     const doAnimate = this.view && this.view.hasSameCoordinates(view) && false !== opts.animateFrustumChange;

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -19,7 +19,7 @@ import { linePlaneIntersect } from "../LinePlaneIntersect";
 import { MessageBoxIconType, MessageBoxType } from "../NotificationManager";
 import { CanvasDecoration } from "../render/CanvasDecoration";
 import { IconSprites } from "../Sprites";
-import { ViewChangeOptions } from "../ViewAnimation";
+import { OnViewExtentsError, ViewChangeOptions } from "../ViewAnimation";
 import { DecorateContext, DynamicsContext } from "../ViewContext";
 import { ScreenViewport, Viewport } from "../Viewport";
 import { ViewStatus } from "../ViewStatus";
@@ -1813,7 +1813,7 @@ export class WheelEventProcessor {
     if (view.is3d() && view.iModel.ecefLocation)
       globalAlignment = { target, transition: zoomRatio > 1 };
 
-    const animationOptions: ViewChangeOptions = {
+    const animationOptions: ViewChangeOptions & OnViewExtentsError = {
       animateFrustumChange: true,
       cancelOnAbort: true,
       animationTime: ScreenViewport.animation.time.wheel.milliseconds,

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -24,7 +24,7 @@ import { LengthDescription } from "../properties/LengthDescription";
 import { GraphicType } from "../render/GraphicBuilder";
 import { Pixel } from "../render/Pixel";
 import { StandardViewId } from "../StandardView";
-import { Animator, ViewChangeOptions } from "../ViewAnimation";
+import { Animator, OnViewExtentsError, ViewChangeOptions } from "../ViewAnimation";
 import { DecorateContext } from "../ViewContext";
 import {
   eyeToCartographicOnGlobeFromGcs, GlobalLocation, queryTerrainElevationOffset, rangeToCartographicArea, viewGlobalLocation,
@@ -3627,7 +3627,7 @@ export class WindowAreaTool extends ViewTool {
     const view = vp.view;
     vp.viewToWorldArray(corners);
 
-    const opts: ViewChangeOptions = {
+    const opts: OnViewExtentsError = {
       onExtentsError: (stat) => view.outputStatusMessage(stat),
     };
 
@@ -4183,7 +4183,7 @@ export class SetupCameraTool extends PrimitiveTool {
     const eyePoint = this.getAdjustedEyePoint();
     const targetPoint = this.getAdjustedTargetPoint();
     const lensAngle = ToolSettings.walkCameraAngle;
-    if (ViewStatus.Success !== view.lookAt({ eyePoint, targetPoint, upVector: Vector3d.unitZ(),  lensAngle }))
+    if (ViewStatus.Success !== view.lookAt({ eyePoint, targetPoint, upVector: Vector3d.unitZ(), lensAngle }))
       return;
 
     vp.synchWithView({ animateFrustumChange: true });
@@ -4475,7 +4475,7 @@ export class SetupWalkCameraTool extends PrimitiveTool {
     const eyePoint = this.getAdjustedEyePoint();
     const targetPoint = this.getAdjustedTargetPoint();
     const lensAngle = ToolSettings.walkCameraAngle;
-    if (ViewStatus.Success !== view.lookAt({ eyePoint, targetPoint, upVector: Vector3d.unitZ(),  lensAngle }))
+    if (ViewStatus.Success !== view.lookAt({ eyePoint, targetPoint, upVector: Vector3d.unitZ(), lensAngle }))
       return;
 
     vp.synchWithView({ animateFrustumChange: true });

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -55,7 +55,14 @@ can become:
 
 ```ts
   viewState.lookAt( {eyePoint: eye, targetPoint: target , upVector: up, lensAngle: lens, frontDistance, backDistance} );
+
 ```
+
+### OnViewExtentsError and MarginOptions Separated from ViewChangeOptions
+
+The `opts` argument to [Viewstate3d.lookAt]($frontend) was previously declared to be of type [ViewChangeOptions]($frontend). However, it only used the `onExtentsError` member to handle invalid view extents. That caused confusion because it led you to believe that [Viewstate3d.lookAt]($frontend) performed a view change when it doesn't, it merely modifies the `ViewState3d`.
+
+There is now a separate interface [OnViewExtentsError]($frontend) that `Viewstate3d.lookAt` accepts it as its `opts` argument. Likewise, [ViewState3d.lookAtVolume]($frontend) and [ViewState3d.lookAtViewAlignedVolume]($frontend) accepts a "[MarginOptions]($frontend) & [OnViewExtentsError]($frontend)" as its `opts` argument.
 
 ## ViewFlags
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -62,7 +62,7 @@ can become:
 
 The `opts` argument to [Viewstate3d.lookAt]($frontend) was previously declared to be of type [ViewChangeOptions]($frontend). However, it only used the `onExtentsError` member to handle invalid view extents. That caused confusion because it led you to believe that [Viewstate3d.lookAt]($frontend) performed a view change when it doesn't, it merely modifies the `ViewState3d`.
 
-There is now a separate interface [OnViewExtentsError]($frontend) that `Viewstate3d.lookAt` accepts it as its `opts` argument. Likewise, [ViewState3d.lookAtVolume]($frontend) and [ViewState3d.lookAtViewAlignedVolume]($frontend) accepts a "[MarginOptions]($frontend) & [OnViewExtentsError]($frontend)" as its `opts` argument.
+There is now a separate interface [OnViewExtentsError]($frontend) that `Viewstate3d.lookAt` accepts it as its `opts` argument. Likewise, [ViewState3d.lookAtVolume]($frontend) and [ViewState3d.lookAtViewAlignedVolume]($frontend) accept "[MarginOptions]($frontend) & [OnViewExtentsError]($frontend)" as their `opts` argument.
 
 ## ViewFlags
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -60,9 +60,9 @@ can become:
 
 ### OnViewExtentsError and MarginOptions Separated from ViewChangeOptions
 
-The `opts` argument to [Viewstate3d.lookAt]($frontend) was previously declared to be of type [ViewChangeOptions]($frontend). However, it only used the `onExtentsError` member to handle invalid view extents. That caused confusion because it led you to believe that [Viewstate3d.lookAt]($frontend) performed a view change when it doesn't, it merely modifies the `ViewState3d`.
+The `opts` argument to [ViewState3d.lookAt]($frontend) was previously declared to be of type [ViewChangeOptions]($frontend). However, it only used the `onExtentsError` member to handle invalid view extents. That caused confusion because it led you to believe that [ViewState3d.lookAt]($frontend) performed a view change when it doesn't, it merely modifies the `ViewState3d`.
 
-There is now a separate interface [OnViewExtentsError]($frontend) that `Viewstate3d.lookAt` accepts it as its `opts` argument. Likewise, [ViewState3d.lookAtVolume]($frontend) and [ViewState3d.lookAtViewAlignedVolume]($frontend) accept "[MarginOptions]($frontend) & [OnViewExtentsError]($frontend)" as their `opts` argument.
+There is now a separate interface [OnViewExtentsError]($frontend) that `ViewState3d.lookAt` accepts it as its `opts` argument. Likewise, [ViewState3d.lookAtVolume]($frontend) and [ViewState3d.lookAtViewAlignedVolume]($frontend) accept "[MarginOptions]($frontend) & [OnViewExtentsError]($frontend)" as their `opts` argument.
 
 ## ViewFlags
 


### PR DESCRIPTION
the onExtentsError method can be used where "view change" isn't appropriate. Caused confusion in places that only wanted the error handler. Allow methods to accept `OnViewExtentsError` without the rest of `ViewChangeOptions`.
