### PR TITLE
Remove ChangeSetApplyOption and ClientRequestContext.useContextForRpc

### DIFF
--- a/common/api/bentleyjs-core.api.md
+++ b/common/api/bentleyjs-core.api.md
@@ -173,13 +173,11 @@ export class ByteStream {
     rewind(numBytes: number): boolean;
     }
 
-// @public
+// @internal (undocumented)
 export enum ChangeSetApplyOption {
+    // (undocumented)
     Merge = 1,
-    None = 0,
-    // @deprecated
-    Reinstate = 3,
-    // @deprecated
+    // (undocumented)
     Reverse = 2
 }
 
@@ -233,10 +231,7 @@ export class ClientRequestContext {
     readonly sessionId: GuidString;
     // @internal (undocumented)
     toJSON(): ClientRequestContextProps;
-    // (undocumented)
-    get useContextForRpc(): boolean;
-    set useContextForRpc(value: boolean);
-    }
+}
 
 // @public
 export interface ClientRequestContextProps extends SessionProps {

--- a/common/api/summary/bentleyjs-core.exports.csv
+++ b/common/api/summary/bentleyjs-core.exports.csv
@@ -20,7 +20,7 @@ public;BeTimePoint
 public;BeUiEvent
 beta;BriefcaseStatus
 public;ByteStream
-public;ChangeSetApplyOption
+internal;ChangeSetApplyOption
 beta;ChangeSetStatus
 public;ClientRequestContext
 public;ClientRequestContextProps 

--- a/common/changes/@bentley/bentleyjs-core/changeset-apply_2021-09-21-11-07.json
+++ b/common/changes/@bentley/bentleyjs-core/changeset-apply_2021-09-21-11-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/bentleyjs-core",
+      "comment": "make ChangeSetApplyOption @internal - to be removed in future",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/bentleyjs-core"
+}

--- a/common/changes/@bentley/imodeljs-frontend/changeset-apply_2021-09-21-11-07.json
+++ b/common/changes/@bentley/imodeljs-frontend/changeset-apply_2021-09-21-11-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "remove unused ClientRequestContext.useContextForRpc",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/bentley/src/BeSQLite.ts
+++ b/core/bentley/src/BeSQLite.ts
@@ -182,21 +182,10 @@ export enum DbResult {
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
-/** Options that specify how to apply ChangeSets.
- * @public
+/**
+ * @internal
  */
 export enum ChangeSetApplyOption {
-  /** ChangeSet won't be used.  */
-  None = 0,
-  /** ChangeSet will be merged into the Db */
-  Merge,
-  /**
-   * ChangeSet will be reversed from the Db
-   * @deprecated
-   */
-  Reverse,
-  /** ChangeSet will be reinstated into the Db
-   * @deprecated
-   */
-  Reinstate,
+  Merge = 1,
+  Reverse = 2,
 }

--- a/core/bentley/src/ClientRequestContext.ts
+++ b/core/bentley/src/ClientRequestContext.ts
@@ -59,7 +59,6 @@ export class ClientRequestContext {
     this.applicationId = applicationId;
     this.applicationVersion = applicationVersion;
     this.sessionId = sessionId;
-    this._useContextForRpc = false;
   }
 
   /** Use this for logging for ClientRequestContext.
@@ -74,12 +73,6 @@ export class ClientRequestContext {
     };
   }
 
-  /** Setup use of this context for the next RPC call
-   * @internal
-   */
-  private _useContextForRpc: boolean;
-  public get useContextForRpc(): boolean { return this._useContextForRpc; }
-  public set useContextForRpc(value: boolean) { this._useContextForRpc = value; }
   /** @internal */
   public toJSON(): ClientRequestContextProps {
     return {

--- a/full-stack-tests/core/src/frontend/hub/IModelApp.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/IModelApp.test.ts
@@ -48,15 +48,6 @@ describe("IModelApp (#integration)", () => {
     assert.equal(actualAuthorizedRequestContext.sessionId, IModelApp.sessionId);
     assert.notEqual(actualAuthorizedRequestContext.activityId, activityId, "The activityId setup wasn't used by the RPC operation");
 
-    // authorizedRequestContext.useContextForRpc = true;
-    // actualAuthorizedRequestContext = await TestRpcInterface.getClient().reportAuthorizedRequestContext();
-    // assert.isFalse(authorizedRequestContext.useContextForRpc);
-    // actualAccessTokenStr = AccessToken.fromJson(actualAuthorizedRequestContext.accessToken).toTokenString();
-    // assert.equal(actualAccessTokenStr, expectedAccessTokenStr);
-    // assert.equal(actualAuthorizedRequestContext.applicationId, IModelApp.applicationId);
-    // assert.equal(actualAuthorizedRequestContext.sessionId, IModelApp.sessionId);
-    // assert.equal(actualAuthorizedRequestContext.activityId, activityId, "The activityId setup wasn't used by the RPC operation");
-
     actualAuthorizedRequestContext = await TestRpcInterface.getClient().reportAuthorizedRequestContext();
     actualAccessTokenStr = AccessToken.fromJson(actualAuthorizedRequestContext.accessToken).toTokenString();
     assert.equal(actualAccessTokenStr, expectedAccessTokenStr);


### PR DESCRIPTION
- `ChangeSetApplyOption` is now @internal. Will be removed with next addon build
- removed unused `ClientRequestContext.useContextForRpc`