### PR TITLE
Presentation: render merged property values before using typename specific renderer

### DIFF
--- a/common/changes/@bentley/ui-components/presentation-fix_merged_values_rendering_2021-09-20-10-59.json
+++ b/common/changes/@bentley/ui-components/presentation-fix_merged_values_rendering_2021-09-20-10-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "'PropertyValueRendererManager': use merged MergedPropertyValueRenderer before looking for typename specific renderer if property is merged.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components"
+}

--- a/ui/components/src/test/properties/ValueRendererManager.test.tsx
+++ b/ui/components/src/test/properties/ValueRendererManager.test.tsx
@@ -140,5 +140,19 @@ describe("PropertyValueRendererManager", () => {
 
       expect(valueMount.text()).to.be.equal(UiComponents.translate("property.varies"));
     });
+
+    it("renders merged properties before looking for custom renderer in property typename", () => {
+      const property = TestUtils.createPrimitiveStringProperty("Label", "Test prop");
+      property.property.typename = "stub";
+      property.isMerged = true;
+
+      const rendererManager = new PropertyValueRendererManager();
+      rendererManager.registerRenderer("stub", fakeRenderer);
+
+      const value = rendererManager.render(property);
+      const valueMount = mount(<div>{value}</div>);
+      expect(valueMount.text()).to.be.equal(UiComponents.translate("property.varies"));
+      expect(fakeRenderer.render).to.not.be.called;
+    });
   });
 });

--- a/ui/components/src/test/properties/renderers/value/MergedPropertyValueRenderer.test.tsx
+++ b/ui/components/src/test/properties/renderers/value/MergedPropertyValueRenderer.test.tsx
@@ -14,6 +14,10 @@ describe("MergedPropertyValueRenderer", () => {
     await TestUtils.initializeUiComponents();
   });
 
+  after(() => {
+    TestUtils.terminateUiComponents();
+  });
+
   describe("render", () => {
     it("renders merged property as localized string '*** Varies ***'", async () => {
       const renderer = new MergedPropertyValueRenderer();

--- a/ui/components/src/ui-components/properties/ValueRendererManager.tsx
+++ b/ui/components/src/ui-components/properties/ValueRendererManager.tsx
@@ -97,11 +97,11 @@ export class PropertyValueRendererManager {
     if (record.property.renderer && this._propertyRenderers.has(record.property.renderer.name))
       return this._propertyRenderers.get(record.property.renderer.name);
 
-    if (this._propertyRenderers.has(record.property.typename))
-      return this._propertyRenderers.get(record.property.typename)!;
-
     if (this._defaultMergedValueRenderer.canRender(record))
       return this._defaultMergedValueRenderer;
+
+    if (this._propertyRenderers.has(record.property.typename))
+      return this._propertyRenderers.get(record.property.typename)!;
 
     // Use one of default renderers
     switch (record.value.valueFormat) {


### PR DESCRIPTION
Merged PropertyRecords might not have any value set and typename specific renderers renders an empty value. Check if MergedPropertyValueRenderer might be used before looking for typename specific renderer.