### PR TITLE
UI: Promote property grid related apis

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -489,7 +489,6 @@ export interface ColumnFilterDescriptor extends FilterDescriptor {
 
 // @public
 export interface CommonPropertyGridProps extends CommonProps {
-    // @beta
     actionButtonRenderers?: ActionButtonRenderer[];
     actionButtonWidth?: number;
     // @beta
@@ -544,7 +543,7 @@ export interface CompositeFilterDescriptorCollection {
     logicalOperator: FilterCompositionLogicalOperator;
 }
 
-// @beta
+// @public
 export enum CompositeFilterType {
     // (undocumented)
     And = 0,
@@ -552,7 +551,7 @@ export enum CompositeFilterType {
     Or = 1
 }
 
-// @beta
+// @public
 export class CompositePropertyDataFilterer extends PropertyDataFiltererBase {
     constructor(_leftFilterer: IPropertyDataFilterer, _operator: CompositeFilterType, _rightFilterer: IPropertyDataFilterer);
     // (undocumented)
@@ -838,7 +837,7 @@ export class DirectionHelpers {
     static readonly TOP_CLASS_NAME = "components-direction-top";
 }
 
-// @beta
+// @public
 export class DisplayValuePropertyDataFilterer extends PropertyRecordDataFiltererBase {
     constructor(filterText?: string);
     // (undocumented)
@@ -1077,9 +1076,8 @@ export abstract class FilterDescriptorCollectionBase<TDescriptor extends FilterD
     remove(item: TDescriptor): boolean;
 }
 
-// @beta
+// @public
 export interface FilteredPropertyData extends PropertyData {
-    // (undocumented)
     filteredTypes?: FilteredType[];
     // (undocumented)
     getMatchByIndex?: (index: number) => HighlightInfo | undefined;
@@ -1087,7 +1085,7 @@ export interface FilteredPropertyData extends PropertyData {
     matchesCount?: number;
 }
 
-// @beta
+// @public
 export enum FilteredType {
     // (undocumented)
     Category = 0,
@@ -1123,7 +1121,7 @@ export enum FilteringInputStatus {
     ReadyToFilter = 0
 }
 
-// @beta
+// @public
 export class FilteringPropertyDataProvider implements IPropertyDataProvider, IDisposable {
     constructor(_dataProvider: IPropertyDataProvider, _filterer: IPropertyDataFilterer);
     // (undocumented)
@@ -1595,7 +1593,7 @@ export class IntTypeConverter extends NumericTypeConverterBase {
     convertToString(value?: Primitives.Int): string;
 }
 
-// @beta
+// @public
 export interface IPropertyDataFilterer {
     // (undocumented)
     categoryMatchesFilter: (node: PropertyCategory, parents: PropertyCategory[]) => Promise<PropertyDataFilterResult>;
@@ -1719,7 +1717,7 @@ export interface ITreeNodeLoaderWithProvider<TDataProvider extends TreeDataProvi
     readonly dataProvider: TDataProvider;
 }
 
-// @beta
+// @public
 export class LabelPropertyDataFilterer extends PropertyRecordDataFiltererBase {
     constructor(filterText?: string);
     // (undocumented)
@@ -2311,7 +2309,7 @@ export interface PrimitiveRendererProps extends SharedRendererProps {
 
 // @public
 export interface PropertyCategory {
-    // @beta (undocumented)
+    // (undocumented)
     childCategories?: PropertyCategory[];
     // (undocumented)
     expand: boolean;
@@ -2319,7 +2317,7 @@ export interface PropertyCategory {
     label: string;
     // (undocumented)
     name: string;
-    // @beta (undocumented)
+    // (undocumented)
     renderer?: {
         name: string;
     };
@@ -2335,18 +2333,17 @@ export class PropertyCategoryBlock extends React.Component<PropertyCategoryBlock
 // @public
 export interface PropertyCategoryBlockProps extends CommonProps {
     category: PropertyCategory;
-    // @beta
     highlight?: HighlightingComponentProps;
     onExpansionToggled?: (categoryName: string) => void;
 }
 
-// @beta
+// @public
 export abstract class PropertyCategoryDataFiltererBase extends PropertyDataFiltererBase {
     // (undocumented)
     recordMatchesFilter(): Promise<PropertyDataFilterResult>;
 }
 
-// @beta
+// @public
 export class PropertyCategoryLabelFilterer extends PropertyCategoryDataFiltererBase {
     constructor(filterText?: string);
     // (undocumented)
@@ -2410,7 +2407,7 @@ export class PropertyDataChangeEvent extends BeEvent<PropertyDataChangesListener
 // @public
 export type PropertyDataChangesListener = () => void;
 
-// @beta
+// @public
 export abstract class PropertyDataFiltererBase implements IPropertyDataFilterer {
     // (undocumented)
     abstract categoryMatchesFilter(node: PropertyCategory, parents: PropertyCategory[]): Promise<PropertyDataFilterResult>;
@@ -2422,7 +2419,7 @@ export abstract class PropertyDataFiltererBase implements IPropertyDataFilterer 
     abstract recordMatchesFilter(node: PropertyRecord, parents: PropertyRecord[]): Promise<PropertyDataFilterResult>;
 }
 
-// @beta
+// @public
 export interface PropertyDataFilterResult {
     filteredTypes?: FilteredType[];
     matchesCount?: number;
@@ -2492,11 +2489,11 @@ export interface PropertyEditorProps extends CommonProps {
     setFocus?: boolean;
 }
 
-// @beta
+// @public
 export class PropertyFilterChangeEvent extends BeEvent<PropertyFilterChangesListener> {
 }
 
-// @beta
+// @public
 export type PropertyFilterChangesListener = () => void;
 
 // @public
@@ -2673,7 +2670,7 @@ export interface PropertyPopupState {
     };
 }
 
-// @beta
+// @public
 export abstract class PropertyRecordDataFiltererBase extends PropertyDataFiltererBase {
     // (undocumented)
     categoryMatchesFilter(): Promise<PropertyDataFilterResult>;
@@ -4226,7 +4223,7 @@ export function useDebouncedAsyncValue<TReturn>(valueToBeResolved: undefined | (
 // @beta
 export function usePagedTreeNodeLoader<TDataProvider extends TreeDataProvider>(dataProvider: TDataProvider, pageSize: number, modelSource: TreeModelSource): PagedTreeNodeLoader<TDataProvider>;
 
-// @beta
+// @public
 export function usePropertyData(props: {
     dataProvider: IPropertyDataProvider;
 }): {

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -58,8 +58,8 @@ public;CommonPropertyGridProps
 public;CompletionObserver
 public;CompositeFilterDescriptor 
 public;CompositeFilterDescriptorCollection
-beta;CompositeFilterType
-beta;CompositePropertyDataFilterer 
+public;CompositeFilterType
+public;CompositePropertyDataFilterer 
 public;CompositeTypeConverter 
 public;computeVisibleNodes(model: TreeModel): VisibleTreeNodes
 public;ControlledSelectableContent(props: ControlledSelectableContentProps): JSX.Element
@@ -89,7 +89,7 @@ public;DEFAULT_LINKS_HANDLER: LinkElementsInfo
 public;DelayLoadedTreeNodeItem 
 public;Direction
 internal;DirectionHelpers
-beta;DisplayValuePropertyDataFilterer 
+public;DisplayValuePropertyDataFilterer 
 public;DistinctValueCollection
 public;DistinctValuesFilterDescriptor 
 public;DoublePropertyValueRenderer 
@@ -114,12 +114,12 @@ public;FilterCompositionLogicalOperator
 public;FilterDescriptor
 public;FilterDescriptorCollection 
 public;class FilterDescriptorCollectionBase
-beta;FilteredPropertyData 
-beta;FilteredType
+public;FilteredPropertyData 
+public;FilteredType
 public;FilteringInput 
 public;FilteringInputProps 
 public;FilteringInputStatus
-beta;FilteringPropertyDataProvider 
+public;FilteringPropertyDataProvider 
 public;FilterOperator
 public;FilterRenderer
 beta;FlatGridItem = CategorizedPropertyItem | GridCategoryItem
@@ -166,7 +166,7 @@ internal;InputSwitchComponent
 internal;InputSwitchProps
 alpha;IntlFormatter 
 public;IntTypeConverter 
-beta;IPropertyDataFilterer
+public;IPropertyDataFilterer
 public;IPropertyDataProvider
 beta;IPropertyGridEventHandler
 beta;IPropertyGridModel
@@ -187,7 +187,7 @@ public;ITreeDataProvider
 public;ITreeImageLoader 
 public;ITreeNodeLoader
 public;ITreeNodeLoaderWithProvider
-beta;LabelPropertyDataFilterer 
+public;LabelPropertyDataFilterer 
 public;LessGreaterOperatorProcessor
 alpha;LinksRenderer(props: LinksRendererProps): JSX.Element
 alpha;LinksRendererProps
@@ -255,8 +255,8 @@ public;PrimitiveRendererProps
 public;PropertyCategory
 public;PropertyCategoryBlock 
 public;PropertyCategoryBlockProps 
-beta;class PropertyCategoryDataFiltererBase 
-beta;PropertyCategoryLabelFilterer 
+public;class PropertyCategoryDataFiltererBase 
+public;PropertyCategoryLabelFilterer 
 beta;PropertyCategoryRenderer = (categoryItem: GridCategoryItem) => React.ComponentType
 beta;PropertyCategoryRendererManager
 beta;PropertyCategoryRendererProps
@@ -264,15 +264,15 @@ public;PropertyContainerType
 public;PropertyData
 public;PropertyDataChangeEvent 
 public;PropertyDataChangesListener = () => void
-beta;class PropertyDataFiltererBase 
-beta;PropertyDataFilterResult
+public;class PropertyDataFiltererBase 
+public;PropertyDataFilterResult
 public;PropertyDialogState
 public;PropertyEditingArgs
 public;class PropertyEditorBase 
 public;PropertyEditorManager
 public;PropertyEditorProps 
-beta;PropertyFilterChangeEvent 
-beta;PropertyFilterChangesListener = () => void
+public;PropertyFilterChangeEvent 
+public;PropertyFilterChangesListener = () => void
 public;PropertyGrid 
 public;PropertyGridCategory
 deprecated;PropertyGridCategory
@@ -292,7 +292,7 @@ public;PropertyLabelRendererProps
 public;PropertyList 
 public;PropertyListProps 
 public;PropertyPopupState
-beta;class PropertyRecordDataFiltererBase 
+public;class PropertyRecordDataFiltererBase 
 public;PropertyRenderer 
 public;PropertyRendererProps 
 public;PropertyUpdatedArgs
@@ -448,7 +448,7 @@ public;UrlPropertyValueRenderer
 public;useAsyncValue: 
 alpha;useDebouncedAsyncValue
 beta;usePagedTreeNodeLoader
-beta;usePropertyData(props:
+public;usePropertyData(props:
 beta;usePropertyGridEventHandler(props:
 beta;usePropertyGridModel(props:
 beta;usePropertyGridModelSource(props:

--- a/common/changes/@itwin/components-react/ui-promote-property-grid-related-apis_2021-10-01-08-55.json
+++ b/common/changes/@itwin/components-react/ui-promote-property-grid-related-apis_2021-10-01-08-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Promote property grid related APIs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components/src/components-react/propertygrid/PropertyCategoryRendererManager.ts
+++ b/ui/components/src/components-react/propertygrid/PropertyCategoryRendererManager.ts
@@ -25,7 +25,7 @@ export interface PropertyCategoryRendererProps {
 
 /**
  * Factory function that produces custom property category components.
- *  @beta
+ * @beta
  */
 export type PropertyCategoryRenderer = (categoryItem: GridCategoryItem) => React.ComponentType<PropertyCategoryRendererProps> | undefined;
 

--- a/ui/components/src/components-react/propertygrid/PropertyDataProvider.ts
+++ b/ui/components/src/components-react/propertygrid/PropertyDataProvider.ts
@@ -6,8 +6,8 @@
  * @module PropertyGrid
  */
 
-import { BeEvent } from "@itwin/core-bentley";
 import { PropertyRecord } from "@itwin/appui-abstract";
+import { BeEvent } from "@itwin/core-bentley";
 
 /**
  * Contains metadata about a group of Properties.
@@ -17,11 +17,7 @@ export interface PropertyCategory {
   name: string;
   label: string;
   expand: boolean;
-
-  /** @beta */
   childCategories?: PropertyCategory[];
-
-  /** @beta */
   renderer?: {
     name: string;
   };

--- a/ui/components/src/components-react/propertygrid/component/PropertyCategoryBlock.tsx
+++ b/ui/components/src/components-react/propertygrid/component/PropertyCategoryBlock.tsx
@@ -22,9 +22,7 @@ export interface PropertyCategoryBlockProps extends CommonProps {
   category: PropertyCategory;
   /** Callback to when PropertyCategoryBlock gets expended or collapsed */
   onExpansionToggled?: (categoryName: string) => void;
-  /** Properties used for highlighting
-  * @beta
-  */
+  /** Properties used for highlighting */
   highlight?: HighlightingComponentProps;
 }
 

--- a/ui/components/src/components-react/propertygrid/component/PropertyGridCommons.ts
+++ b/ui/components/src/components-react/propertygrid/component/PropertyGridCommons.ts
@@ -85,8 +85,6 @@ export interface CommonPropertyGridProps extends CommonProps {
   /**
    * Array of action button renderers. Each renderer is called for each property and can decide
    * to render an action button for the property or not.
-   *
-   * @beta
    */
   actionButtonRenderers?: ActionButtonRenderer[];
 }

--- a/ui/components/src/components-react/propertygrid/dataproviders/FilteringDataProvider.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/FilteringDataProvider.ts
@@ -2,11 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import { PropertyRecord, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
 /** @packageDocumentation
  * @module PropertyGrid
  */
 import { IDisposable } from "@itwin/core-bentley";
-import { PropertyRecord, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
 import { HighlightInfo } from "../../common/HighlightingComponentProps";
 import { CategoryRecordsDict } from "../internal/flat-items/MutableGridCategory";
 import { IPropertyDataProvider, PropertyCategory, PropertyData, PropertyDataChangeEvent } from "../PropertyDataProvider";
@@ -22,27 +22,29 @@ interface FilteredRecords {
 }
 
 /**
- *  Data returned by [[FilteringPropertyDataProvider]]
- * @beta
+ * Data returned by [[FilteringPropertyDataProvider]]
+ * @public
  */
 export interface FilteredPropertyData extends PropertyData {
   /*
   * Shows how many matches were found when filtering data.
-  * Undefined when filterer is not active
+  * `undefined` when filterer is not active
   */
   matchesCount?: number;
+
   /*
-  * Function used for getting PropertyRecordMatchInfo by index from all the filtered matches.
-  * Undefined when filterer is not active
+  * Function used for getting [[HighlightInfo]] by index from all the filtered matches.
+  * `undefined` when filterer is not active
   */
   getMatchByIndex?: (index: number) => HighlightInfo | undefined;
 
+  /** Types of objects that were used for filtering. */
   filteredTypes?: FilteredType[];
 }
 
 /**
- * IPropertyDataProvider implementation which will filter wrapped provider PropertyData using passed IPropertyDataFilterer.
- * @beta
+ * [[IPropertyDataProvider]] implementation which filters wrapped provider [[PropertyData]] using passed [[IPropertyDataFilterer]].
+ * @public
  */
 export class FilteringPropertyDataProvider implements IPropertyDataProvider, IDisposable {
   public onDataChanged = new PropertyDataChangeEvent();

--- a/ui/components/src/components-react/propertygrid/dataproviders/FilteringDataProvider.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/FilteringDataProvider.ts
@@ -2,10 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { PropertyRecord, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
 /** @packageDocumentation
  * @module PropertyGrid
  */
+
+import { PropertyRecord, PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
 import { IDisposable } from "@itwin/core-bentley";
 import { HighlightInfo } from "../../common/HighlightingComponentProps";
 import { CategoryRecordsDict } from "../internal/flat-items/MutableGridCategory";

--- a/ui/components/src/components-react/propertygrid/dataproviders/filterers/CompositePropertyDataFilterer.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/filterers/CompositePropertyDataFilterer.ts
@@ -12,7 +12,7 @@ import { FilteredType, IPropertyDataFilterer, PropertyDataFiltererBase, Property
 
 /**
  * Logical operator for composite filterer.
- * @beta
+ * @public
  */
 export enum CompositeFilterType {
   And,
@@ -21,7 +21,7 @@ export enum CompositeFilterType {
 
 /**
  * Composite PropertyData filter which can join two filters using logic operators
- * @beta
+ * @public
  */
 export class CompositePropertyDataFilterer extends PropertyDataFiltererBase {
   public constructor(private _leftFilterer: IPropertyDataFilterer, private _operator: CompositeFilterType, private _rightFilterer: IPropertyDataFilterer) {

--- a/ui/components/src/components-react/propertygrid/dataproviders/filterers/DisplayValuePropertyDataFilterer.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/filterers/DisplayValuePropertyDataFilterer.ts
@@ -12,7 +12,7 @@ import { FilteredType, PropertyDataFilterResult, PropertyRecordDataFiltererBase 
 
 /**
  * Property data filterer which matches on Primitive Property Record display value text.
- * @beta
+ * @public
  */
 export class DisplayValuePropertyDataFilterer extends PropertyRecordDataFiltererBase {
   private _filterText: string = "";

--- a/ui/components/src/components-react/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.ts
@@ -12,7 +12,7 @@ import { FilteredType, PropertyDataFilterResult, PropertyRecordDataFiltererBase 
 
 /**
  * PropertyData filter which matches on any record type label and includes descendant nodes on match
- * @beta
+ * @public
  */
 export class LabelPropertyDataFilterer extends PropertyRecordDataFiltererBase {
   private _filterText: string = "";

--- a/ui/components/src/components-react/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.ts
@@ -12,7 +12,7 @@ import { FilteredType, PropertyCategoryDataFiltererBase, PropertyDataFilterResul
 
 /**
  * PropertyData filterer which matches on PropertyCategory's label.
- * @beta
+ * @public
  */
 export class PropertyCategoryLabelFilterer extends PropertyCategoryDataFiltererBase {
   private _filterText: string = "";

--- a/ui/components/src/components-react/propertygrid/dataproviders/filterers/PropertyDataFiltererBase.ts
+++ b/ui/components/src/components-react/propertygrid/dataproviders/filterers/PropertyDataFiltererBase.ts
@@ -6,13 +6,13 @@
  * @module PropertyGrid
  */
 
-import { BeEvent } from "@itwin/core-bentley";
 import { PropertyRecord } from "@itwin/appui-abstract";
+import { BeEvent } from "@itwin/core-bentley";
 import { PropertyCategory } from "../../PropertyDataProvider";
 
 /**
  * Enumeration of possible component filtered types
- * @beta
+ * @public
  */
 export enum FilteredType {
   Category,
@@ -21,8 +21,8 @@ export enum FilteredType {
 }
 
 /**
- * Data structure for storing IPropertyDataFilterer matching results
- * @beta
+ * Data structure for storing [[IPropertyDataFilterer]] matching results
+ * @public
  */
 export interface PropertyDataFilterResult {
   /** Indicates whether provided item matched filter */
@@ -53,19 +53,20 @@ export interface PropertyDataFilterResult {
 
 /**
  * A signature for property data change listeners
- * @beta
+ * @public
  */
 export declare type PropertyFilterChangesListener = () => void;
 
 /**
  * An event broadcasted when property filter changes
- * @beta
+ * @public
  */
 export class PropertyFilterChangeEvent extends BeEvent<PropertyFilterChangesListener> { }
 
 /**
- * Interface to be implemented by Property Data Filter classes
- * @beta
+ * An interface for a filterer that filters [[PropertyData]] based on content of [[PropertyRecord]]
+ * and [[PropertyCategory]] objects.
+ * @public
  */
 export interface IPropertyDataFilterer {
   readonly isActive: boolean;
@@ -75,8 +76,8 @@ export interface IPropertyDataFilterer {
 }
 
 /**
- * PropertyDataFilter base which helps implement common logic between all IPropertyDataFilterer
- * @beta
+ * An abstract implementation of [[IPropertyDataFilterer]] to share common behavior between different implementations.
+ * @public
  */
 export abstract class PropertyDataFiltererBase implements IPropertyDataFilterer {
   public onFilterChanged: PropertyFilterChangeEvent = new PropertyFilterChangeEvent();
@@ -84,18 +85,22 @@ export abstract class PropertyDataFiltererBase implements IPropertyDataFilterer 
   public abstract recordMatchesFilter(node: PropertyRecord, parents: PropertyRecord[]): Promise<PropertyDataFilterResult>;
   public abstract categoryMatchesFilter(node: PropertyCategory, parents: PropertyCategory[]): Promise<PropertyDataFilterResult>;
 }
+
 /**
- * PropertyDataFilter base which is suited for only Category filtering
- * @beta
+ * An abstract implementation of [[IPropertyDataFilterer]] that can be used as base for all
+ * filterers that filter based on [[PropertyCategory]] content.
+ * @public
  */
 export abstract class PropertyCategoryDataFiltererBase extends PropertyDataFiltererBase {
   public async recordMatchesFilter(): Promise<PropertyDataFilterResult> {
     return { matchesFilter: !this.isActive };
   }
 }
+
 /**
- * PropertyDataFilter base which is suited for only Record filtering
- * @beta
+ * An abstract implementation of [[IPropertyDataFilterer]] that can be used as base for all
+ * filterers that filter based on [[PropertyRecord]] content.
+ * @public
  */
 export abstract class PropertyRecordDataFiltererBase extends PropertyDataFiltererBase {
   public async categoryMatchesFilter(): Promise<PropertyDataFilterResult> {

--- a/ui/components/src/components-react/propertygrid/internal/PropertyGridHooks.ts
+++ b/ui/components/src/components-react/propertygrid/internal/PropertyGridHooks.ts
@@ -15,8 +15,8 @@ import { IPropertyGridModel } from "./PropertyGridModel";
 import { IPropertyGridModelSource, PropertyGridModelSource } from "./PropertyGridModelSource";
 
 /**
- * Custom hook that gets propertyData from data provider and subscribes to further data changes.
- * @beta
+ * Custom hook that gets [[PropertyData]] from given [[IPropertyDataProvider]] and subscribes to further data changes.
+ * @public
  */
 export function usePropertyData(props: { dataProvider: IPropertyDataProvider }) {
   const { dataProvider } = props;
@@ -28,13 +28,13 @@ export function usePropertyData(props: { dataProvider: IPropertyDataProvider }) 
     });
   }, [dataProvider]);
 
-  // ForcedUpdate is added to dependency list to re-memo getData promise when onDataChanged emits an event.
+  // forcedUpdate is added to dependency list to re-memo getData promise when onDataChanged emits an event.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return useDebouncedAsyncValue(useCallback(async () => dataProvider.getData(), [dataProvider, forcedUpdate]));
 }
 
 /**
- * Custom hook that creates a PropertyGridModelSource and subscribes it to data updates from the data provider.
+ * Custom hook that creates a [[PropertyGridModelSource]] and subscribes it to data updates from the data provider.
  * @beta
  */
 export function usePropertyGridModelSource(props: { dataProvider: IPropertyDataProvider }) {
@@ -54,7 +54,7 @@ export function usePropertyGridModelSource(props: { dataProvider: IPropertyDataP
 }
 
 /**
- * Custom hook that creates memoized version of PropertyGridEventHandler that modifies given modelSource
+ * Custom hook that creates memoized version of [[PropertyGridEventHandler]] that modifies given modelSource
  * @beta
  */
 export function usePropertyGridEventHandler(props: { modelSource: IPropertyGridModelSource }) {


### PR DESCRIPTION
Promote property grid related APIs:
- Action button rendering
- Records' highlighting
- Filtering

Left `@beta`:
- Stuff related to `VirtualizedPropertyGrid` - we feel like it's not ready to be `@public` yet.
- Orientation and editing related props in `CommonPropertyGridProps` - I'm not sure about the state of those. @DanEastBentley can you have a look at them?