### PR TITLE
Fix error output not being included in rush test/cover summaries.

### DIFF
--- a/common/changes/@bentley/build-tools/fix-rush-test_2021-09-17-15-23.json
+++ b/common/changes/@bentley/build-tools/fix-rush-test_2021-09-17-15-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/build-tools"
+}

--- a/tools/build/bin/betools.js
+++ b/tools/build/bin/betools.js
@@ -215,5 +215,11 @@ function pseudolocalizeCommand(options) {
 function exec(cmd) {
   console.log("Running command:");
   console.log(cmd.join(" "));
-  return child_process.execSync(cmd.join(" "), { encoding: "utf8", stdio: 'inherit' });
+  try {
+    return child_process.execSync(cmd.join(" "), { encoding: "utf8", stdio: 'inherit' });
+  } catch (error) {
+    if (error.status)
+      process.exit(error.status);
+    throw error;
+  }
 }

--- a/tools/build/scripts/rush/utils.js
+++ b/tools/build/scripts/rush/utils.js
@@ -4,21 +4,21 @@
 *--------------------------------------------------------------------------------------------*/
 function logBuildWarning(msg) {
   if (process.env.TF_BUILD)
-    console.log("##vso[task.logissue type=warning;]%s", msg);
+    console.error("##vso[task.logissue type=warning;]%s", msg);
   else
     console.error("WARNING: %s", msg);
 }
 
 function logBuildError(msg) {
   if (process.env.TF_BUILD)
-    console.log("##vso[task.logissue type=error;]%s", msg);
+    console.error("##vso[task.logissue type=error;]%s", msg);
   else
     console.error("ERROR: %s", msg);
 }
 
 function failBuild() {
   if (process.env.TF_BUILD) {
-    console.log("##vso[task.complete result=Failed;]DONE")
+    console.error("##vso[task.complete result=Failed;]DONE")
     process.exit(0);
   } else {
     process.exit(1);

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -15,10 +15,10 @@ const Spec = require("mocha/lib/reporters/spec");
 const MochaJUnitReporter = require("mocha-junit-reporter");
 
 function withStdErr(callback: () => void) {
-  const originalConsoleLog = console.log;
-  console.log = console.error;
+  const originalConsoleLog = Base.consoleLog;
+  Base.consoleLog = console.error;
   callback();
-  console.log = originalConsoleLog;
+  Base.consoleLog = originalConsoleLog;
 }
 
 declare const mocha: any;


### PR DESCRIPTION
This has been broken ever since we updated to use mocha 8 in #1190.  Turns out we just needed to react a change (https://github.com/mochajs/mocha/pull/3725) in the base reporter intended to prevent _tests_ from accidentally redirecting reporter output.

Also updated betools to stop logging useless "Error: Command failed: ..." errors (and call stacks) when a test process fails.