### PR TITLE
When building planes for a ClipShape, pre-filter the shape edges to remove danglers that violate triangulation requirements

### DIFF
--- a/common/api/geometry-core.api.md
+++ b/common/api/geometry-core.api.md
@@ -4466,10 +4466,11 @@ export class PolygonWireOffsetContext {
 export class PolylineOps {
     static compressByChordError(source: Point3d[], chordTolerance: number): Point3d[];
     static compressByPerpendicularDistance(source: Point3d[], maxDistance: number, numPass?: number): Point3d[];
+    static compressDanglers(source: Point3d[], closed?: boolean, tolerance?: number): Point3d[];
     static compressShortEdges(source: Point3d[], maxEdgeLength: number): Point3d[];
     static compressSmallTriangles(source: Point3d[], maxTriangleArea: number): Point3d[];
     static edgeLengthRange(points: Point3d[]): Range1d;
-}
+    }
 
 // @internal
 export class PowerPolynomial {

--- a/common/changes/@bentley/geometry-core/EDL-ClipPrimitiveInvisibleBitCleanup_2021-09-21-21-28.json
+++ b/common/changes/@bentley/geometry-core/EDL-ClipPrimitiveInvisibleBitCleanup_2021-09-21-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/geometry-core",
+      "comment": "When building planes for a ClipShape, pre-filter the shape edges to remove danglers that violate triangulation requirements",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/geometry-core"
+}

--- a/core/geometry/src/clipping/ClipPrimitive.ts
+++ b/core/geometry/src/clipping/ClipPrimitive.ts
@@ -23,6 +23,7 @@ import { ConvexClipPlaneSet } from "./ConvexClipPlaneSet";
 import { UnionOfConvexClipPlaneSets, UnionOfConvexClipPlaneSetsProps } from "./UnionOfConvexClipPlaneSets";
 import { AlternatingCCTreeNode } from "./AlternatingConvexClipTree";
 import { Point3dArray } from "../geometry3d/PointHelpers";
+import { PolylineOps } from "../geometry-core";
 
 /**
  * Bit mask type for referencing subsets of 6 planes of range box.
@@ -180,9 +181,6 @@ export class ClipPrimitive {
     let inside = true;
     if (this._clipPlanes)
       inside = this._clipPlanes.isPointOnOrInside(point, onTolerance);
-    // note -- the clip planes are structured to get the mask effects. no reversal necessary.
-    if (this._invisible)
-     inside = !inside;
     return inside;
   }
 
@@ -616,6 +614,7 @@ export class ClipShape extends ClipPrimitive {
   }
   /** Given a (possibly non-convex) polygon defined as an array of points, populate the given UnionOfConvexClipPlaneSets with multiple ConvexClipPlaneSets defining the bounded region. Returns true if successful. */
   private parsePolygonPlanes(set: UnionOfConvexClipPlaneSets, polygon: Point3d[], isMask: boolean, cameraFocalLength?: number): boolean {
+    const cleanPolygon = PolylineOps.compressDanglers(polygon, true);
     const announceFace = (_graph: HalfEdgeGraph, edge: HalfEdge): boolean => {
       if (!edge.isMaskSet(HalfEdgeMask.EXTERIOR)) {
         const convexFacetPoints = edge.collectAroundFace((node: HalfEdge): any => {
@@ -630,7 +629,7 @@ export class ClipShape extends ClipPrimitive {
       return true;
     };
     if (isMask) {
-      const polygonA = Point3dArray.clonePoint3dArray ( polygon);
+      const polygonA = Point3dArray.clonePoint3dArray ( cleanPolygon);
       const hullAndInlets = AlternatingCCTreeNode.createHullAndInletsForPolygon(polygonA);
       const allLoops = hullAndInlets.extractLoops();
       if (allLoops.length === 0)
@@ -647,7 +646,7 @@ export class ClipShape extends ClipPrimitive {
       }
       return true;
     } else {
-      const triangulatedPolygon = Triangulator.createTriangulatedGraphFromSingleLoop(polygon);
+      const triangulatedPolygon = Triangulator.createTriangulatedGraphFromSingleLoop(cleanPolygon);
       if (triangulatedPolygon === undefined)
         return false;
       Triangulator.flipTriangles(triangulatedPolygon);

--- a/core/geometry/src/clipping/ClipPrimitive.ts
+++ b/core/geometry/src/clipping/ClipPrimitive.ts
@@ -23,7 +23,7 @@ import { ConvexClipPlaneSet } from "./ConvexClipPlaneSet";
 import { UnionOfConvexClipPlaneSets, UnionOfConvexClipPlaneSetsProps } from "./UnionOfConvexClipPlaneSets";
 import { AlternatingCCTreeNode } from "./AlternatingConvexClipTree";
 import { Point3dArray } from "../geometry3d/PointHelpers";
-import { PolylineOps } from "../geometry-core";
+import { PolylineOps } from "../geometry3d/PolylineOps";
 
 /**
  * Bit mask type for referencing subsets of 6 planes of range box.

--- a/core/geometry/src/geometry3d/PolylineOps.ts
+++ b/core/geometry/src/geometry3d/PolylineOps.ts
@@ -6,6 +6,8 @@
  * @module CartesianGeometry
  */
 
+import { DESTRUCTION } from "dns";
+import { Geometry } from "../Geometry";
 import { GrowableXYZArray } from "./GrowableXYZArray";
 import { Point3d } from "./Point3dVector3d";
 import { PolylineCompressionContext } from "./PolylineCompressionByEdgeOffset";
@@ -80,6 +82,93 @@ export class PolylineOps {
       num0 = num1;
     }
     return dest.getPoint3dArray();
+  }
+  private static squaredDistanceToInterpolatedPoint(pointQ: Point3d, point0: Point3d, fraction: number, point1: Point3d): number {
+    const g = 1.0 - fraction;
+    const dx = pointQ.x - (g * point0.x + fraction * point1.x);
+    const dy = pointQ.y - (g * point0.y + fraction * point1.y);
+    const dz = pointQ.z - (g * point0.z + fraction * point1.z);
+    return dx * dx + dy * dy + dz * dz;
+  }
+  /**
+   * test if either
+   *   * points[indexA] matches pointQ
+   *   * line from points[indexA] to points[indexB] overlaps points[indexA] to pointQ
+   * @param points
+   * @param pointQ
+   * @param tolerance
+   */
+  private static isDanglerConfiguration(points: Point3d[], indexA: number, indexB: number,pointQ: Point3d, squaredDistanceTolerance: number): boolean {
+    if (indexA < 0 || indexA >= points.length)
+      return false;
+    const pointA = points[indexA];
+    // simple point match ...
+    const d2Q = pointA.distanceSquared(pointQ);
+    if (d2Q <= squaredDistanceTolerance)
+      return true;
+    if (indexB < 0 || indexB >= points.length)
+      return false;
+    const pointB = points[indexB];
+    // The expensive test .. does newPoint double back to an interior or extrapolation of the final dest segment?
+    //
+    // or pointQ
+    const dot = pointA.dotVectorsToTargets(pointB, pointQ);
+    // simple case -- pointB..pointA..pointQ continues forward
+    if (dot <= 0.0)
+      return false;
+    const d2B = pointA.distanceSquared(pointB);
+    let distanceSquared;
+    if (d2Q >= d2B) {
+    //                        pointB----------------------------------->>>>>>> pointA
+    //          pointQ<<<<---------------------------------------------------------
+      const fraction = dot / d2Q; // safe to divide because of earlier d2Q test.
+      distanceSquared = this.squaredDistanceToInterpolatedPoint(pointB, pointA, fraction, pointQ);
+    } else {
+      //           pointB----------------------------------->>>>>>> pointA
+      //                         pointQ<<<<----------------------
+      const fraction = dot / d2B;
+    distanceSquared = this.squaredDistanceToInterpolatedPoint(pointQ, pointA, fraction, pointB);
+    }
+    return distanceSquared < squaredDistanceTolerance;
+  }
+/**
+   * Return a simplified subset of given points, omitting points on "danglers" that depart and return on a single path.
+   * @param source input points
+   */
+   public static compressDanglers(source: Point3d[], closed: boolean = false, tolerance: number = Geometry.smallMetricDistance): Point3d[] {
+     let n = source.length;
+     const squaredDistanceTolerance = tolerance * tolerance;
+     if (closed)
+      while (n > 1 && source[n - 1].distanceSquared(source[0]) <= squaredDistanceTolerance)
+          n--;
+     const dest = [];
+     dest.push(source[0].clone());
+     for (let i = 1; i < n; i++){
+       const newPoint = source[i];
+       while (this.isDanglerConfiguration(dest, dest.length - 1, dest.length - 2, newPoint, squaredDistanceTolerance))
+         dest.pop();
+       dest.push(newPoint.clone());
+     }
+     if (closed) {
+       // No purge moving backwards.   Last point
+       let leftIndex = 0;
+       let rightIndex = dest.length - 1;
+       while (rightIndex > leftIndex + 2) {
+         if (this.isDanglerConfiguration(dest, leftIndex, leftIndex + 1, dest[rightIndex], squaredDistanceTolerance)) {
+           leftIndex++;
+         } else if (this.isDanglerConfiguration(dest, rightIndex, rightIndex - 1, dest[leftIndex], squaredDistanceTolerance)) {
+           rightIndex--;
+         } else {
+           break;
+         }
+       }
+       if (rightIndex + 1 < dest.length)
+         dest.length = rightIndex + 1;
+       if (leftIndex > 0) {
+         dest.splice(0, leftIndex);
+       }
+     }
+     return dest;
   }
 
 }

--- a/core/geometry/src/geometry3d/PolylineOps.ts
+++ b/core/geometry/src/geometry3d/PolylineOps.ts
@@ -6,7 +6,6 @@
  * @module CartesianGeometry
  */
 
-import { DESTRUCTION } from "dns";
 import { Geometry } from "../Geometry";
 import { GrowableXYZArray } from "./GrowableXYZArray";
 import { Point3d } from "./Point3dVector3d";

--- a/core/geometry/src/test/clipping/ClipPrimitives.test.ts
+++ b/core/geometry/src/test/clipping/ClipPrimitives.test.ts
@@ -437,8 +437,8 @@ describe("ClipPrimitive", () => {
   it("ClipShapePointTests", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
-    const minZ =  -5;
-    const maxZ =   5;
+    const minZ =  undefined;  // EDL Sept 2021 z clip combined with hole is not clear.
+    const maxZ =  undefined;
     // Test point location
     const clipShape0 = ClipShape.createEmpty(true);
     let x0 = 0;
@@ -449,15 +449,16 @@ describe("ClipPrimitive", () => {
     ck.testFalse(clipShape0.isXYPolygon, "ClipShape does not contain polygon when no points are present");
     ck.testTrue(ClipShape.createShape(circlePoints, minZ, maxZ, undefined, true, true, clipShape0) !== undefined);
     exerciseClipPrimitive(ck, allGeometry, clipShape0, rectanglePoints, true, x0, y0);
-    const midpoint = Point3dArray.centroid(circlePoints);
-    GeometryCoreTestIO.createAndCaptureXYMarker(allGeometry, 0, midpoint, 0.25, x0, y0);
-    ck.testFalse(clipShape0.pointInside(midpoint), "Midpoint of polygon is not inside due to mask.");
-    ck.testExactNumber(clipShape0.classifyPointContainment([midpoint], false), 3, "Midpoint is completely outside when ClipShape is a mask");
+    const centroid = Point3dArray.centroid(circlePoints);
+    GeometryCoreTestIO.createAndCaptureXYMarker(allGeometry, 0, centroid, 0.25, x0, y0);
+    ck.testFalse(clipShape0.pointInside(centroid), "Centroid of polygon is not inside due to mask.");
+    const containment = clipShape0.classifyPointContainment([centroid], true);
+    ck.testExactNumber(containment, 3, "centroid is completely outside when ClipShape is a mask");
     let clipShape1 = ClipShape.createShape(circlePoints, minZ, maxZ, undefined, false, false);
     exerciseClipPrimitive(ck, allGeometry, clipShape1!, rectanglePoints, false, x0 += 10, y0);
-    GeometryCoreTestIO.createAndCaptureXYMarker(allGeometry, 0, midpoint, 0.25, x0, y0);
+    GeometryCoreTestIO.createAndCaptureXYMarker(allGeometry, 0, centroid, 0.25, x0, y0);
 
-    ck.testTrue(clipShape1!.pointInside(midpoint, 0), "Midpoint of polygon is inside.");
+    ck.testTrue(clipShape1!.pointInside(centroid, 0), "Midpoint of polygon is inside.");
 
     // Test createFrom method
     clipShape1 = ClipShape.createFrom(clipShape0, clipShape1);
@@ -468,7 +469,6 @@ describe("ClipPrimitive", () => {
     ck.testTrue(jsonValue.shape !== undefined, "Shape prop created in toJSON");
     const shape = jsonValue.shape!;
     ck.testTrue(shape.points !== undefined && shape.points.length === clipShape1.polygon.length, "Points prop created in toJSON");
-    ck.testTrue(shape.invisible !== undefined && shape.invisible === true, "Invisible prop created in toJSON");
     ck.testUndefined(shape.trans, "Transform is undefined prop in toJSON having not given one to original ClipShape");
     ck.testTrue(shape.mask !== undefined && shape.mask === true, "Mask prop created in toJSON");
     if (minZ === undefined)
@@ -600,7 +600,7 @@ describe("ClipPrimitive", () => {
 
   it("ClipPrimitive base class", () => {
     const ck = new Checker();
-    for (const invert of [false, true]) {
+    for (const invert of [false]) {   // EDL sept 2021 invert bit on simple plane set has no effect.  Don't test with true.
       const clipper = ConvexClipPlaneSet.createXYBox(1, 1, 10, 8);
       const prim0 = ClipPrimitive.createCapture(clipper, invert);
       const prim1 = prim0.clone();
@@ -674,8 +674,14 @@ describe("ClipPrimitive", () => {
     ck.checkpoint();
     expect(ck.getNumErrors()).equals(0);
   });
-
-  it("ClipVectorWithHole", () => {
+// EDL Sept 2021
+// This tests a ClipPrimitive which is defined ONLY by caller-provided clip planes -- no ClipShape polygon involved.
+// This set on a sense reversal bit in the ClipPrimitive to make one of the clippers act like a hole.
+// But that reversal has been declared a porting mistake -- the native side doesn't support that.
+//   But the native side expects the "hole" to provide its own mask planes, in the manner of the ClipShape.
+//   But there have not been persistent clip plane sets that call for this.
+// Soo .. This test is being marked skip.
+  it.skip("ClipVectorWithHole", () => {
     const ck = new Checker();
     const convexClip = ConvexClipPlaneSet.createXYBox(-1, -2, 8, 10);
     const outerClip = ClipPrimitive.createCapture(convexClip.clone());

--- a/core/geometry/src/test/clipping/ClipVector.test.ts
+++ b/core/geometry/src/test/clipping/ClipVector.test.ts
@@ -361,7 +361,7 @@ describe("StringifiedClipVector", () => {
     expect(StringifiedClipVector.fromClipVector(cv)).to.equal(scv);
   });
 
-  it("OuterAndMask", () => {
+  it.only("OuterAndMask", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     const outer = [[-10, -10], [10, 0], [10, 10], [-10, 10], [-10, -10]];
@@ -370,9 +370,10 @@ describe("StringifiedClipVector", () => {
     // const innerCircle = Sample.createArcStrokes(2, Point3d.create(5, 4), 12.0, Angle.createDegrees(12), Angle.createDegrees(372));
     const innerCircle = Sample.createArcStrokes(2, Point3d.create(0, 0), 5.0, Angle.createDegrees(0), Angle.createDegrees(360));
     const innerU = [[2, 1], [4, 2], [4, 5], [5, 6], [5, 2], [8, 1], [9, 8], [3, 7], [2, 1]];
-    const twoInlets = [[2, 1], [4, 2], [4, 5], [5, 6], [5, 2], [8, 1],
-        [10,8], [5,8],[5,9],[9,9],
-        [9, 12], [7, 11], [3, 12], [2, 1]];
+    const twoInletsWithWhisker = [[2, 1], [4, 2], [4, 5], [5, 6], [5, 2], [8, 1],
+      [10, 8], [5, 8], [5, 9], [9, 9], [9, 12],
+      [10,13],[12,13],[10,13],[9,12],
+      [7, 11], [3, 12], [2, 1]];
     const innerDart = [
         [0, 0],
         [-6, -8],
@@ -402,8 +403,8 @@ describe("StringifiedClipVector", () => {
       const jsonD = [{ shape: { points: outer } }, { shape: { points: innerU, mask: isMask}}];
       const jsonDart = [{ shape: { points: outer } }, { shape: { points: innerDart, mask: isMask}}];
       const jsonDart1 = [{ shape: { points: outer } }, { shape: { points: innerDart1, mask: isMask}}];
-      const jsonTwoInlets = [{ shape: { points: outer } }, { shape: { points: twoInlets, mask: isMask}}];
-      const jsonTwoInletsReversed = [{ shape: { points: outer } }, { shape: { points: twoInlets.slice().reverse(), mask: isMask } }];
+      const jsonTwoInlets = [{ shape: { points: outer } }, { shape: { points: twoInletsWithWhisker, mask: isMask}}];
+      const jsonTwoInletsReversed = [{ shape: { points: outer } }, { shape: { points: twoInletsWithWhisker.slice().reverse(), mask: isMask } }];
       const jsonDart1Trans = [{ shape: { points: outer } }, { shape: { points: innerDart, mask: isMask, trans: shiftAndRotateJson } }];
       const jsonTriangleTrans =  [{ shape: { points: outer } }, { shape: { points: triangle, mask: isMask, trans: shiftAndRotateJson } }];
       // const polygonToClip = Sample.createArcStrokes(3, Point3d.create(5, 5), 6.0, Angle.createDegrees(0), Angle.createDegrees(360));

--- a/core/geometry/src/test/clipping/ClipVector.test.ts
+++ b/core/geometry/src/test/clipping/ClipVector.test.ts
@@ -361,7 +361,7 @@ describe("StringifiedClipVector", () => {
     expect(StringifiedClipVector.fromClipVector(cv)).to.equal(scv);
   });
 
-  it.only("OuterAndMask", () => {
+  it("OuterAndMask", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     const outer = [[-10, -10], [10, 0], [10, 10], [-10, 10], [-10, -10]];

--- a/core/geometry/src/test/geometry3d/PolylineCompression.test.ts
+++ b/core/geometry/src/test/geometry3d/PolylineCompression.test.ts
@@ -190,7 +190,7 @@ describe("GlobalCompression", () => {
     return result;
   }
 
-  it.only("Danglers", () => {
+  it("Danglers", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     const originalPoints: Point3d[] = [];

--- a/core/geometry/src/test/geometry3d/PolylineCompression.test.ts
+++ b/core/geometry/src/test/geometry3d/PolylineCompression.test.ts
@@ -6,7 +6,8 @@
 import { expect } from "chai";
 import { GeometryQuery } from "../../curve/GeometryQuery";
 import { LineString3d } from "../../curve/LineString3d";
-import { Point3d } from "../../geometry3d/Point3dVector3d";
+import { Point3dArray, PolygonOps } from "../../geometry-core";
+import { Point3d, Vector3d } from "../../geometry3d/Point3dVector3d";
 import { PolylineOps } from "../../geometry3d/PolylineOps";
 import { Range3d } from "../../geometry3d/Range";
 import { Sample } from "../../serialization/GeometrySamples";
@@ -168,5 +169,92 @@ describe("GlobalCompression", () => {
     context.verifyGlobalChordErrorCompression(0, pointsWithColinearThroughStart, 0.001);
     context.close("ColinearThroughStart");
   });
+  // append points at multiple fractional positions along a vector.
+  function appendPointsOnVector(points: Point3d[], vector: Vector3d, fractions: number[]) {
+    if (points.length > 0) {
+      const basePoint = points[points.length - 1];
+      for (const f of fractions) {
+        points.push(basePoint.plusScaled(vector, f));
+      }
+  }
+  }
+  // append points at multiple fractional positions along a vector.
+  function insertPointsOnVector(points: Point3d[], baseIndex: number, vector: Vector3d, fractions: number[]): Point3d[] {
+    const result: Point3d[] = [];
+    for (let i = 0; i < points.length; i++){
+      result.push(points[i].clone());
+      if (i === baseIndex) {
+        appendPointsOnVector(result, vector, fractions);
+      }
+    }
+    return result;
+  }
 
+  it.only("Danglers", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+    const originalPoints: Point3d[] = [];
+    originalPoints.push(Point3d.create(0, 0, 0));
+    originalPoints.push(Point3d.create(10, 6, 0));
+    originalPoints.push(Point3d.create(0, 12, 0));
+    originalPoints.push(Point3d.create(-10, 6, 0));
+    const n = originalPoints.length;
+    const vectorX4 = Vector3d.create(4, 0, 0);
+    const vectorY2 = Vector3d.create(0, 2, 0);
+    const vectorQ = Vector3d.create(2, 1, 0);
+    const area0 = PolygonOps.areaXY(originalPoints);
+    const originalLength = Point3dArray.sumEdgeLengths(originalPoints);
+    let x0 = 0;
+    let y0 = 0;
+    const dx = 30;
+    const dy = 20;
+
+    const compressAndTest = (pointsWithDanglers: Point3d[]) => {
+      const e0 = ck.getNumErrors();
+      const y00 = y0;
+      GeometryCoreTestIO.captureCloneGeometry(allGeometry, pointsWithDanglers, x0, y0 += dy);
+      GeometryCoreTestIO.createAndCaptureXYMarker(allGeometry, 0, pointsWithDanglers[0], 0.25, x0, y0);
+      const areaA = PolygonOps.areaXY(pointsWithDanglers); // danglers do not affect area!
+      const compressedPoints = PolylineOps.compressDanglers(pointsWithDanglers, true);
+      GeometryCoreTestIO.captureCloneGeometry(allGeometry, compressedPoints, x0, y0 += dy);
+      ck.testCoordinate(area0, Math.abs (areaA), "area after removing danglers");
+      ck.testExactNumber(originalPoints.length, compressedPoints.length, "point count after compression");
+      const compressedLength = Point3dArray.sumEdgeLengths(compressedPoints);
+      ck.testCoordinate(originalLength, compressedLength);
+      y0 += dy;
+      if (e0 < ck.getNumErrors()) {
+        const range = Range3d.createArray(pointsWithDanglers);
+        GeometryCoreTestIO.captureRangeEdges(allGeometry, range, x0, y00);
+      }
+    };
+    const originalCount = originalPoints.length;
+    for (const baseIndex of [0, 1, n - 2, n - 1]) {
+      x0 += dx;
+      y0 = 0;
+      GeometryCoreTestIO.captureCloneGeometry(allGeometry, originalPoints, x0, y0);
+      const pointsA = insertPointsOnVector(originalPoints, baseIndex, vectorX4, [1, 0]);
+      compressAndTest(pointsA);
+      // we know the dangler tip is at baseIndex + 1 !!!
+      const pointsB = insertPointsOnVector(pointsA, baseIndex + 1, vectorY2, [1, 1.5, 1, 0]);
+      compressAndTest(pointsB);
+      const pointsC = insertPointsOnVector(pointsB, baseIndex + 1, vectorY2, [-1, -1.5, -1, 0]);
+      compressAndTest(pointsC);
+      // Another dangler -- this time with an "on edge" return ---
+      for (const shift of [2,3, 5]){
+        const pointsD = insertPointsOnVector(pointsC, (baseIndex + originalCount - shift) % originalCount, vectorQ, [0,1,0.5,-0.25, -1.0, 0]);
+        compressAndTest(pointsD);
+      }
+      const nC = pointsC.length;
+      for (const setback of [1, 2, 3, 4, 5, 6, 8, 12, nC - 1, nC - 2, nC - 3]) {
+        const i0 = n - setback;
+        if (i0 > 0) {
+          const rotatedPoints = [...pointsC.slice(i0, nC), ...pointsC.slice(0, i0)];
+          compressAndTest(rotatedPoints);
+          compressAndTest(rotatedPoints.slice().reverse());
+        }
+      }
+   }
+    GeometryCoreTestIO.saveGeometry(allGeometry, "PolylineCompression", "Danglers");
+    expect(ck.getNumErrors()).equals(0);
+  });
 });

--- a/core/geometry/src/test/topology/Triangulator.test.ts
+++ b/core/geometry/src/test/topology/Triangulator.test.ts
@@ -9,7 +9,7 @@ import { LineString3d } from "../../curve/LineString3d";
 import { Loop } from "../../curve/Loop";
 import { StrokeOptions } from "../../curve/StrokeOptions";
 import { Geometry } from "../../Geometry";
-import { Point3dArray, PolyfaceQuery, PolylineOps, RegionOps } from "../../geometry-core";
+import { Point3dArray, PolyfaceQuery, PolylineOps} from "../../geometry-core";
 import { Angle } from "../../geometry3d/Angle";
 import { AngleSweep } from "../../geometry3d/AngleSweep";
 import { Matrix3d } from "../../geometry3d/Matrix3d";
@@ -835,10 +835,6 @@ describe("Triangulation", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "Triangulation", "DartInTriangle");
     expect(ck.getNumErrors()).equals(0);
   });
-  const ex0 = 0.3;
-  const ey0 = 0;
-  const ex1 = 0.3;
-  const ey1 = -0.2;
   function messyShapePointsJson(ex0: number = 0, ey0: number = 0, ex1: number = 0, ey1: number = 0): any {
     return [
       [0, 0],
@@ -987,14 +983,8 @@ const _messyShape = [
           GeometryCoreTestIO.captureGeometry(allGeometry, polyface2, x0 + range.xLength (), y0);
         }
     }
-    /*
-    const union1 = RegionOps.polygonXYAreaUnionLoopsToPolyface(points, [], false);
-    const union2 = RegionOps.polygonXYAreaUnionLoopsToPolyface(points, [], true);
-    GeometryCoreTestIO.captureGeometry(allGeometry,union1, x0, y0 + 2 * range.yLength ());
-    GeometryCoreTestIO.captureGeometry(allGeometry,union2, x0, y0 + 3 * range.yLength ());
-    */
   }
-  it.only("MessyPolygon", () => {
+  it("MessyPolygon", () => {
     // This simple dart-inside-triangle showed an error in a special case test in the earcut triangulator.
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];

--- a/core/geometry/src/test/topology/Triangulator.test.ts
+++ b/core/geometry/src/test/topology/Triangulator.test.ts
@@ -9,7 +9,7 @@ import { LineString3d } from "../../curve/LineString3d";
 import { Loop } from "../../curve/Loop";
 import { StrokeOptions } from "../../curve/StrokeOptions";
 import { Geometry } from "../../Geometry";
-import { PolyfaceQuery } from "../../geometry-core";
+import { Point3dArray, PolyfaceQuery, PolylineOps, RegionOps } from "../../geometry-core";
 import { Angle } from "../../geometry3d/Angle";
 import { AngleSweep } from "../../geometry3d/AngleSweep";
 import { Matrix3d } from "../../geometry3d/Matrix3d";
@@ -835,4 +835,179 @@ describe("Triangulation", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "Triangulation", "DartInTriangle");
     expect(ck.getNumErrors()).equals(0);
   });
+  const ex0 = 0.3;
+  const ey0 = 0;
+  const ex1 = 0.3;
+  const ey1 = -0.2;
+  function messyShapePointsJson(ex0: number = 0, ey0: number = 0, ex1: number = 0, ey1: number = 0): any {
+    return [
+      [0, 0],
+      [0.654709, 0.03484],
+      [1.302022, 0.138965],
+      [1.93463, 0.311201],
+      [2.545385, 0.549601],
+      [3.925434, 0.248946],
+      [4.226089, 1.628994],
+      [4.676643, 2.095353],
+      [5.076021, 2.606223],
+      [5.419851, 3.156015],
+      [5.704372, 3.738714],
+      [4.911329, 0.012742],
+      [9.180947, -0.896012],
+      [10.026788, 2.986512],
+      [5.77525, 3.912745],
+      [5.979092, 4.528871],
+      [6.117235, 5.162968],
+      [6.188159, 5.808051],
+      [15.071005, 3.872848],
+      [15.149952, 4.234942],
+      [17.675663, 3.684497],
+      [16.263188, -2.797961],
+      [16.064641, -2.754699],
+      [15.959866, -3.235548],
+      [13.473343, -2.693754],
+      [13.578118, -2.212905],
+      [12.585406, -1.996601],
+      [12.484111, -2.468461],
+      [9.996137, -1.926351],
+      [10.09889, -1.454772],
+      [9.782465, -1.385825],
+      [9.659434, -1.950464],
+      [8.666728, -1.734157],
+      [8.412537, -2.900748],
+      [8.348474, -2.936379],
+      [8.409278, -3.049394],
+      [6.537996, -3.910283],
+      [4.596704, -4.522471],
+      [3.073072, -4.777725],
+      [2.406422, -4.878351],
+      [1.159118, -4.928844],
+      [0.507533, -4.944266],
+      [0.044633, -4.952745],
+      [-4.559386, -3.941573],
+      [-5.084428, -3.72601],
+      [-6.937781, -2.781619],
+      [-8.410058, -1.803001],
+      [-8.88581, -1.41257],
+      [-10.198609, -0.20053],
+      [-11.487166, 1.280115],
+      [-11.379811, 1.362224],
+      [-11.423276, 1.421324],
+      [-11.169085, 2.587913],
+      [-12.161793, 2.804211],
+      [-12.05118, 3.371515],
+      [-12.355197, 3.437758],
+      [-12.459969, 2.956911],
+      [-14.946492, 3.498704],
+      [-14.841721, 3.979552],
+      [-15.834432, 4.195856],
+      [-15.939202, 3.715008],
+      [-18.425726, 4.256801],
+      [-18.32095, 4.737653],
+      [-19.313664, 4.953956],
+      [-19.418435, 4.473105],
+      [-21.904958, 5.014898],
+      [-21.800185, 5.495752],
+      [-22.792897, 5.712056],
+      [-22.89767, 5.231202],
+      [-25.384193, 5.772996],
+      [-25.279418, 6.253847],
+      [-27.642639, 6.768779],
+      [-26.961521, 9.894707],
+      [-25.373773, 9.548751],
+      [-25.513633, 8.906874],
+      [-24.714594, 8.726444],
+      [-25.180075, 6.589819],
+      [-22.71835, 6.053513],
+      [-22.252868, 8.190138],
+      [-22.031532, 8.148114],
+      [-21.06162, 8.765842],
+      [-21.700817, 5.83184],
+      [-19.239094, 5.295533],
+      [-18.393224, 9.178193],
+      [-19.906289, 9.507827],
+      [-17.59824, 10.990118],
+      [-5.777575, 8.414887],
+      [-5.768427, 8.411331],
+      [-5.971378, 7.795457],
+      [-6.108774, 7.161728],
+      [-6.179107, 6.517102],
+      [-10.44429, 7.446451],
+      [-11.290253, 3.563954],
+      [-7.02507, 2.634605],
+      [-6.194445, 6.442253],
+      [-6.195142, 5.901328],
+      [-6.148684, 5.362402],
+      [-6.055425, 4.829577],
+      [-5.916075, 4.30691],
+      [-5.731695, 3.798379],
+      [-6.032348, 2.418332],
+      [-4.709612, 2.129385],
+      [-4.245829, 1.644422],
+      [-3.732387, 1.212379],
+      [-3.175292, 0.838308],
+      [-2.581059, 0.526585],
+      [-3.387468, -3.174972],
+      [-2.539054, -3.414636],
+      [-1.677653, -3.602342],
+      [-0.806443, -3.737396],
+      // The zinger
+      [-0.801128 + ex0, -3.712995 + ey0],
+      [-5.820766e-11 + ex1, -0.035721 + ey1],
+      [-0.801128 + ex0, -3.712995 + ey0],
+      [-0.806443, -3.737396],
+
+      [0, 1.593037e-11]];
+  }
+const _messyShape = [
+      {
+        shape: {
+          points: messyShapePointsJson () ,
+          trans: [
+            [0.998765, 0.049683, -1.032365e-16, 532612.092389],
+            [-0.049683, 0.998765, -5.489607e-20, 212337.746743],
+            [1.031063e-16, 5.183973e-18, 1, 7.41464]],
+        },
+      },
+    ];
+
+  function tryTriangulation(allGeometry: GeometryQuery[], points: Point3d[], x0: number, y0: number) {
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, points, x0, y0);
+    const range = Range3d.createArray(points);
+    y0 += range.yLength();
+    Triangulator.clearAndEnableDebugGraphCapture(true);
+    const graph1 = Triangulator.createTriangulatedGraphFromSingleLoop(points);
+      if (graph1) {
+        const polyface1 = PolyfaceBuilder.graphToPolyface(graph1);
+        GeometryCoreTestIO.captureGeometry(allGeometry, polyface1, x0, y0);
+      } else {
+        const graph2 = Triangulator.claimDebugGraph();
+        if (graph2) {
+          const polyface2 = PolyfaceBuilder.graphToPolyface(graph2);
+          GeometryCoreTestIO.captureGeometry(allGeometry, polyface2, x0 + range.xLength (), y0);
+        }
+    }
+    /*
+    const union1 = RegionOps.polygonXYAreaUnionLoopsToPolyface(points, [], false);
+    const union2 = RegionOps.polygonXYAreaUnionLoopsToPolyface(points, [], true);
+    GeometryCoreTestIO.captureGeometry(allGeometry,union1, x0, y0 + 2 * range.yLength ());
+    GeometryCoreTestIO.captureGeometry(allGeometry,union2, x0, y0 + 3 * range.yLength ());
+    */
+  }
+  it.only("MessyPolygon", () => {
+    // This simple dart-inside-triangle showed an error in a special case test in the earcut triangulator.
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+    let x0 = 0;
+    const y0 = 0;
+    const points = Point3dArray.cloneDeepXYZPoint3dArrays(messyShapePointsJson());
+    const range = Range3d.createFromVariantData(points);
+    tryTriangulation(allGeometry, points, x0, y0);
+    const cleanerPoints = PolylineOps.compressDanglers(points, true);
+    x0 += 3.0 * range.xLength();
+    tryTriangulation(allGeometry, cleanerPoints, x0, y0);
+    GeometryCoreTestIO.saveGeometry(allGeometry, "Triangulation", "MessyPolygon");
+    expect(ck.getNumErrors()).equals(0);
+  });
+
 });


### PR DESCRIPTION
* New method PolylineOps.compressDanglers(points, true) : Point3d[] -- removes (trees of) points that stray into the area and return on the same path.
  * with dangler: 
![image](https://user-images.githubusercontent.com/69321059/134251288-e27083df-3ca6-4075-9bda-39a386dcba45.png)
  * dangler removed 
![image](https://user-images.githubusercontent.com/69321059/134251327-16a60246-4ae4-4689-9a6e-245246f9f1e6.png)

* When triangulating a ClipShape (leading to making UnionOfConvexClipPlaneSets), a user case failed because of dangling edges that break the triangulator.    Prevent this be calling PolylineOps.compressDanglers

* Eliminate incorrect use of _isInvisible property in ClipPrimitive's point classification.  (mask property in ClipShape does this correctly)