### PR TITLE
Presentation: Add assertions for correct classmap 3.0

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1906,6 +1906,9 @@ export interface ParentCategoryIdentifier {
 }
 
 // @public
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+// @public
 export type PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo | NodeUpdateInfo;
 
 // @public (undocumented)
@@ -2350,6 +2353,22 @@ export interface RelatedClassInfoJSON<TClassInfoJSON = ClassInfoJSON> {
 }
 
 // @public
+export type RelatedClassInfoWithOptionalRelationship = PartialBy<RelatedClassInfo, "relationshipInfo" | "isForwardRelationship" | "isPolymorphicRelationship">;
+
+// @public (undocumented)
+export namespace RelatedClassInfoWithOptionalRelationship {
+    export function fromCompressedJSON(json: RelatedClassInfoWithOptionalRelationshipJSON<string>, classesMap: {
+        [id: string]: CompressedClassInfoJSON;
+    }): RelatedClassInfoWithOptionalRelationship;
+    export function toCompressedJSON(classInfo: RelatedClassInfoWithOptionalRelationship, classesMap: {
+        [id: string]: CompressedClassInfoJSON;
+    }): RelatedClassInfoWithOptionalRelationshipJSON<string>;
+}
+
+// @public (undocumented)
+export type RelatedClassInfoWithOptionalRelationshipJSON<TClassInfoJSON = ClassInfoJSON> = PartialBy<RelatedClassInfoJSON<TClassInfoJSON>, "relationshipInfo" | "isForwardRelationship" | "isPolymorphicRelationship">;
+
+// @public
 export type RelatedInstanceNodesSpecification = DEPRECATED_RelatedInstanceNodesSpecification | RelatedInstanceNodesSpecificationNew;
 
 // @public (undocumented)
@@ -2641,7 +2660,7 @@ export interface SchemasSpecification {
 export interface SelectClassInfo {
     isSelectPolymorphic: boolean;
     navigationPropertyClasses?: RelatedClassInfo[];
-    pathFromInputToSelectClass?: RelationshipPath;
+    pathFromInputToSelectClass?: RelatedClassInfoWithOptionalRelationship[];
     relatedInstancePaths?: RelationshipPath[];
     relatedPropertyPaths?: RelationshipPath[];
     selectClassInfo: ClassInfo;
@@ -2652,7 +2671,6 @@ export namespace SelectClassInfo {
     export function fromCompressedJSON(json: SelectClassInfoJSON<string>, classesMap: {
         [id: string]: CompressedClassInfoJSON;
     }): SelectClassInfo;
-    export function fromJSON(json: SelectClassInfoJSON): SelectClassInfo;
     // @internal
     export function listFromCompressedJSON(json: SelectClassInfoJSON<Id64String>[], classesMap: {
         [id: string]: CompressedClassInfoJSON;
@@ -2669,7 +2687,7 @@ export interface SelectClassInfoJSON<TClassInfoJSON = ClassInfoJSON> {
     // (undocumented)
     navigationPropertyClasses?: RelatedClassInfoJSON<TClassInfoJSON>[];
     // (undocumented)
-    pathFromInputToSelectClass?: RelationshipPathJSON<TClassInfoJSON>;
+    pathFromInputToSelectClass?: RelatedClassInfoWithOptionalRelationshipJSON<TClassInfoJSON>[];
     // (undocumented)
     relatedInstancePaths?: RelationshipPathJSON<TClassInfoJSON>[];
     // (undocumented)

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -257,6 +257,7 @@ public;Paged
 public;PagedResponse
 public;PageOptions
 public;ParentCategoryIdentifier
+public;PartialBy
 public;PartialHierarchyModification = NodeInsertionInfo | NodeDeletionInfo | NodeUpdateInfo
 public;PartialHierarchyModification
 public;PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON
@@ -312,6 +313,9 @@ public;RegisteredRuleset
 public;RelatedClassInfo
 public;RelatedClassInfo
 public;RelatedClassInfoJSON
+public;RelatedClassInfoWithOptionalRelationship = PartialBy
+public;RelatedClassInfoWithOptionalRelationship
+public;RelatedClassInfoWithOptionalRelationshipJSON
 public;RelatedInstanceNodesSpecification = DEPRECATED_RelatedInstanceNodesSpecification | RelatedInstanceNodesSpecificationNew
 public;RelatedInstanceNodesSpecificationNew 
 public;RelatedInstanceSpecification = DEPRECATED_RelatedInstanceSpecification | RelatedInstanceSpecificationNew

--- a/common/changes/@bentley/presentation-backend/presentation-add-assertions-for-correct-classmap-3.0_2021-09-28-11-46.json
+++ b/common/changes/@bentley/presentation-backend/presentation-add-assertions-for-correct-classmap-3.0_2021-09-28-11-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend"
+}

--- a/common/changes/@bentley/presentation-common/presentation-add-assertions-for-correct-classmap-3.0_2021-09-21-13-07.json
+++ b/common/changes/@bentley/presentation-common/presentation-add-assertions-for-correct-classmap-3.0_2021-09-21-13-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common"
+}

--- a/common/changes/@bentley/presentation-common/presentation-add-assertions-for-correct-classmap-3.0_2021-09-28-11-46.json
+++ b/common/changes/@bentley/presentation-common/presentation-add-assertions-for-correct-classmap-3.0_2021-09-28-11-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Update `SelectClassInfo.pathFromInputToSelectClass` type definition to match reality - the relationship may not always be set.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common"
+}

--- a/presentation/backend/src/test/PresentationManager.test.snap
+++ b/presentation/backend/src/test/PresentationManager.test.snap
@@ -964,10 +964,13 @@ Object {
     },
   ],
   "classesMap": Object {
-    "0": Object {},
     "0x1": Object {
       "label": "Source",
       "name": "source:class",
+    },
+    "0x1054a000001245d": Object {
+      "label": "Rustic Metal Fish Automotive Cuban Peso Peso Convertible",
+      "name": "Barbados",
     },
     "0x2": Object {
       "label": "Target",
@@ -977,7 +980,14 @@ Object {
       "label": "Relationship",
       "name": "relationship:class",
     },
-    "[object Object]": Object {},
+    "0xab690000009ba9": Object {
+      "label": "back-end",
+      "name": "auxiliary",
+    },
+    "0xea7d000000f2b6": Object {
+      "label": "Assurance turquoise navigating",
+      "name": "Berkshire",
+    },
   },
   "connectionId": "d61dcbd0-3355-426a-9ebf-3eadccd4b8be",
   "contentFlags": 0,
@@ -999,25 +1009,21 @@ Object {
       "properties": Array [
         Object {
           "property": Object {
-            "classInfo": Object {
-              "id": "0xb0b60000001f53",
-              "label": "withdrawal",
-              "name": "utilize",
-            },
+            "classInfo": "0x1",
             "enumerationInfo": Object {
               "choices": Array [
                 Object {
-                  "label": "SQL markets",
-                  "value": "655821da-f1ef-4589-ad49-bacbaea86483",
+                  "label": "Games withdrawal",
+                  "value": "27ad4616-5582-41da-b1ef-5896d49bacba",
                 },
                 Object {
-                  "label": "tangible platforms navigating",
-                  "value": "bc243b63-ea44-46b6-bcee-422bd1fbdfff",
+                  "label": "payment morph Congo",
+                  "value": "b4e62d6b-c243-4b63-aa44-6b6bcee422bd",
                 },
               ],
-              "isStrict": true,
+              "isStrict": false,
             },
-            "name": "Granite",
+            "name": "Practical",
             "type": "string",
           },
         },
@@ -1032,23 +1038,19 @@ Object {
       "category": "test-category",
       "editor": undefined,
       "isReadonly": true,
-      "label": "Directives multi-byte Keys",
+      "label": "bus Strategist Facilitator",
       "name": "Complex array of structs property field",
-      "priority": 4698,
+      "priority": 26470,
       "properties": Array [
         Object {
           "property": Object {
-            "classInfo": Object {
-              "id": "0x675f0000014e92",
-              "label": "stable transmitter",
-              "name": "Kids",
-            },
+            "classInfo": "0x1",
             "kindOfQuantity": Object {
-              "label": "web services",
-              "name": "Personal Loan Account",
-              "persistenceUnit": "Home Loan Account",
+              "label": "Accounts backing up",
+              "name": "Avon",
+              "persistenceUnit": "Senior",
             },
-            "name": "Integration",
+            "name": "Tennessee",
             "type": "double",
           },
         },
@@ -1058,16 +1060,16 @@ Object {
         "memberType": Object {
           "members": Array [
             Object {
-              "label": "Fields open-source Tennessee",
-              "name": "efficient",
+              "label": "multi-byte",
+              "name": "CFA Franc BCEAO",
               "type": Object {
                 "typeName": "string",
                 "valueFormat": "Primitive",
               },
             },
             Object {
-              "label": "Accounts backing up",
-              "name": "Avon",
+              "label": "United States Minor Outlying Islands Fields",
+              "name": "Keys",
               "type": Object {
                 "memberType": Object {
                   "typeName": "string",
@@ -1089,19 +1091,19 @@ Object {
       "actualPrimaryClassIds": Array [],
       "autoExpand": true,
       "category": "test-category",
-      "contentClassInfo": "0",
+      "contentClassInfo": "0x1",
       "editor": undefined,
-      "isReadonly": true,
-      "label": "Rue Assurance",
+      "isReadonly": false,
+      "label": "24/7 Home Loan Account stable",
       "name": "Nested content field",
       "nestedFields": Array [
         Object {
           "category": "test-category",
           "editor": undefined,
-          "isReadonly": false,
-          "label": "reintermediate Licensed Soft Bike",
+          "isReadonly": true,
+          "label": "Avon Planner Ways",
           "name": "Simple property field",
-          "priority": 17182,
+          "priority": 27093,
           "renderer": undefined,
           "type": Object {
             "typeName": "string",
@@ -1114,26 +1116,26 @@ Object {
           "isForwardRelationship": false,
           "isPolymorphicRelationship": false,
           "isPolymorphicTargetClass": false,
-          "relationshipInfo": "0",
-          "sourceClassInfo": "0",
-          "targetClassInfo": "0",
+          "relationshipInfo": "0x1054a000001245d",
+          "sourceClassInfo": "0xea7d000000f2b6",
+          "targetClassInfo": "0xab690000009ba9",
         },
       ],
-      "priority": 60528,
+      "priority": 77648,
       "relationshipMeaning": "RelatedInstance",
       "renderer": undefined,
       "type": Object {
         "members": Array [
           Object {
-            "label": "users Movies",
-            "name": "navigating",
+            "label": "Integration web services",
+            "name": "Integration",
             "type": Object {
               "typeName": "string",
               "valueFormat": "Primitive",
             },
           },
         ],
-        "typeName": "turquoise",
+        "typeName": "transmitter",
         "valueFormat": "Struct",
       },
     },
@@ -1221,7 +1223,6 @@ Array [
     "pathFromInputToSelectClass": Array [
       Object {
         "isForwardRelationship": true,
-        "isPolymorphicRelationship": false,
         "isPolymorphicTargetClass": false,
         "relationshipInfo": Object {
           "id": "0x456",

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -17,7 +17,7 @@ import {
   FieldDescriptor, FieldDescriptorType, FieldJSON, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
   getLocalesDirectory, HierarchyCompareInfo, HierarchyCompareInfoJSON, HierarchyCompareOptions, HierarchyRequestOptions, InstanceKey,
   IntRulesetVariable, ItemJSON, KeySet, KindOfQuantityInfo, LabelDefinition, NestedContentFieldJSON, NodeJSON, NodeKey, Paged, PageOptions,
-  PresentationError, PrimitiveTypeDescription, PropertiesFieldJSON, PropertyInfoJSON, PropertyJSON, RegisteredRuleset, Ruleset,
+  PresentationError, PrimitiveTypeDescription, PropertiesFieldJSON, PropertyInfoJSON, PropertyJSON, RegisteredRuleset, RelatedClassInfo, Ruleset,
   SelectClassInfo, SelectClassInfoJSON, SelectionInfo, SelectionScope, StandardNodeTypes, StructTypeDescription, VariableValueTypes,
 } from "@bentley/presentation-common";
 import {
@@ -27,7 +27,7 @@ import { createTestECClassInfo, createTestRelatedClassInfo, createTestRelationsh
 import {
   createRandomECClassInfoJSON, createRandomECInstanceKey, createRandomECInstanceKeyJSON, createRandomECInstancesNodeJSON,
   createRandomECInstancesNodeKey, createRandomECInstancesNodeKeyJSON, createRandomId, createRandomLabelDefinitionJSON,
-  createRandomNodePathElementJSON, createRandomRelationshipPathJSON, createRandomRuleset,
+  createRandomNodePathElementJSON, createRandomRelationshipPath, createRandomRuleset,
 } from "@bentley/presentation-common/lib/test/_helpers/random";
 import { PRESENTATION_BACKEND_ASSETS_ROOT, PRESENTATION_COMMON_ASSETS_ROOT } from "../presentation-backend/Constants";
 import { NativePlatformDefinition, NativePlatformRequestTypes, NativePresentationUnitSystem } from "../presentation-backend/NativePlatform";
@@ -1222,7 +1222,13 @@ describe("PresentationManager", () => {
         };
 
         // what the addon returns
-        const classesMap = {};
+        const testClassInfo = createTestECClassInfo();
+        const classesMap = {
+          [testClassInfo.id]: {
+            label: testClassInfo.label,
+            name: testClassInfo.name,
+          },
+        };
         const addonResponse: DescriptorJSON = {
           connectionId: faker.random.uuid(),
           inputKeysHash: faker.random.uuid(),
@@ -1256,7 +1262,7 @@ describe("PresentationManager", () => {
             },
             properties: [{
               property: {
-                classInfo: createRandomECClassInfoJSON(),
+                classInfo: testClassInfo.id,
                 name: faker.random.word(),
                 type: "string",
                 enumerationInfo: {
@@ -1269,10 +1275,10 @@ describe("PresentationManager", () => {
                   }],
                   isStrict: faker.random.boolean(),
                 },
-              } as PropertyInfoJSON,
+              } as PropertyInfoJSON<Id64String>,
               relatedClassPath: [],
-            } as PropertyJSON],
-          } as PropertiesFieldJSON, {
+            } as PropertyJSON<Id64String>],
+          } as PropertiesFieldJSON<Id64String>, {
             name: "Complex array of structs property field",
             category: "test-category",
             label: faker.random.words(),
@@ -1307,7 +1313,7 @@ describe("PresentationManager", () => {
             priority: faker.random.number(),
             properties: [{
               property: {
-                classInfo: createRandomECClassInfoJSON(),
+                classInfo: testClassInfo.id,
                 name: faker.random.word(),
                 type: "double",
                 kindOfQuantity: {
@@ -1315,10 +1321,10 @@ describe("PresentationManager", () => {
                   label: faker.random.words(),
                   persistenceUnit: faker.random.word(),
                 } as KindOfQuantityInfo,
-              } as PropertyInfoJSON,
+              } as PropertyInfoJSON<Id64String>,
               relatedClassPath: [],
-            } as PropertyJSON],
-          } as PropertiesFieldJSON, {
+            } as PropertyJSON<Id64String>],
+          } as PropertiesFieldJSON<Id64String>, {
             name: "Nested content field",
             category: "test-category",
             label: faker.random.words(),
@@ -1334,8 +1340,8 @@ describe("PresentationManager", () => {
                 },
               }],
             } as StructTypeDescription,
-            contentClassInfo: createRandomECClassInfoJSON(),
-            pathToPrimaryClass: createRandomRelationshipPathJSON(1),
+            contentClassInfo: testClassInfo.id,
+            pathToPrimaryClass: createRandomRelationshipPath(1).map((step) => RelatedClassInfo.toCompressedJSON(step, classesMap)),
             nestedFields: [{
               name: "Simple property field",
               category: "test-category",
@@ -1350,7 +1356,7 @@ describe("PresentationManager", () => {
             isReadonly: faker.random.boolean(),
             priority: faker.random.number(),
             autoExpand: faker.random.boolean(),
-          } as NestedContentFieldJSON],
+          } as NestedContentFieldJSON<Id64String>],
           contentFlags: 0,
         };
         setup(addonResponse);

--- a/presentation/common/src/presentation-common/EC.ts
+++ b/presentation/common/src/presentation-common/EC.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { Id64, Id64String } from "@bentley/bentleyjs-core";
+import { assert, Id64, Id64String } from "@bentley/bentleyjs-core";
 import { FormatProps } from "@bentley/imodeljs-quantity";
 
 /**
@@ -276,6 +276,9 @@ export namespace RelatedClassInfo {
 
   /** Deserialize [[RelatedClassInfo]] from compressed JSON */
   export function fromCompressedJSON(json: RelatedClassInfoJSON<string>, classesMap: { [id: string]: CompressedClassInfoJSON }): RelatedClassInfo {
+    assert(classesMap.hasOwnProperty(json.sourceClassInfo));
+    assert(classesMap.hasOwnProperty(json.targetClassInfo));
+    assert(classesMap.hasOwnProperty(json.relationshipInfo));
     return {
       ...json,
       sourceClassInfo: ClassInfo.fromJSON({ id: json.sourceClassInfo, ...classesMap[json.sourceClassInfo] }),

--- a/presentation/common/src/presentation-common/Utils.ts
+++ b/presentation/common/src/presentation-common/Utils.ts
@@ -29,6 +29,12 @@ export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type Subtract<T, K> = Omit<T, keyof K>;
 
 /**
+ * Create a type from given type `T` and make specified properties optional.
+ * @public
+ */
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/**
  * A dictionary data structure.
  * @public
  */

--- a/presentation/common/src/presentation-common/content/Descriptor.ts
+++ b/presentation/common/src/presentation-common/content/Descriptor.ts
@@ -6,7 +6,7 @@
  * @module Content
  */
 
-import { Id64String } from "@bentley/bentleyjs-core";
+import { assert, Id64String } from "@bentley/bentleyjs-core";
 import {
   ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, RelatedClassInfo, RelatedClassInfoJSON, RelationshipPath, RelationshipPathJSON,
 } from "../EC";
@@ -66,6 +66,7 @@ export namespace SelectClassInfo {
 
   /** Deserialize [[SelectClassInfo]] from compressed JSON */
   export function fromCompressedJSON(json: SelectClassInfoJSON<string>, classesMap: { [id: string]: CompressedClassInfoJSON }): SelectClassInfo {
+    assert(classesMap.hasOwnProperty(json.selectClassInfo));
     return {
       selectClassInfo: { id: json.selectClassInfo, ...classesMap[json.selectClassInfo] },
       isSelectPolymorphic: json.isSelectPolymorphic,

--- a/presentation/common/src/presentation-common/content/Descriptor.ts
+++ b/presentation/common/src/presentation-common/content/Descriptor.ts
@@ -8,7 +8,8 @@
 
 import { assert, Id64String } from "@bentley/bentleyjs-core";
 import {
-  ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, RelatedClassInfo, RelatedClassInfoJSON, RelationshipPath, RelationshipPathJSON,
+  ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, RelatedClassInfo, RelatedClassInfoJSON, RelatedClassInfoWithOptionalRelationship,
+  RelatedClassInfoWithOptionalRelationshipJSON, RelationshipPath, RelationshipPathJSON,
 } from "../EC";
 import { CategoryDescription, CategoryDescriptionJSON } from "./Category";
 import { Field, FieldDescriptor, FieldJSON, getFieldByName } from "./Fields";
@@ -25,7 +26,7 @@ export interface SelectClassInfo {
   isSelectPolymorphic: boolean;
 
   /** Relationship path from input class to the select class. */
-  pathFromInputToSelectClass?: RelationshipPath;
+  pathFromInputToSelectClass?: RelatedClassInfoWithOptionalRelationship[];
 
   /** Relationship paths to [Related property]($docs/learning/presentation/Content/Terminology#related-properties) classes */
   relatedPropertyPaths?: RelationshipPath[];
@@ -44,7 +45,7 @@ export interface SelectClassInfo {
 export interface SelectClassInfoJSON<TClassInfoJSON = ClassInfoJSON> {
   selectClassInfo: TClassInfoJSON;
   isSelectPolymorphic: boolean;
-  pathFromInputToSelectClass?: RelationshipPathJSON<TClassInfoJSON>;
+  pathFromInputToSelectClass?: RelatedClassInfoWithOptionalRelationshipJSON<TClassInfoJSON>[];
   relatedPropertyPaths?: RelationshipPathJSON<TClassInfoJSON>[];
   navigationPropertyClasses?: RelatedClassInfoJSON<TClassInfoJSON>[];
   relatedInstancePaths?: RelationshipPathJSON<TClassInfoJSON>[];
@@ -52,18 +53,6 @@ export interface SelectClassInfoJSON<TClassInfoJSON = ClassInfoJSON> {
 
 /** @public */
 export namespace SelectClassInfo {
-  /** Deserialize [[SelectClassInfo]] from JSON */
-  export function fromJSON(json: SelectClassInfoJSON): SelectClassInfo {
-    return {
-      selectClassInfo: ClassInfo.fromJSON(json.selectClassInfo),
-      isSelectPolymorphic: json.isSelectPolymorphic,
-      ...(json.pathFromInputToSelectClass ? { pathFromInputToSelectClass: json.pathFromInputToSelectClass.map(RelatedClassInfo.fromJSON) } : undefined),
-      ...(json.relatedPropertyPaths ? { relatedPropertyPaths: json.relatedPropertyPaths.map((rp) => rp.map(RelatedClassInfo.fromJSON)) } : undefined),
-      ...(json.navigationPropertyClasses ? { navigationPropertyClasses: json.navigationPropertyClasses.map(RelatedClassInfo.fromJSON) } : undefined),
-      ...(json.relatedInstancePaths ? { relatedInstancePaths: json.relatedInstancePaths.map((rip) => rip.map(RelatedClassInfo.fromJSON)) } : undefined),
-    };
-  }
-
   /** Deserialize [[SelectClassInfo]] from compressed JSON */
   export function fromCompressedJSON(json: SelectClassInfoJSON<string>, classesMap: { [id: string]: CompressedClassInfoJSON }): SelectClassInfo {
     assert(classesMap.hasOwnProperty(json.selectClassInfo));
@@ -72,7 +61,7 @@ export namespace SelectClassInfo {
       isSelectPolymorphic: json.isSelectPolymorphic,
       ...(json.navigationPropertyClasses ? { navigationPropertyClasses: json.navigationPropertyClasses.map((item) => RelatedClassInfo.fromCompressedJSON(item, classesMap)) } : undefined),
       ...(json.relatedInstancePaths ? { relatedInstancePaths: json.relatedInstancePaths.map((rip) => rip.map((item) => RelatedClassInfo.fromCompressedJSON(item, classesMap))) } : undefined),
-      ...(json.pathFromInputToSelectClass ? { pathFromInputToSelectClass: json.pathFromInputToSelectClass.map((item) => RelatedClassInfo.fromCompressedJSON(item, classesMap)) } : undefined),
+      ...(json.pathFromInputToSelectClass ? { pathFromInputToSelectClass: json.pathFromInputToSelectClass.map((item) => RelatedClassInfoWithOptionalRelationship.fromCompressedJSON(item, classesMap)) } : undefined),
       ...(json.relatedPropertyPaths ? { relatedPropertyPaths: json.relatedPropertyPaths.map((path) => path.map((item) => RelatedClassInfo.fromCompressedJSON(item, classesMap))) } : undefined),
     };
   }
@@ -81,13 +70,12 @@ export namespace SelectClassInfo {
   export function toCompressedJSON(selectClass: SelectClassInfo, classesMap: { [id: string]: CompressedClassInfoJSON }): SelectClassInfoJSON<string> {
     const { id, ...leftOverClassInfo } = selectClass.selectClassInfo;
     classesMap[id] = leftOverClassInfo;
-
     return {
       selectClassInfo: id,
       isSelectPolymorphic: selectClass.isSelectPolymorphic,
       ...(selectClass.relatedInstancePaths ? { relatedInstancePaths: selectClass.relatedInstancePaths.map((rip) => rip.map((item) => RelatedClassInfo.toCompressedJSON(item, classesMap))) } : undefined),
       ...(selectClass.navigationPropertyClasses ? { navigationPropertyClasses: selectClass.navigationPropertyClasses.map((propertyClass) => RelatedClassInfo.toCompressedJSON(propertyClass, classesMap)) } : undefined),
-      ...(selectClass.pathFromInputToSelectClass ? { pathFromInputToSelectClass: selectClass.pathFromInputToSelectClass.map((item) => RelatedClassInfo.toCompressedJSON(item, classesMap)) } : undefined),
+      ...(selectClass.pathFromInputToSelectClass ? { pathFromInputToSelectClass: selectClass.pathFromInputToSelectClass.map((item) => RelatedClassInfoWithOptionalRelationship.toCompressedJSON(item, classesMap)) } : undefined),
       ...(selectClass.relatedPropertyPaths ? { relatedPropertyPaths: selectClass.relatedPropertyPaths.map((path) => path.map((relatedClass) => RelatedClassInfo.toCompressedJSON(relatedClass, classesMap))) } : undefined),
     };
   }

--- a/presentation/common/src/presentation-common/content/Fields.ts
+++ b/presentation/common/src/presentation-common/content/Fields.ts
@@ -6,7 +6,7 @@
  * @module Content
  */
 
-import { Id64String } from "@bentley/bentleyjs-core";
+import { assert, Id64String } from "@bentley/bentleyjs-core";
 import {
   ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, PropertyInfo, PropertyInfoJSON, RelatedClassInfo, RelationshipPath, RelationshipPathJSON,
   StrippedRelationshipPath,
@@ -478,6 +478,7 @@ export class NestedContentField extends Field {
    * @public
    */
   public static override fromCompressedJSON(json: NestedContentFieldJSON<Id64String>, classesMap: { [id: string]: CompressedClassInfoJSON }, categories: CategoryDescription[]) {
+    assert(classesMap.hasOwnProperty(json.contentClassInfo));
     const field = Object.create(NestedContentField.prototype);
     return Object.assign(field, json, this.fromCommonJSON(json, categories), {
       category: this.getCategoryFromFieldJson(json, categories),
@@ -599,6 +600,7 @@ function fromCompressedPropertyJSON(compressedPropertyJSON: PropertyJSON<string>
 }
 
 function fromCompressedPropertyInfoJSON(compressedPropertyJSON: PropertyInfoJSON<string>, classesMap: { [id: string]: CompressedClassInfoJSON }): PropertyInfo {
+  assert(classesMap.hasOwnProperty(compressedPropertyJSON.classInfo));
   return {
     ...compressedPropertyJSON,
     classInfo: { id: compressedPropertyJSON.classInfo, ...classesMap[compressedPropertyJSON.classInfo] },

--- a/presentation/common/src/test/EC.test.ts
+++ b/presentation/common/src/test/EC.test.ts
@@ -5,8 +5,11 @@
 import { expect } from "chai";
 import { Id64, Id64String } from "@bentley/bentleyjs-core";
 import { InstanceKey, RelationshipPath } from "../presentation-common";
-import { ClassInfo, RelatedClassInfo, RelatedClassInfoJSON, StrippedRelatedClassInfo } from "../presentation-common/EC";
-import { createTestECClassInfo, createTestRelatedClassInfo } from "./_helpers/EC";
+import {
+  ClassInfo, RelatedClassInfo, RelatedClassInfoJSON, RelatedClassInfoWithOptionalRelationship, RelatedClassInfoWithOptionalRelationshipJSON,
+  StrippedRelatedClassInfo,
+} from "../presentation-common/EC";
+import { createTestECClassInfo, createTestRelatedClassInfo, createTestRelatedClassInfoWithOptionalRelationship } from "./_helpers/EC";
 import { createRandomECClassInfo } from "./_helpers/random";
 
 describe("InstanceKey", () => {
@@ -187,6 +190,63 @@ describe("RelatedClassInfo", () => {
         sourceClassName: source.sourceClassInfo.name,
         targetClassName: source.targetClassInfo.name,
       });
+    });
+
+  });
+
+});
+
+describe("RelatedClassInfoWithOptionalRelationship", () => {
+
+  describe("to/from compressed JSON", () => {
+
+    it("passes roundtrip", () => {
+      const src = createTestRelatedClassInfoWithOptionalRelationship({
+        isForwardRelationship: true,
+        isPolymorphicRelationship: true,
+        relationshipInfo: createTestECClassInfo({ id: "0x123", name: "relationship:class", label: "Relationship" }),
+      });
+      const classesMap = {};
+      const json = RelatedClassInfoWithOptionalRelationship.toCompressedJSON(src, classesMap);
+      const res = RelatedClassInfoWithOptionalRelationship.fromCompressedJSON(json, classesMap);
+      expect(res).to.deep.eq(src);
+    });
+
+    it("handles optional attributes when serializing", () => {
+      const sourceClassInfo = createTestECClassInfo();
+      const targetClassInfo = createTestECClassInfo();
+      const classInfos = {};
+      const src: RelatedClassInfoWithOptionalRelationship = {
+        sourceClassInfo,
+        targetClassInfo,
+        isPolymorphicTargetClass: true,
+      };
+      const json = RelatedClassInfoWithOptionalRelationship.toCompressedJSON(src, classInfos);
+      expect(classInfos).to.deep.eq({
+        [sourceClassInfo.id]: { name: sourceClassInfo.name, label: sourceClassInfo.label },
+        [targetClassInfo.id]: { name: targetClassInfo.name, label: targetClassInfo.label },
+      });
+      expect(json.relationshipInfo).to.be.undefined;
+      expect(json.isForwardRelationship).to.be.undefined;
+      expect(json.isPolymorphicRelationship).to.be.undefined;
+    });
+
+    it("handles optional attributes when deserializing", () => {
+      const sourceClassInfo = createTestECClassInfo();
+      const targetClassInfo = createTestECClassInfo();
+      const classInfos = {
+        [sourceClassInfo.id]: { name: sourceClassInfo.name, label: sourceClassInfo.label },
+        [targetClassInfo.id]: { name: targetClassInfo.name, label: targetClassInfo.label },
+      };
+      const json: RelatedClassInfoWithOptionalRelationshipJSON<Id64String> = {
+        sourceClassInfo: sourceClassInfo.id,
+        targetClassInfo: targetClassInfo.id,
+      };
+      const res = RelatedClassInfoWithOptionalRelationship.fromCompressedJSON(json, classInfos);
+      expect(res.isPolymorphicTargetClass).to.be.false;
+      expect(res.relationshipInfo).to.be.undefined;
+      expect(res.isForwardRelationship).to.be.undefined;
+      expect(res.isPolymorphicRelationship).to.be.undefined;
     });
 
   });

--- a/presentation/common/src/test/_helpers/EC.ts
+++ b/presentation/common/src/test/_helpers/EC.ts
@@ -27,6 +27,13 @@ export const createTestRelatedClassInfo = (props?: Partial<ec.RelatedClassInfo>)
   ...props,
 });
 
+export const createTestRelatedClassInfoWithOptionalRelationship = (props?: Partial<ec.RelatedClassInfoWithOptionalRelationship>) => ({
+  sourceClassInfo: createTestECClassInfo({ id: "0x1", name: "source:class", label: "Source" }),
+  targetClassInfo: createTestECClassInfo({ id: "0x2", name: "target:class", label: "Target" }),
+  isPolymorphicTargetClass: false,
+  ...props,
+});
+
 export const createTestRelationshipPath = (length: number = 2) => {
   const path = new Array<ec.RelatedClassInfo>();
   while (length--)

--- a/presentation/common/src/test/content/Descriptor.test.snap
+++ b/presentation/common/src/test/content/Descriptor.test.snap
@@ -984,7 +984,6 @@ Object {
       "pathFromInputToSelectClass": Array [
         Object {
           "isForwardRelationship": true,
-          "isPolymorphicRelationship": false,
           "isPolymorphicTargetClass": false,
           "relationshipInfo": "0x4",
           "sourceClassInfo": "0x2",

--- a/presentation/common/src/test/content/Descriptor.test.ts
+++ b/presentation/common/src/test/content/Descriptor.test.ts
@@ -334,19 +334,10 @@ describe("SelectClassInfo", () => {
 
   let classesMap!: { [id: string]: CompressedClassInfoJSON };
   let obj!: SelectClassInfo;
-  let json!: SelectClassInfoJSON;
   let compressedJson!: SelectClassInfoJSON<Id64String>;
 
   beforeEach(() => {
     obj = {
-      selectClassInfo: {
-        id: "0x123",
-        name: "name",
-        label: "Label",
-      },
-      isSelectPolymorphic: true,
-    };
-    json = {
       selectClassInfo: {
         id: "0x123",
         name: "name",
@@ -364,66 +355,6 @@ describe("SelectClassInfo", () => {
         label: "Label",
       },
     };
-  });
-
-  describe("fromJSON", () => {
-
-    it("doesn't create unnecessary members", () => {
-      const result = SelectClassInfo.fromJSON(json);
-      expect(result).to.not.haveOwnProperty("pathFromInputToSelectClass");
-      expect(result).to.not.haveOwnProperty("relatedPropertyPaths");
-      expect(result).to.not.haveOwnProperty("navigationPropertyClasses");
-      expect(result).to.not.haveOwnProperty("relatedInstancePaths");
-    });
-
-    it("parses `pathFromInputToSelectClass`", () => {
-      const pathFromInputToSelectClass = createTestRelationshipPath(2);
-      json = {
-        ...json,
-        pathFromInputToSelectClass: pathFromInputToSelectClass.map(RelatedClassInfo.toJSON),
-      };
-      expect(SelectClassInfo.fromJSON(json)).to.deep.eq({
-        ...obj,
-        pathFromInputToSelectClass,
-      });
-    });
-
-    it("parses `relatedPropertyPaths`", () => {
-      const relatedPropertyPaths = [createTestRelationshipPath(2)];
-      json = {
-        ...json,
-        relatedPropertyPaths: relatedPropertyPaths.map((p) => p.map(RelatedClassInfo.toJSON)),
-      };
-      expect(SelectClassInfo.fromJSON(json)).to.deep.eq({
-        ...obj,
-        relatedPropertyPaths,
-      });
-    });
-
-    it("parses `navigationPropertyClasses`", () => {
-      const navigationPropertyClasses = createTestRelationshipPath(2);
-      json = {
-        ...json,
-        navigationPropertyClasses: navigationPropertyClasses.map(RelatedClassInfo.toJSON),
-      };
-      expect(SelectClassInfo.fromJSON(json)).to.deep.eq({
-        ...obj,
-        navigationPropertyClasses,
-      });
-    });
-
-    it("parses `relatedInstancePaths`", () => {
-      const relatedInstancePaths = [createTestRelationshipPath(2)];
-      json = {
-        ...json,
-        relatedInstancePaths: relatedInstancePaths.map((p) => p.map(RelatedClassInfo.toJSON)),
-      };
-      expect(SelectClassInfo.fromJSON(json)).to.deep.eq({
-        ...obj,
-        relatedInstancePaths,
-      });
-    });
-
   });
 
   describe("fromCompressedJSON", () => {


### PR DESCRIPTION
The assertions also revealed that our `SelectClassInfo.pathFromInputToSelectClass` type definition doesn't match what we're sending from the addon. In case of recursive relationships we're don't have a relationship information. Updated the type definition to match that.