### PR TITLE
Support transparency overrides for point clouds

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/Point-cloud-symbology-overrides_2021-09-22-14-40.json
+++ b/common/changes/@bentley/imodeljs-frontend/Point-cloud-symbology-overrides_2021-09-22-14-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Support transparency overrides for point clouds",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/render/webgl/BatchUniforms.ts
+++ b/core/frontend/src/render/webgl/BatchUniforms.ts
@@ -135,6 +135,22 @@ export class BatchUniforms {
     }
   }
 
+  public bindUniformTransparencyOverride(uniform: UniformHandle): void {
+    if (sync(this, uniform))
+      return;
+
+    if (undefined !== this._overrides) {
+      const uo = this._overrides.getUniformOverrides();
+      if (uo[0] & OvrFlags.Alpha) {
+        uniform.setUniform1f(uo[7]/255.0);
+      } else {
+        uniform.setUniform1f(-1.0);
+      }
+    } else {
+      uniform.setUniform1f(-1.0);
+    }
+  }
+
   public bindUniformNonLocatable(uniform: UniformHandle, ignoreNonLocatable: boolean): void {
     if (sync(this, uniform))
       return;

--- a/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
+++ b/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
@@ -169,6 +169,26 @@ const checkVertexDiscard = `
   return (isOpaquePass && hasAlpha) || (isTranslucentPass && !hasAlpha);
 `;
 
+function addTransparencyDiscardFlags(vert: VertexShaderBuilder) {
+  // Even when transparency view flag is off, we need to allow features to override transparency, because it
+  // is used when applying transparency threshold. However, we need to ensure we don't DISCARD transparent stuff during
+  // opaque pass if transparency is off (see checkVertexDiscard). Especially important for transparency threshold and readPixels().
+  // Also, if we override raster text to be opaque we must still draw it in the translucent pass.
+  // 1: discard translucent during opaque.
+  // 2: discard opaque during translucent.
+  // 3: both
+  vert.addUniform("u_transparencyDiscardFlags", VariableType.Int, (prog) => {
+    prog.addGraphicUniform("u_transparencyDiscardFlags", (uniform, params) => {
+      // During readPixels() we force transparency off. Make sure to ignore a Branch that turns it back on.
+      let flags = params.target.currentViewFlags.transparency && !params.target.isReadPixelsInProgress ? 1 : 0;
+      if (!params.geometry.alwaysRenderTranslucent)
+        flags += 2;
+
+      uniform.setUniform1i(flags);
+    });
+  });
+}
+
 function addCommon(builder: ProgramBuilder, mode: FeatureMode, opts: FeatureSymbologyOptions, wantGlobalOvrFlags = true): boolean {
   if (FeatureMode.None === mode)
     return false;
@@ -255,24 +275,7 @@ function addCommon(builder: ProgramBuilder, mode: FeatureMode, opts: FeatureSymb
       addMaxAlpha(vert);
       addRenderPass(vert);
       addAlpha(vert);
-
-      // Even when transparency view flag is off, we need to allow features to override transparency, because it
-      // is used when applying transparency threshold. However, we need to ensure we don't DISCARD transparent stuff during
-      // opaque pass if transparency is off (see checkVertexDiscard). Especially important for transparency threshold and readPixels().
-      // Also, if we override raster text to be opaque we must still draw it in the translucent pass.
-      // 1: discard translucent during opaque.
-      // 2: discard opaque during translucent.
-      // 3: both
-      vert.addUniform("u_transparencyDiscardFlags", VariableType.Int, (prog) => {
-        prog.addGraphicUniform("u_transparencyDiscardFlags", (uniform, params) => {
-          // During readPixels() we force transparency off. Make sure to ignore a Branch that turns it back on.
-          let flags = params.target.currentViewFlags.transparency && !params.target.isReadPixelsInProgress ? 1 : 0;
-          if (!params.geometry.alwaysRenderTranslucent)
-            flags += 2;
-
-          uniform.setUniform1i(flags);
-        });
-      });
+      addTransparencyDiscardFlags(vert);
 
       vert.set(VertexShaderComponent.CheckForDiscard, checkVertexDiscard);
     }
@@ -752,7 +755,7 @@ export function addUniformHiliter(builder: ProgramBuilder): void {
  *  - Visibility - implcitly, because if the feature is invisible its geometry will never be drawn.
  *  - Flash
  *  - Hilite
- *  - Color - only for point clouds currently which set addFetureColor to true.
+ *  - Color and Transparency- only for point clouds currently which set addFeatureColor to true.
  * This shader could be simplified, but want to share code with the non-uniform versions...hence uniforms/globals with "v_" prefix typically used for varyings on no prefix...
  * @internal
  */
@@ -773,13 +776,19 @@ export function addUniformFeatureSymbology(builder: ProgramBuilder, addFeatureCo
     });
 
     builder.vert.addUniform("feature_alpha", VariableType.Float, (prog) => {
-      prog.addGraphicUniform("feature_alpha", (uniform, _params) => {
-        // For now just hard-code alpha so it doesn't get overridden. Need to do more than setting this to make it work.
-        uniform.setUniform1f(-1.0);
+      prog.addGraphicUniform("feature_alpha", (uniform, params) => {
+        params.target.uniforms.batch.bindUniformTransparencyOverride(uniform);
       });
     });
 
     builder.vert.set(VertexShaderComponent.ApplyFeatureColor, applyFeatureColor);
+    addAlpha(builder.vert);
+    addMaxAlpha(builder.vert);
+    addRenderPass(builder.vert);
+    addTransparencyDiscardFlags(builder.vert);
+    builder.vert.set(VertexShaderComponent.CheckForDiscard, checkVertexDiscard);
+  } else {
+    builder.vert.set(VertexShaderComponent.CheckForDiscard, "return feature_invisible;");
   }
 
   // Non-Locatable...  Discard if picking
@@ -788,7 +797,6 @@ export function addUniformFeatureSymbology(builder: ProgramBuilder, addFeatureCo
       params.target.uniforms.batch.bindUniformNonLocatable(uniform, params.target.drawNonLocatable);
     });
   });
-  builder.vert.set(VertexShaderComponent.CheckForDiscard, "return feature_invisible;");
 
   addApplyFlash(builder.frag);
 }


### PR DESCRIPTION
Point clouds supported overriding color but not symbology.  This extends the override support to include transparency.

![image](https://user-images.githubusercontent.com/20863871/134365208-bd0c8ecc-9396-4e1e-9565-8ce455c6d485.png)
