### PR TITLE
Impose default minimum spatial tolerance of 1mm (#2341)

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/min-pattern-tolerance_2021-09-23-17-00.json
+++ b/common/changes/@bentley/imodeljs-frontend/min-pattern-tolerance_2021-09-23-17-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Impose default minimum spatial tolerance of 1mm.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -238,7 +238,7 @@ export class TileAdmin {
       this.maximumLevelsToSkip = 1;
 
     const minSpatialTol = options.minimumSpatialTolerance;
-    this.minimumSpatialTolerance = minSpatialTol ? Math.max(minSpatialTol, 0) : 0;
+    this.minimumSpatialTolerance = minSpatialTol ? Math.max(minSpatialTol, 0) : 0.001;
 
     const clamp = (seconds: number, min: number, max: number): BeDuration => {
       seconds = Math.min(seconds, max);
@@ -1082,7 +1082,7 @@ export namespace TileAdmin { // eslint-disable-line no-redeclare
     /** If defined and greater than zero, specifies the minimum chord tolerance in meters of a tile. A tile with chord tolerance less than this minimum will not be refined.
      * Applies only to spatial models, which model real-world assets on real-world scales.
      * A reasonable value is on the order of millimeters.
-     * Default value: undefined
+     * Default value: 0.001 (1 millimeter).
      * @public
      */
     minimumSpatialTolerance?: number;

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -397,6 +397,17 @@ It is no longer necessary to supply a [Viewport]($frontend) when creating a [Gra
 
 The backend methods [IModelDb.saveFileProperty]($backend) and [IModelDb.deleteFileProperty]($backend) used to return a [DbResult]($bentleyjs-core). They now are `void`, and throw an exception if an error occurred. The error value can be retrieved in the `errorNumber` member of the exception object, if desired.
 
+## Default minimum level of detail for spatial views
+
+[TileAdmin.Props.minimumSpatialTolerance]($frontend) specifies the minimum level of detail to produce for views of spatial models. Previously, the default was `undefined`, indicating no minimum. The default has been changed to 1 millimeter. This means that when zooming in extremely closely, geometry that contains details on the order of 1mm or smaller will not refine further. This prevents the display system from requesting extraordinarily detailed graphics, improving performance.
+
+To change the minimum, supply a different value at startup. For example, the following code sets the minimum to 1 centimeter:
+```ts
+await IModelApp.startup({
+  tileAdmin: { minimumSpatialTolerance: 0.01 },
+});
+```
+
 ## Signature change to backend Geocoordinate methods
 
 The two methods [IModelDb.getIModelCoordinatesFromGeoCoordinates]($backend) and [IModelDb.getGeoCoordinatesFromIModelCoordinates]($backend) used to take a string argument that was a stringified [IModelCoordinatesRequestProps]($common) and [GeoCoordinatesRequestProps]($common) respectively. Those arguments were changed to accept the interfaces directly. You should remove `JSON.stringify` from your code if you get compile errors.

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -132,6 +132,12 @@ export class TestRunner {
   }
 
   public constructor(props: TestSetsProps) {
+    // NB: The default minimum spatial chord tolerance was changed from "no minimum" to 1mm. To preserve prior behavior,
+    // override it to zero.
+    // Subsequently pushed configs can override this if desired.
+    const defaultTileProps: TileAdmin.Props = { minimumSpatialTolerance: 0 };
+    props.tileProps = props.tileProps ? { ...defaultTileProps, ...props.tileProps } : defaultTileProps;
+
     this._config = new TestConfigStack(new TestConfig(props));
     this._testSets = props.testSet;
     this._minimizeOutput = true === props.minimize;


### PR DESCRIPTION
This got merged onto imodel02 but produces subtle image differences in ImageTests. Rather than having to regenerate all our baseline images, allow display-performance-test-app to opt out of the new minimum (it can opt in by specifying a different minimum in its test configs).

(cherry picked from commit 0af28edc8aad6508b0edfb0cb28ab9db36438fd2)