### PR TITLE
Partial spirals on release/2.19.x

### DIFF
--- a/core/geometry/src/curve/spiral/DirectSpiral3d.ts
+++ b/core/geometry/src/curve/spiral/DirectSpiral3d.ts
@@ -507,7 +507,7 @@ export class DirectSpiral3d extends TransitionSpiral3d {
   /** Return length of the spiral.
    * * True length is stored at back of uvParams . . .
    */
-  public override curveLength() { return this.quickLength(); }
+  //   use the generic integrator ... public override curveLength() { return this.quickLength(); }
   /** Test if `other` is an instance of `TransitionSpiral3d` */
   public isSameGeometryClass(other: any): boolean { return other instanceof DirectSpiral3d; }
   /** Add strokes from this spiral to `dest`.

--- a/core/geometry/src/curve/spiral/DirectSpiral3d.ts
+++ b/core/geometry/src/curve/spiral/DirectSpiral3d.ts
@@ -455,12 +455,6 @@ export class DirectSpiral3d extends TransitionSpiral3d {
 
   /** Return (if possible) a spiral which is a portion of this curve. */
   public override clonePartialCurve(fractionA: number, fractionB: number): DirectSpiral3d | undefined {
-    if (fractionB < fractionA) {
-      const spiralA = this.clonePartialCurve(fractionB, fractionA);
-      if (spiralA)
-        spiralA.reverseInPlace();
-      return spiralA;
-    }
     const spiralB = this.clone();
     const globalFractionA = this._activeFractionInterval.fractionToPoint(fractionA);
     const globalFractionB  = this._activeFractionInterval.fractionToPoint(fractionB);

--- a/core/geometry/src/curve/spiral/DirectSpiral3d.ts
+++ b/core/geometry/src/curve/spiral/DirectSpiral3d.ts
@@ -452,6 +452,23 @@ export class DirectSpiral3d extends TransitionSpiral3d {
       this._activeFractionInterval?.clone(),
       this._evaluator.clone());
   }
+
+  /** Return (if possible) a spiral which is a portion of this curve. */
+  public override clonePartialCurve(fractionA: number, fractionB: number): DirectSpiral3d | undefined {
+    if (fractionB < fractionA) {
+      const spiralA = this.clonePartialCurve(fractionB, fractionA);
+      if (spiralA)
+        spiralA.reverseInPlace();
+      return spiralA;
+    }
+    const spiralB = this.clone();
+    const globalFractionA = this._activeFractionInterval.fractionToPoint(fractionA);
+    const globalFractionB  = this._activeFractionInterval.fractionToPoint(fractionB);
+    spiralB._activeFractionInterval.set(globalFractionA, globalFractionB);
+    spiralB.refreshComputedProperties();
+    return spiralB;
+  }
+
   /** apply `transform` to this spiral's local to world transform. */
   public tryTransformInPlace(transformA: Transform): boolean {
     const rigidData = this.applyRigidPartOfTransform(transformA);

--- a/core/geometry/src/curve/spiral/IntegratedSpiral3d.ts
+++ b/core/geometry/src/curve/spiral/IntegratedSpiral3d.ts
@@ -253,6 +253,23 @@ export class IntegratedSpiral3d extends TransitionSpiral3d {
       this.activeFractionInterval.clone(), this.localToWorld.clone(), this._arcLength01,
       this._designProperties?.clone());
   }
+
+  /** Return (if possible) a spiral which is a portion of this curve. */
+  public override clonePartialCurve(fractionA: number, fractionB: number): IntegratedSpiral3d | undefined {
+    if (fractionB < fractionA) {
+      const spiralA = this.clonePartialCurve(fractionB, fractionA);
+      if (spiralA)
+        spiralA.reverseInPlace();
+      return spiralA;
+    }
+    const spiralB = this.clone();
+    const globalFractionA = this._activeFractionInterval.fractionToPoint(fractionA);
+    const globalFractionB  = this._activeFractionInterval.fractionToPoint(fractionB);
+    spiralB._activeFractionInterval.set(globalFractionA, globalFractionB);
+    spiralB.refreshComputedProperties();
+    return spiralB;
+  }
+
   /** apply `transform` to this spiral's local to world transform. */
   public tryTransformInPlace(transformA: Transform): boolean {
 

--- a/core/geometry/src/curve/spiral/IntegratedSpiral3d.ts
+++ b/core/geometry/src/curve/spiral/IntegratedSpiral3d.ts
@@ -256,12 +256,6 @@ export class IntegratedSpiral3d extends TransitionSpiral3d {
 
   /** Return (if possible) a spiral which is a portion of this curve. */
   public override clonePartialCurve(fractionA: number, fractionB: number): IntegratedSpiral3d | undefined {
-    if (fractionB < fractionA) {
-      const spiralA = this.clonePartialCurve(fractionB, fractionA);
-      if (spiralA)
-        spiralA.reverseInPlace();
-      return spiralA;
-    }
     const spiralB = this.clone();
     const globalFractionA = this._activeFractionInterval.fractionToPoint(fractionA);
     const globalFractionB  = this._activeFractionInterval.fractionToPoint(fractionB);

--- a/core/geometry/src/curve/spiral/IntegratedSpiral3d.ts
+++ b/core/geometry/src/curve/spiral/IntegratedSpiral3d.ts
@@ -303,7 +303,11 @@ export class IntegratedSpiral3d extends TransitionSpiral3d {
   /** Return length of the spiral.  Because TransitionSpiral is parameterized directly in terms of distance along, this is a simple return value. */
   public quickLength() { return this._arcLength01; }
   /** Return length of the spiral.  Because TransitionSpiral is parameterized directly in terms of distance along, this is a simple return value. */
-  public override curveLength() { return this._arcLength01; }
+  public override curveLength() { return this._arcLength01 * (this._activeFractionInterval.absoluteDelta()); }
+  /** Return (unsigned) length of the spiral between fractions.  Because TransitionSpiral is parameterized directly in terms of distance along, this is a simple return value. */
+  public override curveLengthBetweenFractions(fraction0: number, fraction1: number) {
+    return this._arcLength01 * (this._activeFractionInterval.absoluteDelta() * Math.abs (fraction1 - fraction0));
+  }
   /** Test if `other` is an instance of `TransitionSpiral3d` */
   public isSameGeometryClass(other: any): boolean { return other instanceof TransitionSpiral3d; }
   /** Add strokes from this spiral to `dest`.

--- a/core/geometry/src/test/curve/TransitionSpiral3d.test.ts
+++ b/core/geometry/src/test/curve/TransitionSpiral3d.test.ts
@@ -905,7 +905,7 @@ describe("TransitionSpiral3d", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "TransitionSpiral3d", "spiralStroking");
   });
 
-  it("test TransitionSpiral3d clonePartialCurve", () => {
+  it.only("test TransitionSpiral3d clonePartialCurve", () => {
     const ck = new Checker();
     const nominalL1 = 100;
     const nominalR1 = 400;
@@ -932,7 +932,8 @@ describe("TransitionSpiral3d", () => {
     ck.testTrue(cloneD.isAlmostEqual(integratedSpiralReversed));
 
     // For each input spiral, clone partial and validate points/tangents and lengths are the same
-    for (const spiral of [simpleCubic, simpleCubicReversed, integratedSpiral, integratedSpiralReversed] ) {
+    for (const spiral of [simpleCubic, simpleCubicReversed, integratedSpiral, integratedSpiralReversed]) {
+      // console.log(spiral.spiralType);
       const partial = spiral.clonePartialCurve(0.2, 0.8)!;
       ck.testType(partial, TransitionSpiral3d);
       ck.testLT(partial.curveLength(), spiral.curveLength());

--- a/core/geometry/src/test/curve/TransitionSpiral3d.test.ts
+++ b/core/geometry/src/test/curve/TransitionSpiral3d.test.ts
@@ -905,7 +905,7 @@ describe("TransitionSpiral3d", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "TransitionSpiral3d", "spiralStroking");
   });
 
-  it.only("test TransitionSpiral3d clonePartialCurve", () => {
+  it("test TransitionSpiral3d clonePartialCurve", () => {
     const ck = new Checker();
     const nominalL1 = 100;
     const nominalR1 = 400;
@@ -935,8 +935,19 @@ describe("TransitionSpiral3d", () => {
     for (const spiral of [simpleCubic, simpleCubicReversed, integratedSpiral, integratedSpiralReversed]) {
       // console.log(spiral.spiralType);
       const partial = spiral.clonePartialCurve(0.2, 0.8)!;
+      ck.testTrue(spiral.spiralType === partial.spiralType);
       ck.testType(partial, TransitionSpiral3d);
       ck.testLT(partial.curveLength(), spiral.curveLength());
+
+      if (spiral instanceof IntegratedSpiral3d) {
+        // Length is proportional to total length
+        ck.testTightNumber(partial.curveLength(), 0.6 * spiral.curveLength());
+        ck.testTrue((partial as IntegratedSpiral3d).bearing01.isAlmostEqual(spiral.bearing01));
+        ck.testTrue((partial as IntegratedSpiral3d).radius01.isAlmostEqual(spiral.radius01));
+      } else {
+        ck.testExactNumber((partial as DirectSpiral3d).nominalL1, spiral.nominalL1);
+        ck.testExactNumber((partial as DirectSpiral3d).nominalR1, spiral.nominalR1);
+      }
 
       for (const fraction of [0.0, 0.2, 0.4, 0.5, 0.7, 1.0]) {
         const fSpiral = partial.activeFractionInterval.fractionToPoint(fraction);


### PR DESCRIPTION
Backport a change from master

-Add clonePartialCurve support on DirectSpiral3d and IntegratedSpiral3d classes. It is simply a deep clone with changes to the activeFractionInterval.

Length computations had to be adjusted to support partial spirals. (per Earlin)