### PR TITLE
UI: Promote and prune ControlledTree APIs

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -601,7 +601,7 @@ export interface ControlledTreeProps extends CommonProps {
     noDataRenderer?: () => React.ReactElement;
     nodeHighlightingProps?: HighlightableTreeProps;
     nodeLoader: ITreeNodeLoader;
-    // @alpha
+    // @beta
     onItemsRendered?: (items: RenderedItemsRange) => void;
     selectionMode: SelectionMode;
     spinnerRenderer?: () => React.ReactElement;
@@ -982,14 +982,6 @@ export interface ErrorObserver<T> {
     error: (err: any) => void;
     // (undocumented)
     next?: (value: T) => void;
-}
-
-// @beta
-export interface ExtendedTreeNodeRendererProps extends TreeNodeRendererProps {
-    checkboxRenderer?: NodeCheckboxRenderer;
-    descriptionEnabled?: boolean;
-    imageLoader?: ITreeImageLoader;
-    nodeEditorRenderer?: TreeNodeEditorRenderer;
 }
 
 // @public
@@ -2763,7 +2755,7 @@ export interface ReactDataGridColumn extends ReactDataGrid.Column<any> {
     icon?: boolean;
 }
 
-// @alpha
+// @beta
 export interface RenderedItemsRange {
     // (undocumented)
     overscanStartIndex: number;
@@ -3979,10 +3971,10 @@ export class TreeModelSource {
     onModelChanged: BeUiEvent<[TreeModel, TreeModelChanges]>;
 }
 
-// @beta
+// @public
 export function TreeNodeEditor(props: TreeNodeEditorProps): JSX.Element;
 
-// @beta
+// @public
 export interface TreeNodeEditorProps {
     // @internal (undocumented)
     ignoreEditorBlur?: boolean;
@@ -3992,7 +3984,7 @@ export interface TreeNodeEditorProps {
     style?: React.CSSProperties;
 }
 
-// @beta
+// @public
 export type TreeNodeEditorRenderer = (props: TreeNodeEditorProps) => React.ReactNode;
 
 // @public
@@ -4045,21 +4037,23 @@ export interface TreeNodeLoadResult {
     loadedNodes: TreeNodeItem[];
 }
 
-// @beta
-export const TreeNodeRenderer: React.MemoExoticComponent<(props: ExtendedTreeNodeRendererProps) => JSX.Element>;
+// @public
+export const TreeNodeRenderer: React.MemoExoticComponent<(props: TreeNodeRendererProps) => JSX.Element>;
 
 // @public
 export interface TreeNodeRendererProps extends CommonProps {
-    // (undocumented)
+    checkboxRenderer?: NodeCheckboxRenderer;
+    descriptionEnabled?: boolean;
+    imageLoader?: ITreeImageLoader;
     node: TreeModelNode;
+    nodeEditorRenderer?: TreeNodeEditorRenderer;
     nodeHighlightProps?: HighlightableTreeNodeProps;
     // @internal
     onLabelRendered?: (node: TreeModelNode) => void;
-    // (undocumented)
     treeActions: TreeActions;
 }
 
-// @beta
+// @public
 export class TreeRenderer extends React.Component<TreeRendererProps> implements TreeRendererAttributes {
     // (undocumented)
     render(): JSX.Element;
@@ -4072,39 +4066,6 @@ export interface TreeRendererAttributes {
     scrollToNode(nodeId: string, alignment?: Alignment): void;
 }
 
-// @beta
-export interface TreeRendererContext {
-    highlightingEngine?: HighlightingEngine;
-    // (undocumented)
-    nodeLoader: ITreeNodeLoader;
-    nodeRenderer: (props: TreeNodeRendererProps) => React.ReactNode;
-    // @internal
-    onLabelRendered?: (node: TreeModelNode) => void;
-    // @internal
-    onNodeEditorClosed?: () => void;
-    // @internal
-    onNodeWidthMeasured?: (width: number) => void;
-    // (undocumented)
-    treeActions: TreeActions;
-    visibleNodes: VisibleTreeNodes;
-}
-
-// @beta
-export const
-/**
- * Context of [[TreeRenderer]] provider.
- * @beta
- */
-TreeRendererContextConsumer: React.ExoticComponent<React.ConsumerProps<TreeRendererContext>>;
-
-// @beta
-export const
-/**
- * Context of [[TreeRenderer]] provider.
- * @beta
- */
-TreeRendererContextProvider: React.ProviderExoticComponent<React.ProviderProps<TreeRendererContext>>;
-
 // @public
 export interface TreeRendererProps {
     height: number;
@@ -4113,7 +4074,7 @@ export interface TreeRendererProps {
     // (undocumented)
     nodeLoader: ITreeNodeLoader;
     nodeRenderer?: (props: TreeNodeRendererProps) => React.ReactNode;
-    // @alpha
+    // @beta
     onItemsRendered?: (renderedItems: RenderedItemsRange) => void;
     // @internal
     onNodeEditorClosed?: () => void;
@@ -4220,7 +4181,7 @@ export function useDebouncedAsyncValue<TReturn>(valueToBeResolved: undefined | (
     inProgress: boolean;
 };
 
-// @beta
+// @public
 export function usePagedTreeNodeLoader<TDataProvider extends TreeDataProvider>(dataProvider: TDataProvider, pageSize: number, modelSource: TreeModelSource): PagedTreeNodeLoader<TDataProvider>;
 
 // @public
@@ -4272,14 +4233,6 @@ export function useTreeModelSource(dataProvider: TreeDataProvider): TreeModelSou
 
 // @public
 export function useTreeNodeLoader<TDataProvider extends TreeDataProvider>(dataProvider: TDataProvider, modelSource: TreeModelSource): TreeNodeLoader<TDataProvider>;
-
-// @beta
-export const
-/**
- * Context of [[TreeRenderer]] provider.
- * @beta
- */
-useTreeRendererContext: <P>(component: React.ComponentType<P>) => TreeRendererContext;
 
 // @beta
 export class VirtualizedPropertyGrid extends React.Component<VirtualizedPropertyGridProps, VirtualizedPropertyGridState> {

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -103,7 +103,6 @@ public;EnumPropertyButtonGroupEditor
 public;EnumPropertyEditor 
 public;EnumTypeConverter 
 public;ErrorObserver
-beta;ExtendedTreeNodeRendererProps 
 public;FavoritePropertiesRenderer
 alpha;FavoritePropertyList(props: FavoritePropertyListProps): JSX.Element | null
 alpha;FavoritePropertyListProps
@@ -301,7 +300,7 @@ public;PropertyValueRendererManager
 public;PropertyView 
 public;PropertyViewProps 
 public;ReactDataGridColumn 
-alpha;RenderedItemsRange
+beta;RenderedItemsRange
 public;renderLinks: (text: string, links: LinkElementsInfo, highlight?: ((text: string) => React.ReactNode) | undefined) => React.ReactNode
 public;ResultSelector 
 public;ResultSelectorProps 
@@ -422,19 +421,18 @@ public;TreeModelNodePlaceholder
 public;TreeModelNodeType = TreeModelNode | TreeModelNodePlaceholder | TreeModelRootNode
 public;TreeModelRootNode
 public;TreeModelSource
-beta;TreeNodeEditor(props: TreeNodeEditorProps): JSX.Element
-beta;TreeNodeEditorProps
-beta;TreeNodeEditorRenderer = (props: TreeNodeEditorProps) => React.ReactNode
+public;TreeNodeEditor(props: TreeNodeEditorProps): JSX.Element
+public;TreeNodeEditorProps
+public;TreeNodeEditorRenderer = (props: TreeNodeEditorProps) => React.ReactNode
 public;TreeNodeEventArgs
 public;TreeNodeItem
 public;TreeNodeItemData = ImmediatelyLoadedTreeNodeItem & DelayLoadedTreeNodeItem
 public;TreeNodeLoader
 public;TreeNodeLoadResult
-beta;TreeNodeRenderer: React.MemoExoticComponent
+public;TreeNodeRenderer: React.MemoExoticComponent
 public;TreeNodeRendererProps 
-beta;TreeRenderer 
+public;TreeRenderer 
 public;TreeRendererAttributes
-beta;TreeRendererContext
 public;TreeRendererProps
 public;TreeSelectionChange
 public;TreeSelectionModificationEventArgs
@@ -447,7 +445,7 @@ public;Unsubscribable
 public;UrlPropertyValueRenderer 
 public;useAsyncValue: 
 alpha;useDebouncedAsyncValue
-beta;usePagedTreeNodeLoader
+public;usePagedTreeNodeLoader
 public;usePropertyData(props:
 beta;usePropertyGridEventHandler(props:
 beta;usePropertyGridModel(props:

--- a/common/changes/@itwin/components-react/ui-promote-tree-apis_2021-10-01-14-35.json
+++ b/common/changes/@itwin/components-react/ui-promote-tree-apis_2021-10-01-14-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -724,6 +724,10 @@ SAML support has officially been dropped as a supported workflow. All related AP
 | `MutableTreeModel.computeVisibleNodes`                     | `computeVisibleNodes` in @itwin/components-react                                                                              |
 | `TreeModelSource.getVisibleNodes`                          | memoized result of `computeVisibleNodes`                                                                                      |
 | `useVisibleTreeNodes`                                      | `useTreeModel` and `computeVisibleNodes`                                                                                      |
+| `TreeRendererContext`                                      | _eliminated_                                                                                                                  |
+| `TreeRendererContextProvider`                              | _eliminated_                                                                                                                  |
+| `TreeRendererContextConsumer`                              | _eliminated_                                                                                                                  |
+| `useTreeRendererContext`                                   | _eliminated_                                                                                                                  |
 | `ExtendedTreeNodeRendererProps`                            | `TreeNodeRendererProps`                                                                                                       |
 | `SignIn`                                                   | _eliminated_                                                                                                                  |
 | All drag & drop related APIs                               | Third party components. E.g. see this [example](https://www.itwinjs.org/sample-showcase/?group=UI+Trees&sample=drag-and-drop) |

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -714,16 +714,17 @@ SAML support has officially been dropped as a supported workflow. All related AP
 
 | Removed                                                    | Replacement                                                                                                                   |
 | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `hasFlag`                                                  | `hasSelectionModeFlag` in @itwin/components-react                                                                          |
+| `hasFlag`                                                  | `hasSelectionModeFlag` in @itwin/components-react                                                                             |
 | `StandardEditorNames`                                      | `StandardEditorNames` in @itwin/appui-abstract                                                                                |
 | `StandardTypeConverterTypeNames`                           | `StandardTypeNames` in @itwin/appui-abstract                                                                                  |
 | `StandardTypeNames`                                        | `StandardTypeNames` in @itwin/appui-abstract                                                                                  |
-| `Timeline`                                                 | `TimelineComponent` in @itwin/components-react                                                                             |
+| `Timeline`                                                 | `TimelineComponent` in @itwin/components-react                                                                                |
 | `ControlledTreeProps.treeEvents`                           | `ControlledTreeProps.eventsHandler`                                                                                           |
 | `ControlledTreeProps.visibleNodes`                         | `ControlledTreeProps.model`                                                                                                   |
-| `MutableTreeModel.computeVisibleNodes`                     | `computeVisibleNodes` in @itwin/components-react                                                                           |
+| `MutableTreeModel.computeVisibleNodes`                     | `computeVisibleNodes` in @itwin/components-react                                                                              |
 | `TreeModelSource.getVisibleNodes`                          | memoized result of `computeVisibleNodes`                                                                                      |
 | `useVisibleTreeNodes`                                      | `useTreeModel` and `computeVisibleNodes`                                                                                      |
+| `ExtendedTreeNodeRendererProps`                            | `TreeNodeRendererProps`                                                                                                       |
 | `SignIn`                                                   | _eliminated_                                                                                                                  |
 | All drag & drop related APIs                               | Third party components. E.g. see this [example](https://www.itwinjs.org/sample-showcase/?group=UI+Trees&sample=drag-and-drop) |
 | `DEPRECATED_Tree`, `BeInspireTree` and related APIs        | `ControlledTree`                                                                                                              |

--- a/ui/components/src/components-react/tree/controlled/TreeHooks.ts
+++ b/ui/components/src/components-react/tree/controlled/TreeHooks.ts
@@ -46,10 +46,9 @@ export function useTreeNodeLoader<TDataProvider extends TreeDataProvider>(dataPr
 }
 
 /**
- * Custom hook which creates a paging nodes' loader using the supplied data provider and model source. The
- * loader pulls nodes from the data provider and puts them into the model source.
- *
- * @beta
+ * Custom hook which creates a paging nodes' loader using the supplied data provider and model source. The loader pulls
+ * nodes from the data provider and puts them into the model source.
+ * @public
  */
 export function usePagedTreeNodeLoader<TDataProvider extends TreeDataProvider>(dataProvider: TDataProvider, pageSize: number, modelSource: TreeModelSource) {
   const createLoader = useCallback(() => new PagedTreeNodeLoader(dataProvider, modelSource, pageSize), [dataProvider, modelSource, pageSize]);

--- a/ui/components/src/components-react/tree/controlled/component/ControlledTree.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/ControlledTree.tsx
@@ -57,7 +57,7 @@ export interface ControlledTreeProps extends CommonProps {
   noDataRenderer?: () => React.ReactElement;
   /**
    * Callback that is invoked when rendered items range changes.
-   * @alpha
+   * @beta
    */
   onItemsRendered?: (items: RenderedItemsRange) => void;
   /** Width of the tree renderer. */

--- a/ui/components/src/components-react/tree/controlled/component/TreeNodeEditor.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/TreeNodeEditor.tsx
@@ -11,8 +11,9 @@ import { PrimitiveValue, PropertyDescription, PropertyRecord } from "@itwin/appu
 import { EditorContainer, PropertyUpdatedArgs } from "../../../editors/EditorContainer";
 import { TreeModelNode } from "../TreeModel";
 
-/** Properties for [[TreeNodeEditor]] component
- * @beta
+/**
+ * Properties for [[TreeNodeEditor]] component.
+ * @public
  */
 export interface TreeNodeEditorProps {
   /** Tree node which is in editing mode. */
@@ -21,20 +22,22 @@ export interface TreeNodeEditorProps {
   onCommit: (node: TreeModelNode, newValue: string) => void;
   /** Callback that is called when editing is canceled. */
   onCancel: () => void;
-
   /** Editor style. */
   style?: React.CSSProperties;
+
   /** @internal */
   ignoreEditorBlur?: boolean;
 }
 
-/** Type for tree node editor renderer
- * @beta
+/**
+ * Type for tree node editor renderer.
+ * @public
  */
 export type TreeNodeEditorRenderer = (props: TreeNodeEditorProps) => React.ReactNode;
 
-/** React component for displaying tree node editor
- * @beta
+/**
+ * React component for displaying tree node editor.
+ * @public
  */
 export function TreeNodeEditor(props: TreeNodeEditorProps) {
   const onCommit = (args: PropertyUpdatedArgs) => {

--- a/ui/components/src/components-react/tree/controlled/component/TreeNodeRenderer.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/TreeNodeRenderer.tsx
@@ -23,11 +23,26 @@ import { TreeNodeEditorRenderer } from "./TreeNodeEditor";
  * @public
  */
 export interface TreeNodeRendererProps extends CommonProps {
+  /** Tree node to render. */
   node: TreeModelNode;
+
+  /** Action handler. */
   treeActions: TreeActions;
 
   /** Properties used to highlight matches when tree is filtered. */
   nodeHighlightProps?: HighlightableTreeNodeProps;
+
+  /** Specifies whether to show descriptions or not. */
+  descriptionEnabled?: boolean;
+
+  /** Image loader for node icons. */
+  imageLoader?: ITreeImageLoader;
+
+  /** Callback to render custom checkbox. */
+  checkboxRenderer?: NodeCheckboxRenderer;
+
+  /** Callback to render custom node editor when node is in editing mode. */
+  nodeEditorRenderer?: TreeNodeEditorRenderer;
 
   /**
    * Callback used to detect when label is rendered. It is used by TreeRenderer for scrolling to active match.
@@ -37,25 +52,10 @@ export interface TreeNodeRendererProps extends CommonProps {
 }
 
 /**
- * Extended properties for [[TreeNodeRenderer]].
- * @beta
- */
-export interface ExtendedTreeNodeRendererProps extends TreeNodeRendererProps {
-  /** Callback to render custom checkbox. */
-  checkboxRenderer?: NodeCheckboxRenderer;
-  /** Callback to render custom node editor when node is in editing mode. */
-  nodeEditorRenderer?: TreeNodeEditorRenderer;
-  /** Specifies whether to show descriptions or not. */
-  descriptionEnabled?: boolean;
-  /** Image loader used to load icon. */
-  imageLoader?: ITreeImageLoader;
-}
-
-/**
  * Default component for rendering tree node.
- * @beta
+ * @public
  */
-export const TreeNodeRenderer = React.memo((props: ExtendedTreeNodeRendererProps) => { // eslint-disable-line @typescript-eslint/naming-convention
+export const TreeNodeRenderer = React.memo((props: TreeNodeRendererProps) => {
   const label = (
     <TreeNodeContent
       key={props.node.id}

--- a/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -121,7 +121,7 @@ const [
   TreeRendererContextProvider,
 
   /** Context of [[TreeRenderer]] consumer. */
-  TreeRendererContextConsumer,
+  _TreeRendererContextConsumer,
 
   /** Custom hook to use [[TreeRenderer]] context. */
   useTreeRendererContext,

--- a/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -27,7 +27,7 @@ const NODE_LOAD_DELAY = 500;
 
 /**
  * Data structure that describes range of rendered items in the tree.
- * @alpha
+ * @beta
  */
 export interface RenderedItemsRange {
   overscanStartIndex: number;
@@ -58,7 +58,7 @@ export interface TreeRendererProps {
 
   /**
    * Callback that is called when rendered items range changes.
-   * @alpha
+   * @beta
    */
   onItemsRendered?: (renderedItems: RenderedItemsRange) => void;
 

--- a/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -128,8 +128,8 @@ const [
 ] = createContextWithMandatoryProvider<TreeRendererContext>("TreeRendererContext");
 
 /**
- * Default component for rendering tree.
- * @beta
+ * Default tree rendering component.
+ * @public
  */
 export class TreeRenderer extends React.Component<TreeRendererProps> implements TreeRendererAttributes {
   private _ref = React.createRef<TreeRendererAttributes>();

--- a/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -91,11 +91,8 @@ export interface TreeRendererAttributes {
 
 type Alignment = "auto" | "smart" | "center" | "end" | "start";
 
-/**
- * Context of [[TreeRenderer]] component.
- * @beta
- */
-export interface TreeRendererContext {
+/** [[TreeRenderer]] context that is provided to each rendered node. */
+interface TreeRendererContext {
   /** Callback to render custom node. */
   nodeRenderer: (props: TreeNodeRendererProps) => React.ReactNode;
 
@@ -108,48 +105,25 @@ export interface TreeRendererContext {
   /** Engine used to created node highlighting properties. */
   highlightingEngine?: HighlightingEngine;
 
-  /**
-   * Callback used detect when label is rendered. It is used by TreeRenderer for scrolling to active match.
-   * @internal
-   */
+  /** Callback used detect when label is rendered. It is used by TreeRenderer for scrolling to active match. */
   onLabelRendered?: (node: TreeModelNode) => void;
 
-  /**
-   * A callback that node calls after rendering to report its width
-   * @internal
-   */
+  /** A callback that node calls after rendering to report its width */
   onNodeWidthMeasured?: (width: number) => void;
 
-  /**
-   * Callback used when an editor closes
-   * @internal
-   */
+  /** Callback used when an editor closes */
   onNodeEditorClosed?: () => void;
 }
 
-/**
- * [[TreeRenderer]] context provider, consumer and custom hook.
- * @beta
- */
-export const [
-  /**
-   * Context of [[TreeRenderer]] provider.
-   * @beta
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+/** [[TreeRenderer]] context provider, consumer and custom hook. */
+const [
+  /** Context of [[TreeRenderer]] provider. */
   TreeRendererContextProvider,
 
-  /**
-   * Context of [[TreeRenderer]] consumer.
-   * @beta
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+  /** Context of [[TreeRenderer]] consumer. */
   TreeRendererContextConsumer,
 
-  /**
-   * Custom hook to use [[TreeRenderer]] context.
-   * @beta
-   */
+  /** Custom hook to use [[TreeRenderer]] context. */
   useTreeRendererContext,
 ] = createContextWithMandatoryProvider<TreeRendererContext>("TreeRendererContext");
 


### PR DESCRIPTION
Promotions from `alpha` to `beta` and from `beta` to `public`.

Hides `TreeRendererContext` API because it is only usable within `TreeNodeRenderer`.

Removes `ExtentedTreeNodeRendererProps` as it seems unnecessary.