### PR TITLE
Fix exception in cancelTileContentRequests

### DIFF
--- a/common/changes/@itwin/core-backend/fix-access-token-in-cancel-tile-requests_2021-10-05-10-34.json
+++ b/common/changes/@itwin/core-backend/fix-access-token-in-cancel-tile-requests_2021-10-05-10-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}


### PR DESCRIPTION
Induced by #2401. cancelTileContentRequests is an Ipc method - it should not be trying to access `RpcTrace.currentActivity!.accessToken` - currentActivity will be undefined.