### PR TITLE
Replace some uses of `any`

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -3210,7 +3210,7 @@ export interface GeometryContainmentRequestProps {
     // (undocumented)
     candidates: Id64Array;
     // (undocumented)
-    clip: any;
+    clip: ClipVectorProps;
     // (undocumented)
     offSubCategories?: Id64Array;
     // (undocumented)
@@ -7509,7 +7509,7 @@ export interface SnapRequestProps {
     // (undocumented)
     testPoint: XYZProps;
     // (undocumented)
-    viewFlags?: any;
+    viewFlags?: ViewFlagProps;
     // (undocumented)
     worldToView: Matrix4dProps;
 }

--- a/common/changes/@bentley/imodeljs-common/remove-any_2021-09-22-13-59.json
+++ b/common/changes/@bentley/imodeljs-common/remove-any_2021-09-22-13-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "GeometryContainmentRequestProps.clip and SnapRequestProps.viewFlags use stricter type than `any`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common"
+}

--- a/common/changes/@bentley/rpcinterface-full-stack-tests/remove-any_2021-09-22-14-20.json
+++ b/common/changes/@bentley/rpcinterface-full-stack-tests/remove-any_2021-09-22-14-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/rpcinterface-full-stack-tests"
+}

--- a/core/common/src/GeometryContainment.ts
+++ b/core/common/src/GeometryContainment.ts
@@ -8,14 +8,14 @@
 
 import { BentleyStatus, Id64Array } from "@bentley/bentleyjs-core";
 import { ViewFlagProps } from "./ViewFlags";
-import { ClipPlaneContainment } from "@bentley/geometry-core";
+import { ClipPlaneContainment, ClipVectorProps } from "@bentley/geometry-core";
 
 /** Information required to request clip containment status for elements from the front end to the back end.
  * @public
  */
 export interface GeometryContainmentRequestProps {
   candidates: Id64Array;
-  clip: any; // json representing a ClipVector
+  clip: ClipVectorProps;
   allowOverlaps?: boolean;
   viewFlags?: ViewFlagProps;
   offSubCategories?: Id64Array;

--- a/core/common/src/Snapping.ts
+++ b/core/common/src/Snapping.ts
@@ -10,6 +10,7 @@ import { Id64Array, Id64String } from "@bentley/bentleyjs-core";
 import { Matrix4dProps, XYZProps } from "@bentley/geometry-core";
 import { GeometryStreamProps } from "./geometry/GeometryStream";
 import { GeometryClass } from "./GeometryParams";
+import { ViewFlagProps } from "./ViewFlags";
 
 /** Information required to request a *snap* to a pickable decoration from the front end to the back end.
  * @internal
@@ -28,7 +29,7 @@ export interface SnapRequestProps {
   testPoint: XYZProps;
   closePoint: XYZProps;
   worldToView: Matrix4dProps;
-  viewFlags?: any;
+  viewFlags?: ViewFlagProps;
   snapModes?: number[];
   snapAperture?: number;
   snapDivisor?: number;

--- a/full-stack-tests/rpc-interface/src/frontend/IModel.test.ts
+++ b/full-stack-tests/rpc-interface/src/frontend/IModel.test.ts
@@ -31,7 +31,7 @@ describe("IModel Views", () => {
   it("should successfully get geometry containment", async () => {
     const requestProps: GeometryContainmentRequestProps = {
       candidates: [],
-      clip: {},
+      clip: [],
     };
 
     const result = await iModel.getGeometryContainment(requestProps);


### PR DESCRIPTION
There are plenty more. In particular I wish we would use a union type like `number | string | Uint8Array | undefined` for pulling values out of a SqliteStatement, but it looks like too late for 3.0.