### PR TITLE
MaskTreeReference must set isPlanProjection appropriately

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1975,7 +1975,7 @@ export function createDefaultViewFlagOverrides(options: {
 export function createEmptyRenderPlan(): RenderPlan;
 
 // @internal (undocumented)
-export function createMaskTreeReference(model: GeometricModelState): TileTreeReference;
+export function createMaskTreeReference(view: ViewState, model: GeometricModelState): TileTreeReference;
 
 // @internal (undocumented)
 export function createOrbitGtTileTreeReference(props: OrbitGtTileTree.ReferenceProps): RealityModelTileTree.Reference;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -96,7 +96,7 @@ internal;CoreTools
 internal;createClassifierTileTreeReference(classifiers: SpatialClassifiers, classifiedTree: TileTreeReference, iModel: IModelConnection, source: ViewState | DisplayStyleState): SpatialClassifierTileTreeReference
 internal;createDefaultViewFlagOverrides(options:
 internal;createEmptyRenderPlan(): RenderPlan
-internal;createMaskTreeReference(model: GeometricModelState): TileTreeReference
+internal;createMaskTreeReference(view: ViewState, model: GeometricModelState): TileTreeReference
 internal;createOrbitGtTileTreeReference(props: OrbitGtTileTree.ReferenceProps): RealityModelTileTree.Reference
 internal;createPrimaryTileTreeReference(view: ViewState, model: GeometricModelState): TileTreeReference
 internal;createRealityTileTreeReference(props: RealityModelTileTree.ReferenceProps): RealityModelTileTree.Reference

--- a/common/changes/@itwin/core-frontend/fix-plan-projection-exceptions_2021-10-05-11-03.json
+++ b/common/changes/@itwin/core-frontend/fix-plan-projection-exceptions_2021-10-05-11-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/PlanarClipMaskState.ts
+++ b/core/frontend/src/PlanarClipMaskState.ts
@@ -58,7 +58,7 @@ export class PlanarClipMaskState {
           const model = view.iModel.models.getLoaded(modelId);
           assert(model !== undefined);   // Models should be loaded by RealityModelTileTree
           if (model?.asGeometricModel)
-            this._tileTreeRefs.push(createMaskTreeReference(model.asGeometricModel));
+            this._tileTreeRefs.push(createMaskTreeReference(view, model.asGeometricModel));
         }
       }
     }

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -386,10 +386,17 @@ class MaskTreeReference extends TileTreeReference {
   private _owner: TileTreeOwner;
   public readonly model: GeometricModelState;
   public override get castsShadows() { return false; }
-  public constructor(model: GeometricModelState) {
+  public constructor(view: ViewState, model: GeometricModelState) {
     super();
     this.model = model;
-    this._id = { modelId: model.id, is3d: model.is3d, treeId: this.createTreeId(), isPlanProjection: false, forceNoInstancing: false };
+    this._id = {
+      modelId: model.id,
+      is3d: model.is3d,
+      treeId: this.createTreeId(),
+      isPlanProjection: isPlanProjection(view, model),
+      forceNoInstancing: false,
+    };
+
     this._owner = primaryTreeSupplier.getOwner(this._id, model.iModel);
   }
 
@@ -408,8 +415,8 @@ class MaskTreeReference extends TileTreeReference {
 }
 
 /** @internal */
-export function createMaskTreeReference(model: GeometricModelState): TileTreeReference {
-  return new MaskTreeReference(model);
+export function createMaskTreeReference(view: ViewState, model: GeometricModelState): TileTreeReference {
+  return new MaskTreeReference(view, model);
 }
 
 /** Provides [[TileTreeReference]]s for the loaded models present in a [[SpatialViewState]]'s [[ModelSelectorState]].


### PR DESCRIPTION
The nightly ImageTests runs have begun hanging due to a modal dialog popping up because of failed assertion in PlanProjectionTreeReference.computeBaseTransform.
MaskTreeReference always sets `isPlanProjection` to `false` in its tree Id, but whether or not it's a plan projection is determined by the model, not the tree reference.
Later, when we have a PlanProjectionTreeReference for the same model, we expect a PlanProjectionTileTree to have been created, but MaskTreeReference caused us to create an IModelTileTreeReference instead.
See PrimaryTreeSupplier.compareTileTreeIds.

We still need to figure out why display-performance-test-app is running with assertion enabled now, and popping up this dialog that doesn't look like one we created - probably some obscure regression from one of the massive PRs that recently completed. @wgoehrig any ideas?
![image](https://user-images.githubusercontent.com/22944042/136011773-fa7b4be7-1e2f-4464-92d9-7705d6ebb961.png)

