### PR TITLE
UI: Update VirtualizedPropertyGrid styles

### DIFF
--- a/common/changes/@bentley/ui-components/ui-components-expandable-block_2021-09-28-12-14.json
+++ b/common/changes/@bentley/ui-components/ui-components-expandable-block_2021-09-28-12-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-components"
+}

--- a/common/changes/@bentley/ui-core/ui-components-expandable-block_2021-09-28-12-14.json
+++ b/common/changes/@bentley/ui-core/ui-components-expandable-block_2021-09-28-12-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/ui-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/ui-core"
+}

--- a/test-apps/presentation-test-app/src/frontend/components/properties-widget/PropertiesWidget.css
+++ b/test-apps/presentation-test-app/src/frontend/components/properties-widget/PropertiesWidget.css
@@ -32,7 +32,6 @@
 .PropertiesWidget > .ContentContainer {
   flex: 1 0;
   min-height: 0;
-  margin-left: -3px;
   grid-column-start: 1;
   grid-column-end: span 2;
 }

--- a/ui/components/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -524,11 +524,11 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         const category = await findByText("test_category");
         expect(baseElement.querySelector(".iui-expanded")).to.not.exist;
         const node = baseElement.querySelector(".virtualized-grid-node") as HTMLElement;
-        expect(node.style.height).to.be.equal("36px");
+        expect(node.style.height).to.be.equal("38px");
 
         fireEvent.click(category);
         expect(baseElement.querySelector(".iui-expanded")).to.exist;
-        expect(node.style.height).to.be.equal("541px");
+        expect(node.style.height).to.be.equal("543px");
       });
 
       it("updates node height on collapse", async () => {
@@ -541,10 +541,10 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
 
         const category = await findByText("test_category");
         const node = baseElement.querySelector(".virtualized-grid-node") as HTMLElement;
-        expect(node.style.height).to.be.equal("541px");
+        expect(node.style.height).to.be.equal("543px");
 
         fireEvent.click(category);
-        expect(node.style.height).to.be.equal("36px");
+        expect(node.style.height).to.be.equal("38px");
       });
     });
   });

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -15,7 +15,6 @@
 
 .components-virtualized-property-grid {
   user-select: none;
-  padding: 0px 3px 3px 3px;
 
   @include small-itwinui-expandable-block;
 }

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -26,7 +26,9 @@
 }
 
 .virtualized-grid-node {
-  background: var(--iui-color-background-1);
+  > :not(.virtualized-grid-node-category) {
+    background: var(--iui-color-background-1);
+  }
 
   .nested-border-middle {
     height: 100%;

--- a/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components/src/ui-components/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -209,7 +209,7 @@ export class VirtualizedPropertyGrid extends React.Component<VirtualizedProperty
    * @returns current height of node.
    */
   private calculateNodeHeight(node: FlatGridItem) {
-    const categoryHeaderHeight = 32;
+    const categoryHeaderHeight = 34;
     const categoryHeaderPadding = 4;
     const categoryPropertyHeight = 27;
     const bottomBorderPadding = 5;

--- a/ui/core/src/ui-core/style/itwinui-overrides.scss
+++ b/ui/core/src/ui-core/style/itwinui-overrides.scss
@@ -56,9 +56,11 @@
         width: $uicore-icons-x-small !important;
         height: $uicore-icons-x-small !important;
 
-        margin-top: $small-space !important;
         margin-left: $iui-xs !important;
-        margin-right: $iui-s !important;
+      }
+
+      > .iui-expandable-block-label {
+        margin-left: 8px;
       }
     }
 


### PR DESCRIPTION
Recent upgrade to newer version of iTwinUI has broken our style overrides for compact expandable blocks.

This PR makes the following changes to `VirtualizedPropertyGrid`:
* Fixes chevron centering, again.
* Gives category labels more vertical space to fix inconsistent spacing between expandable block borders.
* Fixes an older issue where the top-most expandable block has slightly protruding background through the top edge.
* Drops extra padding around the component to make reasoning about its sizing more straightforward. Previously, if user set its width to `100px`, the component would actually take up `106px` horizontally. This change also removes the need for negative margin in presentation-test-app.