### PR TITLE
Publish BeDragDropContext

### DIFF
--- a/common/api/summary/ui-components.exports.csv
+++ b/common/api/summary/ui-components.exports.csv
@@ -14,6 +14,8 @@ beta;AsyncErrorMessage
 beta;AsyncValueProcessingResult
 public;class BasePointTypeConverter 
 beta;BasicPropertyEditor 
+beta;BeDragDropContext(props:
+deprecated;BeDragDropContext(props:
 beta;BooleanEditor 
 beta;BooleanPropertyEditor 
 public;BooleanTypeConverter 

--- a/common/api/ui-components.api.md
+++ b/common/api/ui-components.api.md
@@ -164,6 +164,11 @@ export class BasicPropertyEditor extends PropertyEditorBase {
     get reactNode(): React.ReactNode;
 }
 
+// @beta @deprecated
+export function BeDragDropContext(props: {
+    children?: React.ReactNode;
+}): JSX.Element;
+
 // @beta
 export class BooleanEditor extends React.PureComponent<PropertyEditorProps, BooleanEditorState> implements TypeEditor {
     // @internal (undocumented)

--- a/common/changes/@bentley/ui-components/ui-drag-drop-context_2021-09-16-22-26.json
+++ b/common/changes/@bentley/ui-components/ui-drag-drop-context_2021-09-16-22-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "Export BeDragDropContext",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components"
+}

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -38,6 +38,7 @@ import {
   ThemeManager, ToolbarDragInteractionContext, UiFramework, UiSettingsProvider, UserSettingsStorage,
 } from "@bentley/ui-framework";
 import { SafeAreaInsets } from "@bentley/ui-ninezone";
+import { BeDragDropContext } from "@bentley/ui-components";
 import { getSupportedRpcs } from "../common/rpcs";
 import { loggerCategory, TestAppConfiguration } from "../common/TestAppConfiguration";
 import { ActiveSettingsManager } from "./api/ActiveSettingsManager";
@@ -616,18 +617,21 @@ class SampleAppViewer extends React.Component<any, { authorized: boolean, uiSett
     return (
       <Provider store={SampleAppIModelApp.store} >
         <ThemeManager>
-          <SafeAreaContext.Provider value={SafeAreaInsets.All}>
-            <AppDragInteraction>
-              <AppFrameworkVersion>
-                {/** UiSettingsProvider is optional. By default LocalUiSettings is used to store UI settings. */}
-                <UiSettingsProvider settingsStorage={this.state.uiSettingsStorage}>
-                  <ConfigurableUiContent
-                    appBackstage={<AppBackstageComposer />}
-                  />
-                </UiSettingsProvider>
-              </AppFrameworkVersion>
-            </AppDragInteraction>
-          </SafeAreaContext.Provider>
+          {/* eslint-disable-next-line deprecation/deprecation */}
+          <BeDragDropContext>
+            <SafeAreaContext.Provider value={SafeAreaInsets.All}>
+              <AppDragInteraction>
+                <AppFrameworkVersion>
+                  {/** UiSettingsProvider is optional. By default LocalUiSettings is used to store UI settings. */}
+                  <UiSettingsProvider settingsStorage={this.state.uiSettingsStorage}>
+                    <ConfigurableUiContent
+                      appBackstage={<AppBackstageComposer />}
+                    />
+                  </UiSettingsProvider>
+                </AppFrameworkVersion>
+              </AppDragInteraction>
+            </SafeAreaContext.Provider>
+          </BeDragDropContext>
         </ThemeManager>
       </Provider >
     );

--- a/ui/components/src/test/table/component/BeDragDropContext.test.tsx
+++ b/ui/components/src/test/table/component/BeDragDropContext.test.tsx
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { BeDragDropContext } from "../../../ui-components/table/component/dragdrop/BeDragDropContext";
+
+describe("BeDragDropContext", () => {
+
+  afterEach(cleanup);
+  it("should render", () => {
+    // eslint-disable-next-line deprecation/deprecation
+    render(<BeDragDropContext> Test </BeDragDropContext>);
+  });
+});

--- a/ui/components/src/ui-components.ts
+++ b/ui/components/src/ui-components.ts
@@ -137,6 +137,7 @@ export * from "./ui-components/table/columnfiltering/TableFilterDescriptorCollec
 export * from "./ui-components/table/component/Table";
 export * from "./ui-components/table/component/TableCell";
 export * from "./ui-components/table/component/TableColumn";
+export * from "./ui-components/table/component/dragdrop/BeDragDropContext";
 
 export * from "./ui-components/toolbar/Toolbar";
 export * from "./ui-components/toolbar/ToolbarWithOverflow";


### PR DESCRIPTION
BeDragDropContext is required at the top level if an app uses the Table component in ui-components. Republish it and use it in ui-test-app to fix the frontstages that have Table components.