### PR TITLE
Ensure memory consumed by instanced geometry is accurately reported and freed

### DIFF
--- a/common/api/imodeljs-frontend.api.md
+++ b/common/api/imodeljs-frontend.api.md
@@ -8131,7 +8131,7 @@ export abstract class RenderSystem implements IDisposable {
     // @internal (undocumented)
     createRealityMeshGraphic(_terrainGeometry: RenderRealityMeshGeometry, _featureTable: PackedFeatureTable, _tileId: string | undefined, _baseColor: ColorDef | undefined, _baseTransparent: boolean, _textures?: TerrainTexture[]): RenderGraphic | undefined;
     // @internal
-    abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern, instancesOwnGeometry?: boolean): RenderGraphic | undefined;
+    abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic | undefined;
     createScreenSpaceEffectBuilder(_params: ScreenSpaceEffectBuilderParams): ScreenSpaceEffectBuilder | undefined;
     createSkyBox(_params: SkyBox.CreateParams): RenderGraphic | undefined;
     // @internal (undocumented)

--- a/common/changes/@bentley/imodeljs-frontend/track-instance-buffers-memory_2021-09-24-15-06.json
+++ b/common/changes/@bentley/imodeljs-frontend/track-instance-buffers-memory_2021-09-24-15-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Ensure memory consumed by instanced geometry is accurately reported.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/render/RenderMemory.ts
+++ b/core/frontend/src/render/RenderMemory.ts
@@ -99,7 +99,6 @@ export namespace RenderMemory {
   /** @internal */
   export class Statistics {
     private _totalBytes = 0;
-    private readonly _instanceSources = new Set<Consumer>();
     public readonly consumers: Consumers[];
     public readonly buffers = new Buffers();
 
@@ -133,7 +132,6 @@ export namespace RenderMemory {
     public clear(): void {
       this._totalBytes = 0;
       this.buffers.clear();
-      this._instanceSources.clear();
       for (const consumer of this.consumers)
         consumer.clear();
     }
@@ -161,13 +159,7 @@ export namespace RenderMemory {
     public addRealityMesh(numBytes: number) {
       this.addBuffer(BufferType.RealityMesh, numBytes);
     }
-    public addInstances(source: Consumer, numBytes: number) {
-      if (this._instanceSources.has(source))
-        return;
-
-      this._instanceSources.add(source);
-      this.addBuffer(BufferType.Instances, numBytes);
-    }
+    public addInstances(numBytes: number) { this.addBuffer(BufferType.Instances, numBytes); }
   }
 
   /** @internal */

--- a/core/frontend/src/render/RenderMemory.ts
+++ b/core/frontend/src/render/RenderMemory.ts
@@ -99,6 +99,7 @@ export namespace RenderMemory {
   /** @internal */
   export class Statistics {
     private _totalBytes = 0;
+    private readonly _instanceSources = new Set<Consumer>();
     public readonly consumers: Consumers[];
     public readonly buffers = new Buffers();
 
@@ -132,6 +133,7 @@ export namespace RenderMemory {
     public clear(): void {
       this._totalBytes = 0;
       this.buffers.clear();
+      this._instanceSources.clear();
       for (const consumer of this.consumers)
         consumer.clear();
     }
@@ -159,7 +161,13 @@ export namespace RenderMemory {
     public addRealityMesh(numBytes: number) {
       this.addBuffer(BufferType.RealityMesh, numBytes);
     }
-    public addInstances(numBytes: number) { this.addBuffer(BufferType.Instances, numBytes); }
+    public addInstances(source: Consumer, numBytes: number) {
+      if (this._instanceSources.has(source))
+        return;
+
+      this._instanceSources.add(source);
+      this.addBuffer(BufferType.Instances, numBytes);
+    }
   }
 
   /** @internal */

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -337,7 +337,7 @@ export abstract class RenderSystem implements IDisposable {
   /** Create a RenderGraphic from a RenderGeometry produced by this RenderSystem.
    * @internal
    */
-  public abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern, instancesOwnGeometry?: boolean): RenderGraphic | undefined;
+  public abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic | undefined;
 
   private createGraphicFromGeometry(
     createGeometry: (viewIndependentOrigin?: Point3d) => RenderGeometry | undefined,
@@ -350,7 +350,7 @@ export abstract class RenderSystem implements IDisposable {
       instances = instancesOrOrigin;
 
     const geom = createGeometry(viOrigin);
-    return geom ? this.createRenderGraphic(geom, instances, true) : undefined;
+    return geom ? this.createRenderGraphic(geom, instances) : undefined;
   }
 
   /** @internal */

--- a/core/frontend/src/render/webgl/AttributeBuffers.ts
+++ b/core/frontend/src/render/webgl/AttributeBuffers.ts
@@ -372,6 +372,7 @@ export class BufferHandle implements WebGLDisposable {
     if (!this.isDisposed) {
       System.instance.context.deleteBuffer(this._glBuffer!);
       this._glBuffer = undefined;
+      this._bytesUsed = 0;
     }
   }
 

--- a/core/frontend/src/render/webgl/InstancedGeometry.ts
+++ b/core/frontend/src/render/webgl/InstancedGeometry.ts
@@ -153,7 +153,7 @@ export class InstanceBuffers extends InstanceData {
     const symBytes = undefined !== this.symbology ? this.symbology.bytesUsed : 0;
 
     const bytesUsed = this.transforms.bytesUsed + symBytes + featureBytes;
-    stats.addInstances(this, bytesUsed);
+    stats.addInstances(bytesUsed);
   }
 
   public static computeRange(reprRange: Range3d, tfs: Float32Array, rtcCenter: Point3d, out?: Range3d): Range3d {
@@ -256,7 +256,7 @@ export class PatternBuffers extends InstanceData {
   }
 
   public collectStatistics(stats: RenderMemory.Statistics): void {
-    stats.addInstances(this, this.offsets.bytesUsed);
+    stats.addInstances(this.offsets.bytesUsed);
   }
 }
 
@@ -376,7 +376,8 @@ export class InstancedGeometry extends CachedGeometry {
 
   public collectStatistics(stats: RenderMemory.Statistics) {
     this._repr.collectStatistics(stats);
-    this._buffers.collectStatistics(stats);
+    if (this._ownsRepr)
+      this._buffers.collectStatistics(stats);
   }
 
   public get patternParams(): Float32Array { return this._buffers.patternParams; }

--- a/core/frontend/src/render/webgl/Mesh.ts
+++ b/core/frontend/src/render/webgl/Mesh.ts
@@ -156,7 +156,7 @@ export class MeshGraphic extends Graphic {
         buffers = instances;
       } else {
         const instancesRange = InstanceBuffers.computeRange(geometry.range, instances.transforms, instances.transformCenter);
-        buffers = InstanceBuffers.create(instances, true, instancesRange);
+        buffers = InstanceBuffers.create(instances, instancesRange);
         if (!buffers)
           return undefined;
       }
@@ -200,10 +200,7 @@ export class MeshGraphic extends Graphic {
   public collectStatistics(stats: RenderMemory.Statistics): void {
     this.meshData.collectStatistics(stats);
     this._primitives.forEach((prim) => prim.collectStatistics(stats));
-
-    // Only count the shared instance buffers once...
-    if (undefined !== this._instances)
-      this._instances.collectStatistics(stats);
+    this._instances?.collectStatistics(stats);
   }
 
   public addCommands(cmds: RenderCommands): void { this._primitives.forEach((prim) => prim.addCommands(cmds)); }

--- a/core/frontend/src/render/webgl/Mesh.ts
+++ b/core/frontend/src/render/webgl/Mesh.ts
@@ -139,8 +139,21 @@ export class MeshRenderGeometry {
     return data ? new this(data, params) : undefined;
   }
 
-  public dispose() { }
-  public collectStatistics() { }
+  public dispose() {
+    dispose(this.data);
+    dispose(this.surface);
+    dispose(this.segmentEdges);
+    dispose(this.silhouetteEdges);
+    dispose(this.polylineEdges);
+  }
+
+  public collectStatistics(stats: RenderMemory.Statistics) {
+    this.data.collectStatistics(stats);
+    this.surface?.collectStatistics(stats);
+    this.segmentEdges?.collectStatistics(stats);
+    this.silhouetteEdges?.collectStatistics(stats);
+    this.polylineEdges?.collectStatistics(stats);
+  }
 }
 
 /** @internal */

--- a/core/frontend/src/render/webgl/Mesh.ts
+++ b/core/frontend/src/render/webgl/Mesh.ts
@@ -203,10 +203,11 @@ export class MeshGraphic extends Graphic {
   public get isPickable() { return false; }
 
   public dispose() {
-    dispose(this.meshData);
     for (const primitive of this._primitives)
       dispose(primitive);
 
+    dispose(this.meshData);
+    dispose(this._instances);
     this._primitives.length = 0;
   }
 

--- a/core/frontend/src/render/webgl/Primitive.ts
+++ b/core/frontend/src/render/webgl/Primitive.ts
@@ -40,7 +40,7 @@ export class Primitive extends Graphic {
       } else {
         assert(isInstancedGraphicParams(instances));
         const range = InstanceBuffers.computeRange(geom.computeRange(), instances.transforms, instances.transformCenter);
-        const instanceBuffers = InstanceBuffers.create(instances, false, range);
+        const instanceBuffers = InstanceBuffers.create(instances, range);
         if (!instanceBuffers)
           return undefined;
 

--- a/core/frontend/src/render/webgl/Primitive.ts
+++ b/core/frontend/src/render/webgl/Primitive.ts
@@ -58,9 +58,9 @@ export class Primitive extends Graphic {
     if (instances) {
       assert(geom instanceof LUTGeometry, "Invalid geometry type for instancing");
       if (instances instanceof InstanceBuffers)
-        geom = InstancedGeometry.create(geom, true, instances);
+        geom = InstancedGeometry.create(geom, false, instances);
       else
-        geom = InstancedGeometry.createPattern(geom, true, instances);
+        geom = InstancedGeometry.createPattern(geom, false, instances);
     }
 
     return new this(geom);

--- a/core/frontend/src/render/webgl/System.ts
+++ b/core/frontend/src/render/webgl/System.ts
@@ -549,10 +549,7 @@ export class System extends RenderSystem implements RenderSystemDebugControl, Re
   }
 
   public override createAreaPattern(params: PatternGraphicParams): PatternBuffers | undefined {
-    // ###TODO? The "shared" flag on PatternBuffers is always true, because the buffers can be shared amongst any number of RenderGraphics
-    // Unless we can figure out how to track those references we'll have to rely on garbage collection to dispose of it, and
-    // we won't be able to accurately report GPU memory usage (we can either report none for patterns, or count each occurrence of each pattern).
-    return PatternBuffers.create(params, true);
+    return PatternBuffers.create(params);
   }
 
   public override createRenderGraphic(geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic | undefined {

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -348,6 +348,7 @@ export abstract class TextureHandle implements WebGLDisposable {
     if (!this.isDisposed) {
       System.instance.disposeTexture(this._glTexture!);
       this._glTexture = undefined;
+      this.bytesUsed = 0;
     }
   }
 

--- a/core/frontend/src/test/render/webgl/RenderMemory.test.ts
+++ b/core/frontend/src/test/render/webgl/RenderMemory.test.ts
@@ -8,7 +8,7 @@ import { ColorDef, ImageBuffer, ImageBufferFormat, MeshEdge, QParams3d, QPoint3d
 import { IModelApp } from "../../../IModelApp";
 import { IModelConnection } from "../../../IModelConnection";
 import { RenderMemory } from "../../../render/RenderMemory";
-import { RenderAreaPattern, RenderGeometry } from "../../../render/RenderSystem";
+import { RenderGeometry } from "../../../render/RenderSystem";
 import { RenderGraphic } from "../../../render/RenderGraphic";
 import { MeshArgs } from "../../../render/primitives/mesh/MeshPrimitives";
 import { MeshParams } from "../../../render/primitives/VertexTable";
@@ -51,7 +51,7 @@ function createMeshGeometry(opts?: { texture?: RenderTexture, includeEdges?: boo
   return geom!;
 }
 
-function createGraphic(geom: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic {
+function createGraphic(geom: RenderGeometry, instances?: InstancedGraphicParams): RenderGraphic {
   const graphic = IModelApp.renderSystem.createRenderGraphic(geom, instances);
   expect(graphic).not.to.be.undefined;
   return graphic!;
@@ -62,7 +62,7 @@ function createTexture(imodel: IModelConnection, persistent: boolean): RenderTex
   const id = persistent ? imodel.transientIds.next : undefined;
   const tex = IModelApp.renderSystem.createTextureFromImageBuffer(img, imodel, new RenderTexture.Params(id))!;
   expect(tex).not.to.be.undefined;
-  return tex!;
+  return tex;
 }
 
 function createInstanceParams(count: number): InstancedGraphicParams {

--- a/core/frontend/src/test/render/webgl/RenderMemory.test.ts
+++ b/core/frontend/src/test/render/webgl/RenderMemory.test.ts
@@ -94,7 +94,7 @@ function expectBytesUsed(expected: number, consumer: RenderMemory.Consumer | Ren
   expect(getBytesUsed(consumer)).to.equal(expected);
 }
 
-describe.only("RenderMemory", () => {
+describe("RenderMemory", () => {
   let imodel: IModelConnection;
 
   before(async () => {
@@ -190,9 +190,10 @@ describe.only("RenderMemory", () => {
     expectBytesUsed(0, texture);
   });
 
+  const numBytesPerInstance = 12 * 4 + 3 + 8; // 12 floats per transform, 3 bytes per feature Id, 8 bytes per symbology override.
+
   it("should collect memory used by instanced mesh", () => {
     const params = createInstanceParams(5);
-    const numBytesPerInstance = 12 * 4 + 3 + 8; // 12 floats per transform, 3 bytes per feature Id, 8 bytes per symbology override.
     const numInstanceBytes = params.count * numBytesPerInstance;
 
     const mesh = createMeshGeometry();
@@ -206,7 +207,6 @@ describe.only("RenderMemory", () => {
 
   it("should collect memory used by instanced mesh and its edges", () => {
     const params = createInstanceParams(5);
-    const numBytesPerInstance = 12 * 4 + 3 + 8; // 12 floats per transform, 3 bytes per feature Id, 8 bytes per symbology override.
     const numInstanceBytes = params.count * numBytesPerInstance;
 
     const mesh = createMeshGeometry({ includeEdges: true });
@@ -216,11 +216,5 @@ describe.only("RenderMemory", () => {
     graphic.dispose();
     expectBytesUsed(0, mesh);
     expectBytesUsed(0, graphic);
-  });
-
-  it("should collect memory used by instanced point string", () => {
-  });
-
-  it("should collect memory used by patterned geometry", () => {
   });
 });

--- a/core/frontend/src/test/render/webgl/RenderMemory.test.ts
+++ b/core/frontend/src/test/render/webgl/RenderMemory.test.ts
@@ -168,6 +168,13 @@ describe("RenderMemory", () => {
     expectBytesUsed(sizeOfTexturedMesh, createGraphic(mesh));
   });
 
+  it("reports zero memory after disposal", () => {
+    const mesh = createGraphic(createMeshGeometry());
+    expect(getBytesUsed(mesh)).greaterThan(0);
+    mesh.dispose();
+    expectBytesUsed(0, mesh);
+  });
+
   it("should collect memory used by instanced geometry", () => {
   });
 

--- a/core/frontend/src/test/render/webgl/RenderMemory.test.ts
+++ b/core/frontend/src/test/render/webgl/RenderMemory.test.ts
@@ -8,12 +8,13 @@ import { ColorDef, ImageBuffer, ImageBufferFormat, MeshEdge, QParams3d, QPoint3d
 import { IModelApp } from "../../../IModelApp";
 import { IModelConnection } from "../../../IModelConnection";
 import { RenderMemory } from "../../../render/RenderMemory";
-import { RenderGeometry } from "../../../render/RenderSystem";
+import { RenderAreaPattern, RenderGeometry } from "../../../render/RenderSystem";
 import { RenderGraphic } from "../../../render/RenderGraphic";
 import { MeshArgs } from "../../../render/primitives/mesh/MeshPrimitives";
 import { MeshParams } from "../../../render/primitives/VertexTable";
 import { Texture } from "../../../render/webgl/Texture";
 import { createBlankConnection } from "../../createBlankConnection";
+import { InstancedGraphicParams } from "../../../imodeljs-frontend";
 
 function expectMemory(consumer: RenderMemory.Consumers, total: number, max: number, count: number) {
   expect(consumer.totalBytes).to.equal(total);
@@ -50,8 +51,8 @@ function createMeshGeometry(opts?: { texture?: RenderTexture, includeEdges?: boo
   return geom!;
 }
 
-function createGraphic(geom: RenderGeometry): RenderGraphic {
-  const graphic = IModelApp.renderSystem.createRenderGraphic(geom);
+function createGraphic(geom: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic {
+  const graphic = IModelApp.renderSystem.createRenderGraphic(geom, instances);
   expect(graphic).not.to.be.undefined;
   return graphic!;
 }
@@ -83,7 +84,7 @@ function expectBytesUsed(expected: number, consumer: RenderMemory.Consumer | Ren
   expect(getBytesUsed(consumer)).to.equal(expected);
 }
 
-describe("RenderMemory", () => {
+describe.only("RenderMemory", () => {
   let imodel: IModelConnection;
 
   before(async () => {

--- a/core/frontend/src/test/render/webgl/RenderMemory.test.ts
+++ b/core/frontend/src/test/render/webgl/RenderMemory.test.ts
@@ -218,6 +218,9 @@ describe.only("RenderMemory", () => {
     expectBytesUsed(0, graphic);
   });
 
+  it("should collect memory used by instanced point string", () => {
+  });
+
   it("should collect memory used by patterned geometry", () => {
   });
 });

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -496,7 +496,7 @@ export class ImdlReader extends GltfReader {
     if (!pattern)
       return undefined;
 
-    const branch = new GraphicBranch();
+    const branch = new GraphicBranch(true);
     for (const geom of geometry) {
       const graphic = this._system.createRenderGraphic(geom, pattern);
       if (graphic)


### PR DESCRIPTION
The instancing data allocated on the GPU can be shared amongst multiple primitives (e.g., a mesh's surface and edges), or owned by a single primitive (e.g., a polyline or point string). Ensure that each set of instances is reported exactly once, and freed when its single owner is disposed of.