### PR TITLE
Remove hardcoded testing contextId (iTwinId) 

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/RemoveHardcodedContextId_2021-09-21-13-27.json
+++ b/common/changes/@bentley/imodeljs-frontend/RemoveHardcodedContextId_2021-09-21-13-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Remove hardcoded contextId (aka iTwinId) used for testing",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -872,12 +872,7 @@ export class RealityModelTileClient {
     const tilesId = urlParts.find(Guid.isGuid);
     let props: RDSClientProps | undefined;
     if (undefined !== tilesId) {
-      let projectId = urlParts.find((val: string) => val.includes("--"))!.split("--")[1];
-
-      // ###TODO This is a temporary workaround for accessing the reality meshes with a test account
-      // The hardcoded project id corresponds to a project setup to yield access to the test account which is linked to the tileId
-      if (projectId === "Server")
-        projectId = "fb1696c8-c074-4c76-a539-a5546e048cc6";
+      const projectId = urlParts.find((val: string) => val.includes("--"))!.split("--")[1];
 
       props = { projectId, tilesId };
     }

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -162,6 +162,8 @@ You can use these environment variables to alter the default behavior of various
   * See TileAdmin.Props.minimumSpatialTolerance.
 * SVT_NO_EXTERNAL_TEXTURES
   * If defined, the backend will embed all texture image data directly in the tiles.
+* IMJS_ITWIN_ID.
+  * GuidString of the Context Id (aka project id) to use to query Reality Data - use by Spatial Classification (e.g. "fb1696c8-c074-4c76-a539-a5546e048cc6").
 
 ## Key-ins
 


### PR DESCRIPTION
Remove hardcoded testing contextId (iTwinId)  from RealityModelTileTree.ts and display-test-app