### PR TITLE
Update copy static plugin to support the '@itwin' scope

### DIFF
--- a/common/changes/@itwin/core-webpack-tools/fix-copy-static-plugin_2021-09-30-13-28.json
+++ b/common/changes/@itwin/core-webpack-tools/fix-copy-static-plugin_2021-09-30-13-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-webpack-tools",
+      "comment": "Update the CopyBentleyStaticResourcesPlugin to support the `@itwin` scope in addition to the `@bentley` scope.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-webpack-tools"
+}

--- a/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
+++ b/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
@@ -79,16 +79,16 @@ export class CopyBentleyStaticResourcesPlugin extends AbstractAsyncStartupPlugin
     const copyContents = async (basePath: string) => {
       let subDirectoryNames: string[];
       try {
-        subDirectoryNames = await fs.readdir(bentleyDir);
+        subDirectoryNames = await fs.readdir(basePath);
       } catch (err: any) {
         this.logger.error(`Can't locate ${err.path}`);
         return;
       }
       for (const thisSubDir of subDirectoryNames) {
-        if (!(await isDirectory(path.resolve(bentleyDir, thisSubDir))))
+        if (!(await isDirectory(path.resolve(basePath, thisSubDir))))
           continue;
 
-        const fullDirName = path.resolve(bentleyDir, thisSubDir);
+        const fullDirName = path.resolve(basePath, thisSubDir);
         for (const staticAssetsDirectoryName of this._directoryNames) {
           await tryCopyDirectoryContents(
             path.join(fullDirName, "lib", staticAssetsDirectoryName),

--- a/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
+++ b/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
@@ -74,26 +74,36 @@ export class CopyBentleyStaticResourcesPlugin extends AbstractAsyncStartupPlugin
 
   public async runAsync(compiler: Compiler) {
     const paths = getPaths();
-    const bentleyDir = path.resolve(paths.appNodeModules, "@bentley");
-    let subDirectoryNames: string[];
-    try {
-      subDirectoryNames = await fs.readdir(bentleyDir);
-    } catch (err: any) {
-      this.logger.error(`Can't locate ${err.path}`);
-      return;
-    }
-    for (const thisSubDir of subDirectoryNames) {
-      if (!(await isDirectory(path.resolve(bentleyDir, thisSubDir))))
-        continue;
 
-      const fullDirName = path.resolve(bentleyDir, thisSubDir);
-      for (const staticAssetsDirectoryName of this._directoryNames) {
-        await tryCopyDirectoryContents(
-          path.join(fullDirName, "lib", staticAssetsDirectoryName),
-          this._useDirectoryName ? compiler.outputPath : path.join(compiler.outputPath, staticAssetsDirectoryName),
-        );
+
+    const copyContents = async (basePath: string) => {
+      let subDirectoryNames: string[];
+      try {
+        subDirectoryNames = await fs.readdir(bentleyDir);
+      } catch (err: any) {
+        this.logger.error(`Can't locate ${err.path}`);
+        return;
+      }
+      for (const thisSubDir of subDirectoryNames) {
+        if (!(await isDirectory(path.resolve(bentleyDir, thisSubDir))))
+          continue;
+
+        const fullDirName = path.resolve(bentleyDir, thisSubDir);
+        for (const staticAssetsDirectoryName of this._directoryNames) {
+          await tryCopyDirectoryContents(
+            path.join(fullDirName, "lib", staticAssetsDirectoryName),
+            this._useDirectoryName ? compiler.outputPath : path.join(compiler.outputPath, staticAssetsDirectoryName),
+          );
+        }
       }
     }
+
+    const bentleyDir = path.resolve(paths.appNodeModules, "@bentley");
+    const itwinDir = path.resolve(paths.appNodeModules, "@itwin");
+
+    await copyContents(bentleyDir);
+    await copyContents(itwinDir);
+
     return;
   }
 }

--- a/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
+++ b/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
@@ -80,7 +80,6 @@ export class CopyBentleyStaticResourcesPlugin extends AbstractAsyncStartupPlugin
       try {
         subDirectoryNames = await fs.readdir(basePath);
       } catch (err: any) {
-        this.logger.error(`Can't locate ${err.path}`);
         return;
       }
       for (const thisSubDir of subDirectoryNames) {

--- a/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
+++ b/tools/webpack-core/src/plugins/CopyBentleyStaticResourcesPlugin.ts
@@ -75,7 +75,6 @@ export class CopyBentleyStaticResourcesPlugin extends AbstractAsyncStartupPlugin
   public async runAsync(compiler: Compiler) {
     const paths = getPaths();
 
-
     const copyContents = async (basePath: string) => {
       let subDirectoryNames: string[];
       try {
@@ -96,7 +95,7 @@ export class CopyBentleyStaticResourcesPlugin extends AbstractAsyncStartupPlugin
           );
         }
       }
-    }
+    };
 
     const bentleyDir = path.resolve(paths.appNodeModules, "@bentley");
     const itwinDir = path.resolve(paths.appNodeModules, "@itwin");

--- a/tools/webpack-core/src/test/CopyBentleyStaticResourcesPlugin.test.ts
+++ b/tools/webpack-core/src/test/CopyBentleyStaticResourcesPlugin.test.ts
@@ -33,12 +33,6 @@ describe("CopyBentleyStaticResourcesPlugin", () => {
     expect(fs.readFileSync(path.join(__dirname, "dist/assets/staticResourcePlugin.js"), "utf8")).to.equal(`console.log("Fake resource");`);
   });
 
-  it("should log warning when unable to find node_modules/@bentley directory", async () => {
-    setApplicationDir(__dirname);
-    const result = await runWebpack(testConfig, vol);
-    expect(result.logging.CopyBentleyStaticResourcesPlugin.entries[0].message).to.include(`Can't locate`);
-  });
-
   afterEach(() => {
     resetPaths();
     vol.reset();


### PR DESCRIPTION
With the renaming of many packages to the `@itwin` scope the copying is broken within master of the imodeljs repo.

I think we should backport this to 2.19.x so it can easily be pulled into `@bentley/react-scripts`.