### PR TITLE
Remove the chrome debugger extension as it is now built-in to VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "streetsidesoftware.code-spell-checker",
-    "msjsdiag.debugger-for-chrome",
     "dbaeumer.vscode-eslint",
     "davidanson.vscode-markdownlint",
     "mike-co.import-sorter"


### PR DESCRIPTION
The list of recommendations is outdated as the latest VSCode versions come with the functionality already built-in this Extension provides.