### PR TITLE
Allow multiple FeatureOverrides per tile per viewport

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2964,7 +2964,15 @@ export namespace FeatureSymbology {
         initFromView(view: ViewState): void;
         // @internal
         initFromViewport(viewport: Viewport): void;
-        }
+        // @alpha (undocumented)
+        get source(): Source | undefined;
+        // @alpha
+        static withSource(source: Source, view?: ViewState | Viewport): Overrides;
+    }
+    // @alpha
+    export interface Source {
+        readonly onSourceDisposed: BeEvent<() => void>;
+    }
 }
 
 // @public

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -153,6 +153,7 @@ internal;eyeToCartographicOnGlobe(viewport: ScreenViewport, preserveHeight?: boo
 internal;eyeToCartographicOnGlobeFromGcs(viewport: ScreenViewport, preserveHeight?: boolean): Promise
 public;FeatureOverrideProvider
 public;FeatureSymbology
+alpha;Source
 public;FitViewTool 
 internal;Flags
 public;FlashMode

--- a/common/changes/@itwin/core-frontend/feature-overrides-source_2021-10-05-17-09.json
+++ b/common/changes/@itwin/core-frontend/feature-overrides-source_2021-10-05-17-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Allow the same tile to be drawn repeatedly and efficiently in same Viewport with different symbology overrides.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/FeatureSymbology.ts
+++ b/core/frontend/src/render/FeatureSymbology.ts
@@ -18,7 +18,11 @@ import { ViewState } from "../ViewState";
  */
 export namespace FeatureSymbology {
   /** An object that serves as the source of a [[FeatureSymbology.Overrides]].
-   * ###TODO document me
+   * Use this if you are drawing the same tiles into a single Viewport and overriding the FeatureSymbology.Overrides defined for the view.
+   * Each tile will have a separate set of feature overrides per combination of Source and Viewport. This prevents the display system
+   * from constantly recomputing the feature overrides for a tile.
+   * You must call `onSourceDisposed.raiseEvent()` when the source is no longer being used by the Viewport to allow the feature overrides
+   * and their WebGL resources to be freed.
    * @alpha
    */
   export interface Source {

--- a/core/frontend/src/render/FeatureSymbology.ts
+++ b/core/frontend/src/render/FeatureSymbology.ts
@@ -23,7 +23,7 @@ export namespace FeatureSymbology {
    * Each tile will have a separate set of feature overrides per combination of Source and Viewport. This prevents the display system
    * from constantly recomputing the feature overrides for a tile.
    * You must call `onSourceDisposed.raiseEvent()` when the source is no longer being used by the Viewport to allow the feature overrides
-   * and their WebGL resources to be freed.
+   * and their WebGL resources to be freed - failure to do so will result in memory leaks, which may eventually produce WebGL context loss.
    * @alpha
    */
   export interface Source {

--- a/core/frontend/src/render/FeatureSymbology.ts
+++ b/core/frontend/src/render/FeatureSymbology.ts
@@ -6,7 +6,7 @@
  * @module Rendering
  */
 
-import { Id64 } from "@itwin/core-bentley";
+import { BeEvent, Id64 } from "@itwin/core-bentley";
 import { FeatureAppearance, FeatureOverrides } from "@itwin/core-common";
 import { Viewport } from "../Viewport";
 import { ViewState } from "../ViewState";
@@ -17,6 +17,14 @@ import { ViewState } from "../ViewState";
  * @public
  */
 export namespace FeatureSymbology {
+  /** An object that serves as the source of a [[FeatureSymbology.Overrides]].
+   * ###TODO document me
+   * @alpha
+   */
+  export interface Source {
+    readonly onSourceDisposed: BeEvent<() => void>;
+  }
+
   /** Allows a [[Viewport]] to customize the appearance of individual [Feature]($common)s within it.
    *
    * The Viewport computes its base Overrides based on the following:
@@ -41,6 +49,13 @@ export namespace FeatureSymbology {
    * @see [[Viewport.neverDrawn]]
    */
   export class Overrides extends FeatureOverrides {
+    private _source?: Source;
+
+    /** @alpha */
+    public get source(): Source | undefined {
+      return this._source;
+    }
+
     /** Construct a new Overrides. The result is an empty set of overrides if no view or viewport is supplied.
      * @param view If supplied, the overrides will be initialized based on the current state of the view or viewport.
      */
@@ -52,6 +67,13 @@ export namespace FeatureSymbology {
         else
           this.initFromView(view);
       }
+    }
+
+    /** @alpha */
+    public static withSource(source: Source, view?: ViewState | Viewport): Overrides {
+      const ovrs = new Overrides(view);
+      ovrs._source = source;
+      return ovrs;
     }
 
     /** Initialize these Overrides based on a specific view.

--- a/core/frontend/src/render/FeatureSymbology.ts
+++ b/core/frontend/src/render/FeatureSymbology.ts
@@ -26,6 +26,10 @@ export namespace FeatureSymbology {
    * @alpha
    */
   export interface Source {
+    /** An event raised when this source becomes disassociated with the viewport, indicating any WebGL resources allocated for it
+     * can be freed.
+     * Failure to invoke this event appropriately will result in memory leaks, which may eventually produce WebGL context loss.
+     */
     readonly onSourceDisposed: BeEvent<() => void>;
   }
 

--- a/core/frontend/src/render/FeatureSymbology.ts
+++ b/core/frontend/src/render/FeatureSymbology.ts
@@ -77,7 +77,9 @@ export namespace FeatureSymbology {
       }
     }
 
-    /** @alpha */
+    /** Create symbology overrides associated with a [[FeatureSymbology.Source]].
+     * @alpha
+     */
     public static withSource(source: Source, view?: ViewState | Viewport): Overrides {
       const ovrs = new Overrides(view);
       ovrs._source = source;

--- a/core/frontend/src/render/FeatureSymbology.ts
+++ b/core/frontend/src/render/FeatureSymbology.ts
@@ -18,7 +18,8 @@ import { ViewState } from "../ViewState";
  */
 export namespace FeatureSymbology {
   /** An object that serves as the source of a [[FeatureSymbology.Overrides]].
-   * Use this if you are drawing the same tiles into a single Viewport and overriding the FeatureSymbology.Overrides defined for the view.
+   * Use this if you are drawing the same tiles into a single Viewport and overriding the FeatureSymbology.Overrides applied to them
+   * by settings [[GraphicBranch.symbologyOverrides]].
    * Each tile will have a separate set of feature overrides per combination of Source and Viewport. This prevents the display system
    * from constantly recomputing the feature overrides for a tile.
    * You must call `onSourceDisposed.raiseEvent()` when the source is no longer being used by the Viewport to allow the feature overrides

--- a/core/frontend/src/render/webgl/FeatureOverrides.ts
+++ b/core/frontend/src/render/webgl/FeatureOverrides.ts
@@ -357,9 +357,9 @@ export class FeatureOverrides implements WebGLDisposable {
     const hilite = this.target.hilites;
     if (ovrsUpdated || hiliteUpdated || flashedId !== this._lastFlashId) {
       // _lut can be undefined if context was lost, (gl.createTexture returns null)
-      if (this._lut) {
+      if (this._lut)
         this._update(features, this._lut, this.target.flashed, undefined !== ovrs || hiliteUpdated ? hilite : undefined, ovrs);
-      }
+
       this._lastFlashId = flashedId;
     }
   }

--- a/core/frontend/src/render/webgl/Graphic.ts
+++ b/core/frontend/src/render/webgl/Graphic.ts
@@ -111,7 +111,8 @@ export class PerTargetBatchData {
     const source = this.target.currentFeatureSymbologyOverrides?.source;
     let ovrs = this._featureOverrides.get(source);
     if (!ovrs) {
-      this._featureOverrides.set(source, ovrs = FeatureOverrides.createFromTarget(this.target, batch.options));
+      const cleanup = source ? source.onSourceDisposed.addOnce(() => this.onSourceDisposed(source)) : undefined;
+      this._featureOverrides.set(source, ovrs = FeatureOverrides.createFromTarget(this.target, batch.options, cleanup));
       ovrs.initFromMap(batch.featureTable);
     }
 
@@ -129,6 +130,14 @@ export class PerTargetBatchData {
 
   /** Exposed strictly for tests. */
   public get featureOverrides() { return this._featureOverrides; }
+
+  private onSourceDisposed(source: FeatureSymbology.Source): void {
+    const ovrs = this._featureOverrides.get(source);
+    if (ovrs) {
+      this._featureOverrides.delete(source);
+      ovrs.dispose();
+    }
+  }
 }
 
 /** @internal exported strictly for tests. */

--- a/core/frontend/src/test/render/webgl/Batch.test.ts
+++ b/core/frontend/src/test/render/webgl/Batch.test.ts
@@ -12,11 +12,10 @@ import { FeatureSymbology } from "../../../render/FeatureSymbology";
 import { GraphicBranch } from "../../../render/GraphicBranch";
 import { Target } from "../../../render/webgl/Target";
 import { Batch, Branch } from "../../../render/webgl/Graphic";
-import { FeatureOverrides } from "../../../render/webgl/FeatureOverrides";
 
 describe("Batch", () => {
-  before(async () => await IModelApp.startup());
-  after(async () => await IModelApp.shutdown());
+  before(async () => IModelApp.startup());
+  after(async () => IModelApp.shutdown());
 
   function makeTarget(): Target {
     const rect = new ViewRect(0, 0, 100, 50);
@@ -126,14 +125,14 @@ describe("Batch", () => {
         updated: boolean;
       }
 
-      function reset(ovrs: Overrides[]): void {
-        for (const ovr of ovrs)
+      function reset(overrides: Overrides[]): void {
+        for (const ovr of overrides)
           ovr.updated = false;
       }
 
-      function hook(ovrs: Overrides[]): void {
-        reset(ovrs);
-        for (const ovr of ovrs)
+      function hook(overrides: Overrides[]): void {
+        reset(overrides);
+        for (const ovr of overrides)
           ovr.buildLookupTable = () => ovr.updated = true;
       }
 

--- a/core/frontend/src/test/render/webgl/Batch.test.ts
+++ b/core/frontend/src/test/render/webgl/Batch.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { BeEvent } from "@itwin/core-bentley";
+import { Range3d, Transform } from "@itwin/core-geometry";
+import { Feature, FeatureTable, PackedFeatureTable } from "@itwin/core-common";
+import { ViewRect } from "../../../ViewRect";
+import { IModelApp } from "../../../IModelApp";
+import { FeatureSymbology } from "../../../render/FeatureSymbology";
+import { GraphicBranch } from "../../../render/GraphicBranch";
+import { Target } from "../../../render/webgl/Target";
+import { Batch, Branch } from "../../../render/webgl/Graphic";
+
+describe("Batch", () => {
+  before(async () => await IModelApp.startup());
+  after(async () => await IModelApp.shutdown());
+
+  function makeTarget(): Target {
+    const rect = new ViewRect(0, 0, 100, 50);
+    const target = IModelApp.renderSystem.createOffscreenTarget(rect);
+    expect(target).instanceof(Target);
+    return target as Target;
+  }
+
+  function makeBranch(ovrs?: FeatureSymbology.Overrides): Branch {
+    const branch = new GraphicBranch();
+    branch.symbologyOverrides = ovrs;
+    const graphic = IModelApp.renderSystem.createGraphicBranch(branch, Transform.identity);
+    expect(graphic).instanceOf(Branch);
+    return graphic as Branch;
+  }
+
+  function makeBatch(): Batch {
+    const featureTable = new FeatureTable(100, "0x123");
+    featureTable.insertWithIndex(new Feature("0x456", "0x789"), 0);
+    const graphic = IModelApp.renderSystem.createGraphicList([]);
+    const batch = IModelApp.renderSystem.createBatch(graphic, PackedFeatureTable.pack(featureTable), Range3d.createNull());
+    expect(batch).instanceOf(Batch);
+    return batch as Batch;
+  }
+
+  function makeOverrides(source?: FeatureSymbology.Source): FeatureSymbology.Overrides {
+    return source ? FeatureSymbology.Overrides.withSource(source) : new FeatureSymbology.Overrides();
+  }
+
+  function makeSource(): FeatureSymbology.Source {
+    return {
+      onSourceDisposed: new BeEvent<() => void>(),
+    };
+  }
+
+  describe("feature overrides", () => {
+    it("is allocated per combination of target, batch, and source", () => {
+      const t1 = makeTarget();
+      const br1 = makeBranch();
+      const ba1 = makeBatch();
+      const o1 = makeOverrides();
+
+      expect(ba1.perTargetData.data.length).to.equal(0);
+
+      t1.overrideFeatureSymbology(o1);
+      t1.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(1);
+      t1.popBatch();
+
+      t1.pushBranch(br1);
+      t1.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(1);
+      expect(ba1.perTargetData.data[0].featureOverrides.size).to.equal(1);
+      expect(ba1.perTargetData.data[0].featureOverrides.get(undefined)).not.to.be.undefined;
+      t1.popBatch();
+      t1.popBranch();
+
+      const br2 = makeBranch();
+      t1.pushBranch(br2);
+      t1.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(1);
+      expect(ba1.perTargetData.data[0].featureOverrides.size).to.equal(1);
+      t1.popBatch();
+      t1.popBranch();
+
+      const s1 = makeSource();
+      const br3 = makeBranch(makeOverrides(s1));
+      t1.pushBranch(br3);
+      t1.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(1);
+      expect(ba1.perTargetData.data[0].featureOverrides.size).to.equal(2);
+      expect(ba1.perTargetData.data[0].featureOverrides.get(s1)).not.to.be.undefined;
+      t1.popBatch();
+      t1.popBranch();
+
+      const br4 = makeBranch(makeOverrides(s1));
+      t1.pushBranch(br4);
+      t1.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(1);
+      expect(ba1.perTargetData.data[0].featureOverrides.size).to.equal(2);
+      t1.popBatch();
+      t1.popBranch();
+
+      const t2 = makeTarget();
+      t2.pushBranch(br3);
+      t2.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(2);
+      expect(ba1.perTargetData.data[0].featureOverrides.size).to.equal(2);
+      expect(ba1.perTargetData.data[1].featureOverrides.size).to.equal(1);
+      t2.popBatch();
+      t2.popBranch();
+
+      const s2 = makeSource();
+      const br5 = makeBranch(makeOverrides(s2));
+      t2.pushBranch(br5);
+      t2.pushBatch(ba1);
+      expect(ba1.perTargetData.data.length).to.equal(2);
+      expect(ba1.perTargetData.data[1].featureOverrides.get(s1)).not.to.be.undefined;
+      expect(ba1.perTargetData.data[1].featureOverrides.get(s2)).not.to.be.undefined;
+      expect(ba1.perTargetData.data[1].featureOverrides.size).to.equal(2);
+      t2.popBatch();
+      t2.popBranch();
+    });
+
+    it("is recomputed only when the associated symbology overrides change", () => {
+    });
+
+    it("is updated when flash or hilite changes", () => {
+    });
+
+    it("is disposed when batch, target, or source is disposed", () => {
+    });
+  });
+});

--- a/full-stack-tests/core/src/frontend/standalone/FeatureOverrides.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/FeatureOverrides.test.ts
@@ -49,7 +49,7 @@ describe("FeatureOverrides", () => {
     vp = ScreenViewport.create(viewDiv, vpView);
 
     vp.target.setHiliteSet(new HiliteSet(imodel));
-    const ovr = FeatureOverrides.createFromTarget(vp.target as Target, {});
+    const ovr = FeatureOverrides.createFromTarget(vp.target as Target, {}, undefined);
     const features = new FeatureTable(1);
     features.insertWithIndex(new Feature(Id64.fromString("0x1")), 0);
 
@@ -74,7 +74,7 @@ describe("FeatureOverrides", () => {
     vp = ScreenViewport.create(viewDiv, vpView);
 
     vp.target.setHiliteSet(new HiliteSet(imodel));
-    const ovr = FeatureOverrides.createFromTarget(vp.target as Target, {});
+    const ovr = FeatureOverrides.createFromTarget(vp.target as Target, {}, undefined);
     const features = new FeatureTable(2);
     features.insertWithIndex(new Feature(Id64.fromString("0x1")), 0);
     features.insertWithIndex(new Feature(Id64.fromString("0x2")), 1);


### PR DESCRIPTION
OpenCitiesPlanner draws the same tiles repeatedly into the same viewport, applying different symbology overrides each time.
This causes the texture by which we pass the overrides to the GPU to be recomputed constantly and unnecessarily.
Introduced the concept of FeatureSymbology.Source which can be associated with a FeatureSymbology.Overrides.
Now, instead of caching the textures by the combination of tile (aka "batch") and viewport (aka "target"), we cache by the combination of tile and viewport and source.
It is imperative that the caller raise the onSourceDisposed event when the source becomes dissociated from the viewport so we can reclaim the texture memory.

TODO: Backport to 2.19.x.