### PR TITLE
Reality data connection

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -1656,6 +1656,8 @@ export class ContextRealityModel {
     set planarClipMaskSettings(settings: PlanarClipMaskSettings | undefined);
     // (undocumented)
     protected readonly _props: ContextRealityModelProps;
+    // @alpha
+    readonly rdSourceKey?: RealityDataSourceKey;
     readonly realityDataId?: string;
     toJSON(): ContextRealityModelProps;
     readonly url: string;
@@ -1670,6 +1672,8 @@ export interface ContextRealityModelProps {
     // @alpha
     orbitGtBlob?: OrbitGtBlobProps;
     planarClipMask?: PlanarClipMaskProps;
+    // @alpha
+    rdSourceKey?: RealityDataSourceKey;
     realityDataId?: string;
     tilesetUrl: string;
 }
@@ -6226,6 +6230,32 @@ export interface ReadableFormData extends Readable {
 
 // @internal
 export function readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription;
+
+// @alpha
+export enum RealityDataFormat {
+    OPC = "OPC",
+    ThreeDTile = "ThreeDTile"
+}
+
+// @alpha
+export enum RealityDataProvider {
+    CesiumIonAsset = "CesiumIonAsset",
+    ContextShare = "ContextShare",
+    TilesetUrl = "TilesetUrl"
+}
+
+// @alpha
+export interface RealityDataSourceKey {
+    format: string;
+    id: string;
+    iTwinId?: string;
+    provider: string;
+}
+
+// @alpha
+export interface RealityDataSourceProps {
+    sourceKey: RealityDataSourceKey;
+}
 
 // @internal (undocumented)
 export const REGISTRY: unique symbol;

--- a/common/api/summary/imodeljs-common.exports.csv
+++ b/common/api/summary/imodeljs-common.exports.csv
@@ -486,6 +486,10 @@ public;QueryResponseStatus
 public;Rank
 internal;ReadableFormData 
 internal;readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription
+alpha;RealityDataFormat
+alpha;RealityDataProvider
+alpha;RealityDataSourceKey
+alpha;RealityDataSourceProps
 internal;REGISTRY: unique symbol
 public;RelatedElement 
 public;RelatedElementProps

--- a/common/api/summary/imodeljs-frontend.exports.csv
+++ b/common/api/summary/imodeljs-frontend.exports.csv
@@ -301,6 +301,7 @@ internal;internalMapLayerImageryFormats: (typeof WmsMapLayerFormat)[]
 public;IntersectDetail 
 public;IpcApp
 public;IpcAppOptions
+alpha;IRealityDataConnection
 beta;isCheckboxFormatPropEditorSpec: (item: CustomFormatPropEditorSpec) => item is CheckboxFormatPropEditorSpec
 beta;isCustomQuantityTypeDefinition(item: QuantityTypeDefinition): item is CustomQuantityTypeDefinition
 beta;isTextInputFormatPropEditorSpec: (item: CustomFormatPropEditorSpec) => item is TextInputFormatPropEditorSpec
@@ -444,7 +445,10 @@ beta;QueryVisibleFeaturesOptions = QueryScreenFeaturesOptions | QueryTileFeature
 internal;rangeToCartographicArea(view3d: ViewState3d, range: Range3d): GlobalLocationArea | undefined
 public;readElementGraphics(bytes: Uint8Array, iModel: IModelConnection, modelId: Id64String, is3d: boolean, options?: BatchOptions): Promise
 internal;readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, range: ElementAlignedBox3d, system: RenderSystem): RenderGraphic | undefined
+alpha;RealityDataConnectionManager
 public;RealityDataQueryCriteria
+alpha;RealityDataSource
+alpha;realityDataSourceKeyToString(rdSourceKey: RealityDataSourceKey): string
 internal;RealityModelSource = ViewState | DisplayStyleState
 internal;RealityModelTileClient
 internal;RealityModelTileTree 

--- a/common/changes/@bentley/imodeljs-common/RealityDataConnection_2021-10-05-16-48.json
+++ b/common/changes/@bentley/imodeljs-common/RealityDataConnection_2021-10-05-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Add a new property to ContextRealityModelState named rdSourecKey that provide a new way of attaching Reality Data that will resolve tilesetUrl at runtime.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "31048177+MarcBedard8@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/RealityDataConnection_2021-10-05-16-48.json
+++ b/common/changes/@bentley/imodeljs-frontend/RealityDataConnection_2021-10-05-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Add a new property to ContextRealityModelState named rdSourecKey that provide a new way of attaching Reality Data that will resolve tilesetUrl at runtime.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "31048177+MarcBedard8@users.noreply.github.com"
+}

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -6,11 +6,45 @@
  * @module DisplayStyles
  */
 
-import { assert, BeEvent } from "@bentley/bentleyjs-core";
-import { SpatialClassifierProps, SpatialClassifiers } from "./SpatialClassification";
-import { PlanarClipMaskMode, PlanarClipMaskProps, PlanarClipMaskSettings } from "./PlanarClipMask";
+import { assert, BeEvent, GuidString } from "@bentley/bentleyjs-core";
 import { FeatureAppearance, FeatureAppearanceProps } from "./FeatureSymbology";
+import { PlanarClipMaskMode, PlanarClipMaskProps, PlanarClipMaskSettings } from "./PlanarClipMask";
+import { SpatialClassifierProps, SpatialClassifiers } from "./SpatialClassification";
 
+/** Controls whether the user has exclusive or shared access to a local briefcase
+ * @alpha
+ */
+export enum RealityDataProvider {
+  /** The logger category used by iModelHub clients */
+  TilesetUrl = "TilesetUrl",   // This is the legacy mode where the access to the 3d tiles is harcoded in tilesetUrl property.
+  ContextShare = "ContextShare", // Will resolve tilesetUrl from realityDataId and iTwinId on contextShare.
+}
+
+/** JSON representation of the reality data reference attachment properties.
+ * @alpha
+ */
+export interface RealityDataSourceProps {
+  /** The provider that supplies the 3d tiles for displaying the reality model. */
+  provider: RealityDataProvider;
+  /** The reality data id that identify a reality data for the provider. */
+  realityDataId?: string;
+  /** The iTwin id that identify the "context" for the provider. */
+  iTwinId?: GuidString;
+  /** The URL that supplies the 3d tiles for displaying the reality model*/
+  tilesetUrl?: string;
+}
+export interface RealityDataConnectionProps {
+  /** The provider that supplies the 3d tiles for displaying the reality model. */
+  provider: RealityDataProvider;
+  /** The reality data id that identify a reality data for the provider. */
+  realityDataId?: string;
+  /** The iTwin id that identify the "context" for the provider. */
+  iTwinId?: GuidString;
+  /** The reality data type of this reality data meaningful to the provider. */
+  realityDataType?: string;
+  /** The URL that supplies the 3d tiles for displaying the reality model*/
+  tilesetUrl: string;
+}
 /** JSON representation of the blob properties for an OrbitGt property cloud.
  * @alpha
  */
@@ -26,6 +60,8 @@ export interface OrbitGtBlobProps {
  * @public
  */
 export interface ContextRealityModelProps {
+  /** The source that supplies the 3d tiles for displaying the reality model.*/
+  rdConnection?: RealityDataConnectionProps;
   /** The URL that supplies the 3d tiles for displaying the reality model. */
   tilesetUrl: string;
   /** @see [[ContextRealityModel.orbitGtBlob]].
@@ -53,6 +89,9 @@ export namespace ContextRealityModelProps {
     // Spread operator is shallow, and includes `undefined` properties and empty strings.
     // We want to make deep copies, omit undefined properties and empty strings, and require tilesetUrl to be defined.
     const output: ContextRealityModelProps = { tilesetUrl: input.tilesetUrl ?? "" };
+
+    if (input.rdConnection)
+      output.rdConnection = { ...input.rdConnection };
 
     if (input.name)
       output.name = input.name;

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -22,7 +22,7 @@ export interface OrbitGtBlobProps {
   accountName: string;
 }
 
-/** Identify the Reality Data service provider and storage formats supported by this provider
+/** Identify the Reality Data service provider
  * @alpha
  */
 export enum RealityDataProvider {
@@ -45,37 +45,32 @@ export enum RealityDataProvider {
   CesiumIonAsset = "CesiumIonAsset",
 }
 
-export type RealityDataProviderString = keyof typeof RealityDataProvider;
-
-export enum RealityDataFormat {
+/** Identify the Reality Data storage format
+ * @alpha
+ */export enum RealityDataFormat {
   /**
-   * This is the legacy mode where the access to the 3d tiles is harcoded in ContextRealityModelProps.tilesetUrl property.
-   * It was use to support RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles
-   * You should use other mode when possible
-   * @see [[RealityDataSource.createRealityDataSourceKeyFromUrl]] that will try to detect provider from an URL
+   * 3dTile supported formats; RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles
    * */
   ThreeDTile = "ThreeDTile",
   /**
-   * Will provide access url from realityDataId and iTwinId on contextShare for OPC storage format
-   * This is the mode that support PointCloud OPC storage format (RealityDataType.OPC)
+   * Orbit Point Cloud (OPC) storage format (RealityDataType.OPC)
   */
   OPC = "OPC",
 }
-export type RealityDataFormatString = keyof typeof RealityDataFormat;
 
 // Key used by ContextShare RealityDataProvider
 export interface RealityDataSourceKey {
   /**
    * The provider that supplies the access to reality data source for displaying the reality model
-   * @see [[RealityDataProviderString]] for default supported value;
+   * @see [[RealityDataProvider]] for default supported value;
    *
   */
   provider: string;
   /**
    * The format used by the provider to store the reality data
-   * @see [[RealityDataFormatString]] for default supported value;
+   * @see [[RealityDataFormat]] for default supported value;
   */
-  format: RealityDataFormat;
+  format: string;
   /** The reality data id that identify a reality data for the provider */
   id: string;
   /** The context id that was used when reality data was attached - if none provided, current session iTwinId will be used */

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -40,14 +40,15 @@ export enum RealityDataProvider {
   */
   ContextShare = "ContextShare",
   /**
-   * Will provide Open Street Map Building (OCM) from Cesium Ion (in 3dTile format)
+   * Will provide Open Street Map Building (OSM) from Cesium Ion (in 3dTile format)
   */
   CesiumIonAsset = "CesiumIonAsset",
 }
 
 /** Identify the Reality Data storage format
  * @alpha
- */export enum RealityDataFormat {
+ */
+export enum RealityDataFormat {
   /**
    * 3dTile supported formats; RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles
    * */
@@ -58,12 +59,14 @@ export enum RealityDataProvider {
   OPC = "OPC",
 }
 
-// Key used by ContextShare RealityDataProvider
+/**
+ * Key used by ContextShare RealityDataProvider
+ * @alpha
+ */
 export interface RealityDataSourceKey {
   /**
    * The provider that supplies the access to reality data source for displaying the reality model
    * @see [[RealityDataProvider]] for default supported value;
-   *
   */
   provider: string;
   /**
@@ -84,12 +87,7 @@ export interface RealityDataSourceProps {
   /** The source key that identify a reality data for the provider. */
   sourceKey: RealityDataSourceKey;
 }
-export interface RealityDataConnectionProps {
-  /** The source key that identify a reality data for the provider. */
-  sourceKey: RealityDataSourceKey;
-  /** The URL that supplies the 3d tiles for displaying the reality model*/
-  tilesetUrl: string;
-}
+
 /** JSON representation of a [[ContextRealityModel]].
  * @public
  */
@@ -97,6 +95,7 @@ export interface ContextRealityModelProps {
   /**
    * The reality data source key identify the reality data provider and storage format.
    * It takes precedence over tilesetUrl and orbitGtBlob when present and can be use to actually replace these properties.
+   * @alpha
    */
   rdSourceKey?: RealityDataSourceKey;
   /** The URL that supplies the 3d tiles for displaying the reality model. */
@@ -168,6 +167,7 @@ export class ContextRealityModel {
   protected readonly _props: ContextRealityModelProps;
   /**
    * The reality data source key identify the reality data provider and storage format.
+   * @alpha
    */
   public readonly  rdSourceKey?: RealityDataSourceKey;
   /** A name suitable for display in a user interface. By default, an empty string. */

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -11,40 +11,6 @@ import { FeatureAppearance, FeatureAppearanceProps } from "./FeatureSymbology";
 import { PlanarClipMaskMode, PlanarClipMaskProps, PlanarClipMaskSettings } from "./PlanarClipMask";
 import { SpatialClassifierProps, SpatialClassifiers } from "./SpatialClassification";
 
-/** Controls whether the user has exclusive or shared access to a local briefcase
- * @alpha
- */
-export enum RealityDataProvider {
-  /** The logger category used by iModelHub clients */
-  TilesetUrl = "TilesetUrl",   // This is the legacy mode where the access to the 3d tiles is harcoded in tilesetUrl property.
-  ContextShare = "ContextShare", // Will resolve tilesetUrl from realityDataId and iTwinId on contextShare.
-}
-
-/** JSON representation of the reality data reference attachment properties.
- * @alpha
- */
-export interface RealityDataSourceProps {
-  /** The provider that supplies the 3d tiles for displaying the reality model. */
-  provider: RealityDataProvider;
-  /** The reality data id that identify a reality data for the provider. */
-  realityDataId?: string;
-  /** The iTwin id that identify the "context" for the provider. */
-  iTwinId?: GuidString;
-  /** The URL that supplies the 3d tiles for displaying the reality model*/
-  tilesetUrl?: string;
-}
-export interface RealityDataConnectionProps {
-  /** The provider that supplies the 3d tiles for displaying the reality model. */
-  provider: RealityDataProvider;
-  /** The reality data id that identify a reality data for the provider. */
-  realityDataId?: string;
-  /** The iTwin id that identify the "context" for the provider. */
-  iTwinId?: GuidString;
-  /** The reality data type of this reality data meaningful to the provider. */
-  realityDataType?: string;
-  /** The URL that supplies the 3d tiles for displaying the reality model*/
-  tilesetUrl: string;
-}
 /** JSON representation of the blob properties for an OrbitGt property cloud.
  * @alpha
  */
@@ -56,12 +22,54 @@ export interface OrbitGtBlobProps {
   accountName: string;
 }
 
+/** Controls whether the user has exclusive or shared access to a local briefcase
+ * @alpha
+ */
+export enum RealityDataProvider {
+  TilesetUrl = "TilesetUrl",   // This is the legacy mode where the access to the 3d tiles is harcoded in tilesetUrl property.
+  ContextShare = "ContextShare", // Will resolve tilesetUrl from realityDataId and iTwinId on contextShare.
+  ContextShareOrbitGt = "ContextShareOrbitGt", // Will resolve tilesetUrl from realityDataId and iTwinId on contextShare but use OrbitGt TileTree implementation
+}
+
+// Key used by ContextShare RealityDataProvider
+export interface RealityDataSourceContextShareKey {
+  /** The provider that supplies the 3d tiles for displaying the reality model. */
+  provider: RealityDataProvider;
+  /** The reality data id that identify a reality data for the provider. */
+  realityDataId: string;
+  /** The iTwin id that identify the "context" for the provider. If undefined, will use current context (iTwinId) */
+  iTwinId?: GuidString;
+}
+
+// Key used by TilesetUrl RealityDataProvider
+export interface RealityDataSourceURLKey {
+  /** The provider that supplies the 3d tiles for displaying the reality model. */
+  provider: RealityDataProvider;
+  /** The URL that supplies the 3d tiles for displaying the reality model*/
+  tilesetUrl: string;
+}
+
+export type RealityDataSourceKey = RealityDataSourceContextShareKey | RealityDataSourceURLKey;
+
+/** JSON representation of the reality data reference attachment properties.
+ * @alpha
+ */
+export interface RealityDataSourceProps {
+  /** The source key that identify a reality data for the provider. */
+  sourceKey: RealityDataSourceKey;
+}
+export interface RealityDataConnectionProps {
+  /** The source key that identify a reality data for the provider. */
+  sourceKey: RealityDataSourceKey;
+  /** The URL that supplies the 3d tiles for displaying the reality model*/
+  tilesetUrl: string;
+}
 /** JSON representation of a [[ContextRealityModel]].
  * @public
  */
 export interface ContextRealityModelProps {
   /** The source that supplies the 3d tiles for displaying the reality model.*/
-  rdConnection?: RealityDataConnectionProps;
+  rdSourceKey?: RealityDataSourceKey;
   /** The URL that supplies the 3d tiles for displaying the reality model. */
   tilesetUrl: string;
   /** @see [[ContextRealityModel.orbitGtBlob]].
@@ -90,8 +98,8 @@ export namespace ContextRealityModelProps {
     // We want to make deep copies, omit undefined properties and empty strings, and require tilesetUrl to be defined.
     const output: ContextRealityModelProps = { tilesetUrl: input.tilesetUrl ?? "" };
 
-    if (input.rdConnection)
-      output.rdConnection = { ...input.rdConnection };
+    if (input.rdSourceKey)
+      output.rdSourceKey = { ...input.rdSourceKey };
 
     if (input.name)
       output.name = input.name;

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -43,6 +43,10 @@ export enum RealityDataProvider {
    * This is the mode that support PointCloud OPC storage format (RealityDataType.OPC)
   */
   ContextShareOrbitGt = "ContextShare:OPC",
+  /**
+   * Will provide Open Street Map Building (OCM) from Cesium Ion
+  */
+  CesiumIonAsset = "CesiumIonAsset:OCM"
 }
 
 // Key used by ContextShare RealityDataProvider
@@ -80,7 +84,10 @@ export interface RealityDataConnectionProps {
  * @public
  */
 export interface ContextRealityModelProps {
-  /** The source that supplies the 3d tiles for displaying the reality model.*/
+  /**
+   * The reality data source key identify the reality data provider and storage format.
+   * It takes precedence over tilesetUrl and orbitGtBlob when present and can be use to actually replace these properties.
+   */
   rdSourceKey?: RealityDataSourceKey;
   /** The URL that supplies the 3d tiles for displaying the reality model. */
   tilesetUrl: string;
@@ -149,6 +156,10 @@ export namespace ContextRealityModelProps {
  */
 export class ContextRealityModel {
   protected readonly _props: ContextRealityModelProps;
+  /**
+   * The reality data source key identify the reality data provider and storage format.
+   */
+  public readonly  rdSourceKey?: RealityDataSourceKey;
   /** A name suitable for display in a user interface. By default, an empty string. */
   public readonly name: string;
   /** The URL that supplies the 3d tiles for displaying the reality model. */
@@ -173,6 +184,7 @@ export class ContextRealityModel {
    */
   public constructor(props: ContextRealityModelProps) {
     this._props = props;
+    this.rdSourceKey = props.rdSourceKey;
     this.name = props.name ?? "";
     this.url = props.tilesetUrl ?? "";
     this.orbitGtBlob = props.orbitGtBlob;

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -6,7 +6,7 @@
  * @module DisplayStyles
  */
 
-import { assert, BeEvent, GuidString } from "@bentley/bentleyjs-core";
+import { assert, BeEvent } from "@bentley/bentleyjs-core";
 import { FeatureAppearance, FeatureAppearanceProps } from "./FeatureSymbology";
 import { PlanarClipMaskMode, PlanarClipMaskProps, PlanarClipMaskSettings } from "./PlanarClipMask";
 import { SpatialClassifierProps, SpatialClassifiers } from "./SpatialClassification";
@@ -22,13 +22,27 @@ export interface OrbitGtBlobProps {
   accountName: string;
 }
 
-/** Controls whether the user has exclusive or shared access to a local briefcase
+/** Identify the Reality Data service provider and storage formats supported by this provider
  * @alpha
  */
 export enum RealityDataProvider {
-  TilesetUrl = "TilesetUrl",   // This is the legacy mode where the access to the 3d tiles is harcoded in tilesetUrl property.
-  ContextShare = "ContextShare", // Will resolve tilesetUrl from realityDataId and iTwinId on contextShare.
-  ContextShareOrbitGt = "ContextShareOrbitGt", // Will resolve tilesetUrl from realityDataId and iTwinId on contextShare but use OrbitGt TileTree implementation
+  /**
+   * This is the legacy mode where the access to the 3d tiles is harcoded in ContextRealityModelProps.tilesetUrl property.
+   * It was use to support RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles
+   * You should use other mode when possible
+   * @see [[RealityDataSource.createRealityDataSourceKeyFromUrl]] that will try to detect provider from an URL
+   * */
+  TilesetUrl = "TilesetUrl:3dtile",
+  /**
+   * Will provide access url from realityDataId and iTwinId on contextShare for 3dTile storage format
+   * This provider support all type of 3dTile storage fomat: RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles,
+  */
+  ContextShare = "ContextShare:3dtile",
+  /**
+   * Will provide access url from realityDataId and iTwinId on contextShare for OPC storage format
+   * This is the mode that support PointCloud OPC storage format (RealityDataType.OPC)
+  */
+  ContextShareOrbitGt = "ContextShare:OPC",
 }
 
 // Key used by ContextShare RealityDataProvider
@@ -37,8 +51,6 @@ export interface RealityDataSourceContextShareKey {
   provider: RealityDataProvider;
   /** The reality data id that identify a reality data for the provider. */
   realityDataId: string;
-  /** The iTwin id that identify the "context" for the provider. If undefined, will use current context (iTwinId) */
-  iTwinId?: GuidString;
 }
 
 // Key used by TilesetUrl RealityDataProvider

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -32,40 +32,55 @@ export enum RealityDataProvider {
    * You should use other mode when possible
    * @see [[RealityDataSource.createRealityDataSourceKeyFromUrl]] that will try to detect provider from an URL
    * */
-  TilesetUrl = "TilesetUrl:3dtile",
+  TilesetUrl = "TilesetUrl",
   /**
-   * Will provide access url from realityDataId and iTwinId on contextShare for 3dTile storage format
-   * This provider support all type of 3dTile storage fomat: RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles,
+   * Will provide access url from realityDataId and iTwinId on contextShare for 3dTile storage format or  OPC storage format
+   * This provider support all type of 3dTile storage fomat and OrbitPointCloud: RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles, OPC
+   * @see [[RealityDataFormat]].
   */
-  ContextShare = "ContextShare:3dtile",
+  ContextShare = "ContextShare",
+  /**
+   * Will provide Open Street Map Building (OCM) from Cesium Ion (in 3dTile format)
+  */
+  CesiumIonAsset = "CesiumIonAsset",
+}
+
+export type RealityDataProviderString = keyof typeof RealityDataProvider;
+
+export enum RealityDataFormat {
+  /**
+   * This is the legacy mode where the access to the 3d tiles is harcoded in ContextRealityModelProps.tilesetUrl property.
+   * It was use to support RealityMesh3DTiles, Terrain3DTiles, Cesium3DTiles
+   * You should use other mode when possible
+   * @see [[RealityDataSource.createRealityDataSourceKeyFromUrl]] that will try to detect provider from an URL
+   * */
+  ThreeDTile = "ThreeDTile",
   /**
    * Will provide access url from realityDataId and iTwinId on contextShare for OPC storage format
    * This is the mode that support PointCloud OPC storage format (RealityDataType.OPC)
   */
-  ContextShareOrbitGt = "ContextShare:OPC",
-  /**
-   * Will provide Open Street Map Building (OCM) from Cesium Ion
-  */
-  CesiumIonAsset = "CesiumIonAsset:OCM"
+  OPC = "OPC",
 }
+export type RealityDataFormatString = keyof typeof RealityDataFormat;
 
 // Key used by ContextShare RealityDataProvider
-export interface RealityDataSourceContextShareKey {
-  /** The provider that supplies the 3d tiles for displaying the reality model. */
-  provider: RealityDataProvider;
-  /** The reality data id that identify a reality data for the provider. */
-  realityDataId: string;
+export interface RealityDataSourceKey {
+  /**
+   * The provider that supplies the access to reality data source for displaying the reality model
+   * @see [[RealityDataProviderString]] for default supported value;
+   *
+  */
+  provider: string;
+  /**
+   * The format used by the provider to store the reality data
+   * @see [[RealityDataFormatString]] for default supported value;
+  */
+  format: RealityDataFormat;
+  /** The reality data id that identify a reality data for the provider */
+  id: string;
+  /** The context id that was used when reality data was attached - if none provided, current session iTwinId will be used */
+  iTwinId?: string;
 }
-
-// Key used by TilesetUrl RealityDataProvider
-export interface RealityDataSourceURLKey {
-  /** The provider that supplies the 3d tiles for displaying the reality model. */
-  provider: RealityDataProvider;
-  /** The URL that supplies the 3d tiles for displaying the reality model*/
-  tilesetUrl: string;
-}
-
-export type RealityDataSourceKey = RealityDataSourceContextShareKey | RealityDataSourceURLKey;
 
 /** JSON representation of the reality data reference attachment properties.
  * @alpha

--- a/core/common/src/test/ContextRealityModel.test.ts
+++ b/core/common/src/test/ContextRealityModel.test.ts
@@ -22,6 +22,7 @@ describe("ContextRealityModel", () => {
 
   it("initializes from JSON", () => {
     let m = makeModel({ tilesetUrl: "a" });
+    expect(m.rdSourceKey).to.be.undefined;
     expect(m.url).to.equal("a");
     expect(m.name).to.equal("");
     expect(m.realityDataId).to.be.undefined;
@@ -32,6 +33,9 @@ describe("ContextRealityModel", () => {
     expect(m.planarClipMaskSettings).to.be.undefined;
 
     m = makeModel({
+      rdSourceKey: {
+        provider: "ContextShare", format: "ThreeDTile", id: "dummy",
+      },
       tilesetUrl: "b",
       name: "c",
       description: "d",
@@ -47,6 +51,7 @@ describe("ContextRealityModel", () => {
       },
       planarClipMask: { mode: PlanarClipMaskMode.Priority },
     });
+    expect(m.rdSourceKey).not.to.be.undefined;
     expect(m.url).to.equal("b");
     expect(m.name).to.equal("c");
     expect(m.description).to.equal("d");
@@ -106,7 +111,7 @@ describe("ContextRealityModel", () => {
 
   it("normalizes JSON when cloning", () => {
     const props: ContextRealityModelProps = {
-      tilesetUrl: "a", name: "", description: undefined, realityDataId: "", appearanceOverrides: undefined,
+      rdSourceKey: undefined, tilesetUrl: "a", name: "", description: undefined, realityDataId: "", appearanceOverrides: undefined,
       classifiers: undefined, orbitGtBlob: undefined, planarClipMask: undefined,
     };
     (props as any).tilesetUrl = undefined;
@@ -117,6 +122,9 @@ describe("ContextRealityModel", () => {
 
   it("clones deeply", () => {
     const props = {
+      rdSourceKey: {
+        provider: "ContextShare", format: "ThreeDTile", id: "dummy",
+      },
       tilesetUrl: "b",
       name: "c",
       description: "d",
@@ -137,6 +145,7 @@ describe("ContextRealityModel", () => {
     expect(clone).to.deep.equal(props);
     expect(clone).not.to.equal(props);
 
+    expect(clone.rdSourceKey).to.deep.equal(props.rdSourceKey);
     expect(clone.orbitGtBlob).not.to.equal(props.orbitGtBlob);
     expect(clone.planarClipMask).not.to.equal(props.planarClipMask);
 

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -9,7 +9,7 @@
 import { GuidString, Id64String } from "@bentley/bentleyjs-core";
 import { Angle } from "@bentley/geometry-core";
 import {
-  CartographicRange, ContextRealityModel, ContextRealityModelProps, FeatureAppearance, OrbitGtBlobProps, RealityDataProvider,
+  CartographicRange, ContextRealityModel, ContextRealityModelProps, FeatureAppearance, OrbitGtBlobProps, RealityDataProvider, RealityDataSourceKey,
 } from "@bentley/imodeljs-common";
 import { AccessToken } from "@bentley/itwin-client";
 import { RealityData, RealityDataClient } from "@bentley/reality-data-client";
@@ -46,6 +46,8 @@ export class ContextRealityModelState extends ContextRealityModel {
   private readonly _treeRef: RealityModelTileTree.Reference;
   /** The iModel with which the reality model is associated. */
   public readonly iModel: IModelConnection;
+  /** The reality data source key with which the reality model is associated. */
+  public readonly rdSourceKey: RealityDataSourceKey;
 
   /** @internal */
   public constructor(props: ContextRealityModelProps, iModel: IModelConnection, displayStyle: DisplayStyleState) {
@@ -54,14 +56,14 @@ export class ContextRealityModelState extends ContextRealityModel {
     this._appearanceOverrides = props.appearanceOverrides ? FeatureAppearance.fromJSON(props.appearanceOverrides) : undefined;
     const provider = (undefined === props.orbitGtBlob) ? RealityDataProvider.ContextShare : RealityDataProvider.ContextShareOrbitGt;
     // TODO: &&Bed: use provider from key to select proper realityTileTree
-    const rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.tilesetUrl,provider);
+    this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.tilesetUrl,provider);
     const useOrbitGtTileTreeReference = provider === RealityDataProvider.ContextShareOrbitGt;
 
     this._treeRef = (!useOrbitGtTileTreeReference) ?
       createRealityTileTreeReference({
         iModel,
         source: displayStyle,
-        rdSourceKey,
+        rdSourceKey: this.rdSourceKey,
         url: props.tilesetUrl,
         name: props.name,
         classifiers: this.classifiers,
@@ -70,7 +72,7 @@ export class ContextRealityModelState extends ContextRealityModel {
       createOrbitGtTileTreeReference({
         iModel,
         orbitGtBlob: props.orbitGtBlob!,
-        rdSourceKey,
+        rdSourceKey: this.rdSourceKey,
         name: props.name,
         classifiers: this.classifiers,
         source: displayStyle,

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -9,7 +9,7 @@
 import { GuidString, Id64String } from "@bentley/bentleyjs-core";
 import { Angle } from "@bentley/geometry-core";
 import {
-  CartographicRange, ContextRealityModel, ContextRealityModelProps, FeatureAppearance, OrbitGtBlobProps, RealityDataProvider, RealityDataSourceKey,
+  CartographicRange, ContextRealityModel, ContextRealityModelProps, FeatureAppearance, OrbitGtBlobProps, RealityDataFormat, RealityDataProvider, RealityDataSourceKey,
 } from "@bentley/imodeljs-common";
 import { AccessToken } from "@bentley/itwin-client";
 import { RealityData, RealityDataClient } from "@bentley/reality-data-client";
@@ -57,13 +57,13 @@ export class ContextRealityModelState extends ContextRealityModel {
     if (undefined === props.orbitGtBlob) {
       this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.tilesetUrl);
     } else {
-      const provider = RealityDataProvider.ContextShareOrbitGt;
+      const provider = RealityDataProvider.ContextShare;
       if (props.orbitGtBlob.rdsUrl)
         this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.rdsUrl,provider);
       else
         this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.blobFileName,provider);
     }
-    const useOrbitGtTileTreeReference = this.rdSourceKey.provider === RealityDataProvider.ContextShareOrbitGt;
+    const useOrbitGtTileTreeReference = this.rdSourceKey.format === RealityDataFormat.OPC;
     this._treeRef = (!useOrbitGtTileTreeReference) ?
       createRealityTileTreeReference({
         iModel,

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -58,10 +58,11 @@ export class ContextRealityModelState extends ContextRealityModel {
       this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.tilesetUrl);
     } else {
       const provider = RealityDataProvider.ContextShare;
+      const format = RealityDataFormat.OPC;
       if (props.orbitGtBlob.rdsUrl)
-        this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.rdsUrl,provider);
+        this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.rdsUrl,provider, format);
       else
-        this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.blobFileName,provider);
+        this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.blobFileName,provider, format);
     }
     const useOrbitGtTileTreeReference = this.rdSourceKey.format === RealityDataFormat.OPC;
     this._treeRef = (!useOrbitGtTileTreeReference) ?

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -47,18 +47,23 @@ export class ContextRealityModelState extends ContextRealityModel {
   /** The iModel with which the reality model is associated. */
   public readonly iModel: IModelConnection;
   /** The reality data source key with which the reality model is associated. */
-  public readonly rdSourceKey: RealityDataSourceKey;
+  public override readonly rdSourceKey: RealityDataSourceKey;
 
   /** @internal */
   public constructor(props: ContextRealityModelProps, iModel: IModelConnection, displayStyle: DisplayStyleState) {
     super(props);
     this.iModel = iModel;
     this._appearanceOverrides = props.appearanceOverrides ? FeatureAppearance.fromJSON(props.appearanceOverrides) : undefined;
-    const provider = (undefined === props.orbitGtBlob) ? RealityDataProvider.ContextShare : RealityDataProvider.ContextShareOrbitGt;
-    // TODO: &&Bed: use provider from key to select proper realityTileTree
-    this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.tilesetUrl,provider);
-    const useOrbitGtTileTreeReference = provider === RealityDataProvider.ContextShareOrbitGt;
-
+    if (undefined === props.orbitGtBlob) {
+      this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.tilesetUrl);
+    } else {
+      const provider = RealityDataProvider.ContextShareOrbitGt;
+      if (props.orbitGtBlob.rdsUrl)
+        this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.rdsUrl,provider);
+      else
+        this.rdSourceKey = props.rdSourceKey ? props.rdSourceKey : RealityDataSource.createRealityDataSourceKeyFromUrl(props.orbitGtBlob.blobFileName,provider);
+    }
+    const useOrbitGtTileTreeReference = this.rdSourceKey.provider === RealityDataProvider.ContextShareOrbitGt;
     this._treeRef = (!useOrbitGtTileTreeReference) ?
       createRealityTileTreeReference({
         iModel,

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -19,7 +19,7 @@ import { IModelApp } from "./IModelApp";
 import { IModelConnection } from "./IModelConnection";
 import { SpatialModelState } from "./ModelState";
 import { PlanarClipMaskState } from "./PlanarClipMaskState";
-import { RealityDataSource } from "./RealityDataConnection";
+import { RealityDataSource } from "./RealityDataSource";
 import {
   createOrbitGtTileTreeReference, createRealityTileTreeReference, RealityModelTileTree, TileTreeReference,
 } from "./tile/internal";

--- a/core/frontend/src/FrontendLoggerCategory.ts
+++ b/core/frontend/src/FrontendLoggerCategory.ts
@@ -37,4 +37,10 @@ export enum FrontendLoggerCategory {
    * @alpha
    */
   FeatureTracking = "imodeljs-frontend.FeatureTracking",
+
+  /**
+   * The logger category used by RealityData
+   * @alpha
+   */
+  RealityData = "imodeljs-frontend.RealityData",
 }

--- a/core/frontend/src/ModelState.ts
+++ b/core/frontend/src/ModelState.ts
@@ -154,11 +154,11 @@ export abstract class GeometricModelState extends ModelState implements Geometri
       // Create rdSourceKey if not provided
       let rdSourceKeyOGT: RealityDataSourceKey;
       if (orbitGtBlob.rdsUrl) {
-        rdSourceKeyOGT = RealityDataSource.createRealityDataSourceKeyFromUrl(orbitGtBlob.rdsUrl, RealityDataProvider.ContextShare);
+        rdSourceKeyOGT = RealityDataSource.createRealityDataSourceKeyFromUrl(orbitGtBlob.rdsUrl, RealityDataProvider.ContextShare, RealityDataFormat.OPC);
       } else if (orbitGtBlob.containerName && Guid.isGuid(orbitGtBlob.containerName)) {
         rdSourceKeyOGT = {provider: RealityDataProvider.ContextShare, format: RealityDataFormat.OPC, id: orbitGtBlob.containerName };
       } else {
-        rdSourceKeyOGT = RealityDataSource.createFromBlobUrl(orbitGtBlob.blobFileName, RealityDataProvider.ContextShare);
+        rdSourceKeyOGT = RealityDataSource.createFromBlobUrl(orbitGtBlob.blobFileName, RealityDataProvider.ContextShare, RealityDataFormat.OPC);
       }
 
       return createOrbitGtTileTreeReference({

--- a/core/frontend/src/ModelState.ts
+++ b/core/frontend/src/ModelState.ts
@@ -9,7 +9,7 @@
 import { Guid, Id64, Id64String, JsonUtils } from "@bentley/bentleyjs-core";
 import { Point2d, Range3d } from "@bentley/geometry-core";
 import {
-  GeometricModel2dProps, GeometricModel3dProps, GeometricModelProps, ModelProps, RealityDataProvider, RealityDataSourceKey, RelatedElement, SpatialClassifiers,
+  GeometricModel2dProps, GeometricModel3dProps, GeometricModelProps, ModelProps, RealityDataFormat, RealityDataProvider, RealityDataSourceKey, RelatedElement, SpatialClassifiers,
 } from "@bentley/imodeljs-common";
 import { EntityState } from "./EntityState";
 import { HitDetail } from "./HitDetail";
@@ -119,7 +119,7 @@ export abstract class GeometricModelState extends ModelState implements Geometri
     const rdSourceKey = this.jsonProperties.rdSourceKey;
 
     if (rdSourceKey) {
-      const useOrbitGtTileTreeReference = rdSourceKey.provider === RealityDataProvider.ContextShareOrbitGt;
+      const useOrbitGtTileTreeReference = rdSourceKey.format === RealityDataFormat.OPC;
       const treeRef = (!useOrbitGtTileTreeReference) ?
         createRealityTileTreeReference({
           rdSourceKey,
@@ -154,11 +154,11 @@ export abstract class GeometricModelState extends ModelState implements Geometri
       // Create rdSourceKey if not provided
       let rdSourceKeyOGT: RealityDataSourceKey;
       if (orbitGtBlob.rdsUrl) {
-        rdSourceKeyOGT = RealityDataSource.createRealityDataSourceKeyFromUrl(orbitGtBlob.rdsUrl, RealityDataProvider.ContextShareOrbitGt);
+        rdSourceKeyOGT = RealityDataSource.createRealityDataSourceKeyFromUrl(orbitGtBlob.rdsUrl, RealityDataProvider.ContextShare);
       } else if (orbitGtBlob.containerName && Guid.isGuid(orbitGtBlob.containerName)) {
-        rdSourceKeyOGT = {provider: RealityDataProvider.ContextShareOrbitGt, realityDataId: orbitGtBlob.containerName };
+        rdSourceKeyOGT = {provider: RealityDataProvider.ContextShare, format: RealityDataFormat.OPC, id: orbitGtBlob.containerName };
       } else {
-        rdSourceKeyOGT = RealityDataSource.createFromBlobUrl(orbitGtBlob.blobFileName, RealityDataProvider.ContextShareOrbitGt);
+        rdSourceKeyOGT = RealityDataSource.createFromBlobUrl(orbitGtBlob.blobFileName, RealityDataProvider.ContextShare);
       }
 
       return createOrbitGtTileTreeReference({

--- a/core/frontend/src/ModelState.ts
+++ b/core/frontend/src/ModelState.ts
@@ -14,7 +14,7 @@ import {
 import { EntityState } from "./EntityState";
 import { HitDetail } from "./HitDetail";
 import { IModelConnection } from "./IModelConnection";
-import { RealityDataSource } from "./RealityDataConnection";
+import { RealityDataSource } from "./RealityDataSource";
 import { createOrbitGtTileTreeReference, createPrimaryTileTreeReference, createRealityTileTreeReference, TileTreeReference } from "./tile/internal";
 import { ViewState } from "./ViewState";
 

--- a/core/frontend/src/RealityDataConnection.ts
+++ b/core/frontend/src/RealityDataConnection.ts
@@ -9,6 +9,10 @@ import { RealityData, RealityDataClient } from "@bentley/reality-data-client";
 import { AuthorizedFrontendRequestContext } from "./FrontendRequestContext";
 import { RealityDataSource, realityDataSourceKeyToString } from "./RealityDataSource";
 
+/**
+ * This interface provide methods used to access a reality data from ContextShare
+ * @alpha
+ */
 export interface IRealityDataConnection {
   getRealityData(): RealityData | undefined;
   getRealityDataType(): string | undefined;
@@ -16,6 +20,11 @@ export interface IRealityDataConnection {
   getSource(): RealityDataSource;
 }
 
+/**
+ * This class encapsulates access to a reality data from ContextShare
+ * There is a one to one relationship between a reality data and the instances of present class.
+ * @alpha
+ */
 class RealityDataConnection implements IRealityDataConnection {
   private _rd: RealityData | undefined;
   private _rdSource: RealityDataSource;
@@ -23,7 +32,10 @@ class RealityDataConnection implements IRealityDataConnection {
   private constructor(props: RealityDataSourceProps) {
     this._rdSource = RealityDataSource.fromProps(props);
   }
-
+  /**
+   * Create an instance of this class from a source key and iTwin context/
+   * @alpha
+   */
   public static async createFromSourceKey(sk: RealityDataSourceKey, iTwinId: GuidString | undefined): Promise<RealityDataConnection | undefined> {
     const props: RealityDataSourceProps = {sourceKey: sk};
     const rdConnection = new RealityDataConnection(props);
@@ -36,8 +48,10 @@ class RealityDataConnection implements IRealityDataConnection {
 
     return (tilesetUrl !== undefined) ? rdConnection : undefined;
   }
-
-  public async queryRealityData(iTwinId: GuidString | undefined) {
+  /**
+   * Query Reality Data from provider
+   */
+  private async queryRealityData(iTwinId: GuidString | undefined) {
     if (this._rdSource.isContextShare && !this._rd) {
       const token = await this._rdSource.getAccessToken();
       if (token && this._rdSource.realityDataId) {
@@ -47,22 +61,41 @@ class RealityDataConnection implements IRealityDataConnection {
       }
     }
   }
-
+  /**
+   * Returns Reality Data if available
+   */
   public getRealityData(): RealityData | undefined {
     return this._rd;
   }
-
+  /**
+   * Returns Reality Data type if available
+   */
   public getRealityDataType(): string | undefined {
     return this._rd?.type;
   }
+  /**
+   * This method returns the URL to obtain the Reality Data details from PW Context Share.
+   * Technically it should never be required as the RealityData object returned should have all the information to obtain the
+   * data.
+   * @param iTwinId id of associated iTwin project
+   * @returns string containing the URL to reality data for indicated tile.
+   */
   public async getServiceUrl(iTwinId: GuidString | undefined): Promise<string | undefined> {
     return this._rdSource.getServiceUrl(iTwinId);
   }
+  /**
+  * Returns the source implementation associated to this reality data connection
+  */
   public getSource(): RealityDataSource {
     return this._rdSource;
   }
 }
 
+/**
+ * This class manage reality data connection instance used to access reality data from ContextShare
+ * There will aways be only one reality data connection for a corresponding reality data source key
+ * @alpha
+ */
 export class RealityDataConnectionManager {
   private _realityDataConnections = new Map<string, IRealityDataConnection>();
   // Singleton implementation

--- a/core/frontend/src/RealityDataConnection.ts
+++ b/core/frontend/src/RealityDataConnection.ts
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { GuidString, Logger } from "@bentley/bentleyjs-core";
+import { RealityDataConnectionProps, RealityDataProvider, RealityDataSourceProps } from "@bentley/imodeljs-common";
+import { AccessToken } from "@bentley/itwin-client";
+import { RealityData, RealityDataClient } from "@bentley/reality-data-client";
+import { FrontendLoggerCategory } from "./FrontendLoggerCategory";
+import { AuthorizedFrontendRequestContext } from "./FrontendRequestContext";
+import { IModelApp } from "./IModelApp";
+
+export class RealityDataSource {
+  protected readonly _props: RealityDataSourceProps;
+  /** The URL that supplies the 3d tiles for displaying the reality model. */
+  public readonly provider: RealityDataProvider;
+  /** Identifier that can be used to elide a request to the reality data service. */
+  public readonly realityDataId?: string;
+  /** The iTwin id that identify the "context" for the provider. */
+  public readonly iTwinId?: GuidString;
+  /** The URL that supplies the 3d tiles for displaying the reality model. */
+  protected _tilesetUrl: string;
+  protected _isUrlResolved: boolean = false;
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  protected constructor(props: RealityDataSourceProps) {
+    this._props = props;
+    this.provider = props.provider;
+    this.realityDataId = props.realityDataId;
+    this.iTwinId = props.iTwinId;
+    this._tilesetUrl = props.tilesetUrl ?? "";
+    if (this.provider === RealityDataProvider.TilesetUrl)
+      this._isUrlResolved=true;
+  }
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  public static fromProps(props: RealityDataSourceProps): RealityDataSource {
+    return new RealityDataSource(props);
+  }
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  public static fromUrl(url: string): RealityDataSource {
+    const props: RealityDataSourceProps = {
+      provider: RealityDataProvider.TilesetUrl,
+      tilesetUrl: url,
+    };
+    return new RealityDataSource(props);
+  }
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  public toProps(): RealityDataSourceProps {
+    const props: RealityDataSourceProps = {
+      provider: this.provider,
+      realityDataId: this.realityDataId,
+      iTwinId: this.iTwinId,
+      tilesetUrl: this._tilesetUrl,
+    };
+    return props;
+  }
+  protected async getAccessToken(): Promise<AccessToken | undefined> {
+    if (!IModelApp.authorizationClient || !IModelApp.authorizationClient.hasSignedIn)
+      return undefined; // Not signed in
+    let accessToken: AccessToken;
+    try {
+      accessToken = await IModelApp.authorizationClient.getAccessToken();
+    } catch (error) {
+      return undefined;
+    }
+    return accessToken;
+  }
+  /**
+   * This method returns the URL to access the actual 3d tiles from the service provider.
+   * @returns string containing the URL to reality data.
+   */
+  public async getTilesetUrl(): Promise<string> {
+    // If url was not resolved - resolve it
+    if (this.provider === RealityDataProvider.ContextShare && !this._isUrlResolved && this.realityDataId) {
+      // we need to resolve tilesetURl from realityDataId and iTwinId
+      const client = new RealityDataClient();
+      try {
+        const accessToken = await this.getAccessToken();
+        if (accessToken) {
+          const authRequestContext = new AuthorizedFrontendRequestContext(accessToken);
+          authRequestContext.enter();
+          this._tilesetUrl = await client.getRealityDataUrl(authRequestContext, this.iTwinId, this.realityDataId);
+          this._isUrlResolved=true;
+        }
+      } catch (e) {
+        const errMsg = `Error getting URL from ContextShare using realityDataId=${this.realityDataId} and iTwinId=${this.iTwinId}`;
+        Logger.logError(FrontendLoggerCategory.RealityData, errMsg);
+      }
+    }
+    return this._tilesetUrl;
+  }
+
+  /**
+   * This method returns the URL to obtain the Reality Data details from PW Context Share.
+   * @returns string containing the URL to reality data.
+   */
+  public async getServiceUrl(): Promise<string> {
+    // If url was not resolved - resolve it
+    if (this.provider === RealityDataProvider.ContextShare && !this._isUrlResolved && this.realityDataId) {
+      // we need to resolve tilesetURl from realityDataId and iTwinId
+      const client = new RealityDataClient();
+      try {
+        const accessToken = await this.getAccessToken();
+        if (accessToken) {
+          const authRequestContext = new AuthorizedFrontendRequestContext(accessToken);
+          authRequestContext.enter();
+          this._tilesetUrl = await client.getRealityDataUrl(authRequestContext, this.iTwinId,this.realityDataId);
+          this._isUrlResolved=true;
+        }
+      } catch (e) {
+        const errMsg = `Error getting URL from ContextShare using realityDataId=${this.realityDataId} and iTwinId=${this.iTwinId}`;
+        Logger.logError(FrontendLoggerCategory.RealityData, errMsg);
+      }
+    }
+    return this._tilesetUrl;
+  }
+
+  public static equal(lhsProps: RealityDataSourceProps, rhsProps: RealityDataSourceProps): boolean {
+    if (lhsProps.iTwinId !== rhsProps.iTwinId)
+      return false;
+    if (lhsProps.provider !== rhsProps.provider)
+      return false;
+    if (lhsProps.realityDataId !== rhsProps.realityDataId)
+      return false;
+    if (lhsProps.tilesetUrl !== rhsProps.tilesetUrl)
+      return false;
+    return true;
+  }
+}
+
+export class RealityDataConnection extends RealityDataSource {
+  private _rd: RealityData | undefined;
+
+  private constructor(props: RealityDataSourceProps) {
+    super(props);
+  }
+
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  // public static override fromProps(props: RealityDataSourceProps | RealityDataConnectionProps): RealityDataConnection {
+  //   return new RealityDataConnection(props);
+  // }
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  public static override fromUrl(url: string): RealityDataConnection {
+    const props: RealityDataSourceProps = {
+      provider: RealityDataProvider.TilesetUrl,
+      tilesetUrl: url,
+    };
+    return new RealityDataConnection(props);
+  }
+  /** Create a new RealityDataConnection object from a set of properties.
+   * @param props JSON representation of the reality data source or RealityDataConnectionProps
+   */
+  public static async createFromProps(props: RealityDataSourceProps | RealityDataConnectionProps): Promise<RealityDataConnection | undefined>  {
+    const rdConnection = new RealityDataConnection(props);
+    let tilesetUrl: string | undefined;
+    try {
+      await rdConnection.queryRealityData();
+      tilesetUrl = await rdConnection.getTilesetUrl();
+    } catch (e) {
+    }
+
+    return (tilesetUrl !== undefined) ? rdConnection : undefined;
+  }
+  public static async createFromUrl(url: string): Promise<RealityDataConnection | undefined>  {
+    const rdConnection =  RealityDataConnection.fromUrl(url);
+    let tilesetUrl: string | undefined;
+    try {
+      await rdConnection.queryRealityData();
+      tilesetUrl = await rdConnection.getTilesetUrl();
+    } catch (e) {
+    }
+    return tilesetUrl ? rdConnection : undefined;
+  }
+
+  public async queryRealityData() {
+    if (this.provider === RealityDataProvider.ContextShare && this._rd === undefined) {
+      const token = await this.getAccessToken();
+      if (token && this.realityDataId) {
+        const client = new RealityDataClient();      // we need to resolve tilesetURl from realityDataId and iTwinId
+        const requestContext = new AuthorizedFrontendRequestContext(token);
+        this._rd = await client.getRealityData(requestContext,this.iTwinId, this.realityDataId);
+      }
+    }
+  }
+
+  public get realityData(): RealityData | undefined {
+    return this._rd;
+  }
+
+  public get realityDataType(): string | undefined {
+    return this._rd?.type;
+  }
+
+  /** Serialize a RealityDataConnection to JSON. The returned JSON can later be passed to [deserializeViewState] to reinstantiate the ViewState.
+   * @beta
+   */
+  public override toProps(): RealityDataConnectionProps {
+    const props: RealityDataConnectionProps = {
+      provider: this.provider,
+      realityDataId: this.realityDataId,
+      iTwinId: this.iTwinId,
+      realityDataType: this.realityDataType,
+      tilesetUrl: this._tilesetUrl,
+    };
+    return props;
+  }
+}

--- a/core/frontend/src/RealityDataConnection.ts
+++ b/core/frontend/src/RealityDataConnection.ts
@@ -3,155 +3,20 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Guid, GuidString, Logger } from "@bentley/bentleyjs-core";
-import { RealityDataProvider, RealityDataSourceContextShareKey, RealityDataSourceKey, RealityDataSourceProps, RealityDataSourceURLKey } from "@bentley/imodeljs-common";
-import { AccessToken } from "@bentley/itwin-client";
+import { GuidString } from "@bentley/bentleyjs-core";
+import { RealityDataSourceKey, RealityDataSourceProps } from "@bentley/imodeljs-common";
 import { RealityData, RealityDataClient } from "@bentley/reality-data-client";
-import { FrontendLoggerCategory } from "./FrontendLoggerCategory";
 import { AuthorizedFrontendRequestContext } from "./FrontendRequestContext";
-import { IModelApp } from "./IModelApp";
+import { RealityDataSource, realityDataSourceKeyToString } from "./RealityDataSource";
 
-export class RealityDataSource {
-  protected readonly _rdSourceKey: RealityDataSourceKey;
-  /** The URL that supplies the 3d tiles for displaying the reality model. */
-  public tilesetUrl: string | undefined;
-  public isUrlResolved: boolean = false;
-
-  /** Construct a new reality data source.
-   * @param props JSON representation of the reality data source
-   */
-  protected constructor(props: RealityDataSourceProps) {
-    this._rdSourceKey = props.sourceKey;
-    this.isUrlResolved=false;
-  }
-  public static createRealityDataSourceKeyFromUrl(tilesetUrl: string, inputProvider?: RealityDataProvider): RealityDataSourceKey {
-    if (tilesetUrl.includes("$CesiumIonAsset=")) {
-      const provider = inputProvider ? inputProvider : RealityDataProvider.CesiumIonAsset;
-      const cesiumIonAssetKey: RealityDataSourceURLKey = { provider, tilesetUrl };
-      return cesiumIonAssetKey;
-    }
-
-    // Try to extract realityDataId from URL and if not possible, use the url as the key
-    let attUrl: URL;
-    try {
-      attUrl = new URL(tilesetUrl);
-    } catch (e) {
-      // Not a valid URL and not equal, probably $cesiumAsset
-      const invalidUrlKey: RealityDataSourceURLKey = { provider: RealityDataProvider.TilesetUrl, tilesetUrl };
-      return invalidUrlKey;
-    }
-    // detect if it is a RDS url
-    const formattedUrl1 = attUrl.pathname.replace(/~2F/g, "/").replace(/\\/g, "/");
-    const urlParts1 = formattedUrl1.split("/").map((entry: string) => entry.replace(/%2D/g, "-"));
-    let partOffset1: number = 0;
-    urlParts1.find((value, index) => {
-      if (value === "Repositories") {
-        partOffset1 = index;
-        return true;
-      }
-      return false;
-    });
-    const isOPC = attUrl.pathname.match(".opc*") !== null;
-    const isRDSUrl = (urlParts1[partOffset1] === "Repositories") && (urlParts1[partOffset1 + 1].match("S3MXECPlugin--*") !== null) && (urlParts1[partOffset1 + 2] === "S3MX");
-    // Make sure the url to compare are REALITYMESH3DTILES url, otherwise, compare the url directly
-    if (isRDSUrl || isOPC) {
-      // Make sure the reality data id are the same
-      const guid1 = urlParts1.find(Guid.isGuid);
-      if (guid1 !== undefined) {
-        const provider = inputProvider ? inputProvider : isOPC ? RealityDataProvider.ContextShareOrbitGt : RealityDataProvider.ContextShare;
-        const contextShareKey: RealityDataSourceContextShareKey = { provider, realityDataId: guid1 };
-        return contextShareKey;
-      }
-    }
-    // default to tileSetUrl
-    const provider2 = inputProvider ? inputProvider : RealityDataProvider.TilesetUrl;
-    const urlKey: RealityDataSourceURLKey = { provider: provider2, tilesetUrl };
-    return urlKey;
-  }
-  public static createFromBlobUrl(blobUrl: string, inputProvider?: RealityDataProvider): RealityDataSourceKey {
-    const url = new URL(blobUrl);
-
-    // If we cannot interpret that url pass in parameter we just fallback to old implementation
-    if(!url.pathname)
-      return { provider: RealityDataProvider.TilesetUrl, tilesetUrl: blobUrl };
-
-    // const accountName   = url.hostname.split(".")[0];
-    const pathSplit     = url.pathname.split("/");
-    const containerName = pathSplit[1];
-    // const blobFileName  = `/${pathSplit[2]}`;
-    // const sasToken      = url.search.substr(1);
-    const isOPC = url.pathname.match(".opc*") !== null;
-    const provider = inputProvider ? inputProvider : isOPC ? RealityDataProvider.ContextShareOrbitGt : RealityDataProvider.ContextShare;
-    const contextShareKey: RealityDataSourceContextShareKey = { provider, realityDataId: containerName };
-    return contextShareKey;
-  }
-  /** Construct a new reality data source.
-   * @param props JSON representation of the reality data source
-   */
-  public static fromProps(props: RealityDataSourceProps): RealityDataSource {
-    return new RealityDataSource(props);
-  }
-  /** Construct a new reality data source.
-   * @param props JSON representation of the reality data source
-   */
-  public static fromUrl(url: string): RealityDataSource {
-    const sourceKey = RealityDataSource.createRealityDataSourceKeyFromUrl(url);
-    const props: RealityDataSourceProps = {
-      sourceKey,
-    };
-    return new RealityDataSource(props);
-  }
-
-  public get isContextShare() {
-    return (this._rdSourceKey.provider === RealityDataProvider.ContextShare ||
-            this._rdSourceKey.provider === RealityDataProvider.ContextShareOrbitGt);
-  }
-  public get realityDataId(): string | undefined {
-    const sourceKey = this._rdSourceKey as RealityDataSourceContextShareKey;
-    return sourceKey.realityDataId;
-  }
-  public async getAccessToken(): Promise<AccessToken | undefined> {
-    if (!IModelApp.authorizationClient || !IModelApp.authorizationClient.hasSignedIn)
-      return undefined; // Not signed in
-    let accessToken: AccessToken;
-    try {
-      accessToken = await IModelApp.authorizationClient.getAccessToken();
-    } catch (error) {
-      return undefined;
-    }
-    return accessToken;
-  }
-  /**
-   * This method returns the URL to access the actual 3d tiles from the service provider.
-   * @returns string containing the URL to reality data.
-   */
-  public async getServiceUrl(iTwinId: GuidString | undefined): Promise<string | undefined> {
-    // If url was not resolved - resolve it
-    if (this.isContextShare && !this.isUrlResolved) {
-      const rdSourceKey = this._rdSourceKey as RealityDataSourceContextShareKey;
-      // we need to resolve tilesetURl from realityDataId and iTwinId
-      const client = new RealityDataClient();
-      try {
-        const accessToken = await this.getAccessToken();
-        if (accessToken) {
-          const authRequestContext = new AuthorizedFrontendRequestContext(accessToken);
-          authRequestContext.enter();
-
-          this.tilesetUrl = await client.getRealityDataUrl(authRequestContext, iTwinId, rdSourceKey.realityDataId);
-          this.isUrlResolved=true;
-        }
-      } catch (e) {
-        const errMsg = `Error getting URL from ContextShare using realityDataId=${rdSourceKey.realityDataId} and iTwinId=${iTwinId}`;
-        Logger.logError(FrontendLoggerCategory.RealityData, errMsg);
-      }
-    } else if (this._rdSourceKey.provider === RealityDataProvider.TilesetUrl || this._rdSourceKey.provider === RealityDataProvider.CesiumIonAsset) {
-      const rdSourceKey = this._rdSourceKey as RealityDataSourceURLKey;
-      this.tilesetUrl = rdSourceKey.tilesetUrl;
-    }
-    return this.tilesetUrl;
-  }
+export interface IRealityDataConnection {
+  getRealityData(): RealityData | undefined;
+  getRealityDataType(): string | undefined;
+  getServiceUrl(iTwinId: GuidString | undefined): Promise<string | undefined>;
+  getSource(): RealityDataSource;
 }
-export class RealityDataConnection {
+
+class RealityDataConnection implements IRealityDataConnection {
   private _rd: RealityData | undefined;
   private _rdSource: RealityDataSource;
 
@@ -187,14 +52,38 @@ export class RealityDataConnection {
     }
   }
 
-  public get realityData(): RealityData | undefined {
+  public getRealityData(): RealityData | undefined {
     return this._rd;
   }
 
-  public get realityDataType(): string | undefined {
+  public getRealityDataType(): string | undefined {
     return this._rd?.type;
   }
   public async getServiceUrl(iTwinId: GuidString | undefined): Promise<string | undefined> {
     return this._rdSource.getServiceUrl(iTwinId);
+  }
+  public getSource(): RealityDataSource {
+    return this._rdSource;
+  }
+}
+
+export class RealityDataConnectionManager {
+  private _realityDataConnections = new Map<string, IRealityDataConnection>();
+  // Singleton implementation
+  private static _instance: RealityDataConnectionManager = new RealityDataConnectionManager();
+  public static get instance(): RealityDataConnectionManager {
+    return RealityDataConnectionManager._instance;
+  }
+  public async getFromSourceKey(rdSourceKey: RealityDataSourceKey, iTwinId: GuidString | undefined): Promise<IRealityDataConnection | undefined> {
+    // search to see if it was already created
+    const rdSourceKeyString = realityDataSourceKeyToString(rdSourceKey);
+    let rdConnection = this._realityDataConnections.get(rdSourceKeyString);
+    if (rdConnection)
+      return rdConnection;
+    // If not already in our list, create and add it to our list before returing it.
+    rdConnection = await RealityDataConnection.createFromSourceKey(rdSourceKey,  iTwinId);
+    if (rdConnection)
+      this._realityDataConnections.set(rdSourceKeyString,rdConnection);
+    return rdConnection;
   }
 }

--- a/core/frontend/src/RealityDataConnection.ts
+++ b/core/frontend/src/RealityDataConnection.ts
@@ -36,10 +36,6 @@ class RealityDataConnection implements IRealityDataConnection {
 
     return (tilesetUrl !== undefined) ? rdConnection : undefined;
   }
-  public static async createFromUrl(url: string, iTwinId: GuidString): Promise<RealityDataConnection | undefined>  {
-    const sourceKey = RealityDataSource.createRealityDataSourceKeyFromUrl(url);
-    return RealityDataConnection.createFromSourceKey(sourceKey, iTwinId);
-  }
 
   public async queryRealityData(iTwinId: GuidString | undefined) {
     if (this._rdSource.isContextShare && !this._rd) {

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -11,10 +11,16 @@ import { FrontendLoggerCategory } from "./FrontendLoggerCategory";
 import { AuthorizedFrontendRequestContext } from "./FrontendRequestContext";
 import { IModelApp } from "./IModelApp";
 
+/** Utility function to convert a RealityDataSourceKey into its string representation
+* @alpha
+*/
 export function realityDataSourceKeyToString(rdSourceKey: RealityDataSourceKey): string {
   return `${rdSourceKey.provider}:${rdSourceKey.format}:${rdSourceKey.id}:${rdSourceKey.iTwinId}`;
 }
 
+/** This class provides access to the reality data provider services.
+* @alpha
+*/
 export class RealityDataSource {
   public readonly rdSourceKey: RealityDataSourceKey;
   /** The URL that supplies the 3d tiles for displaying the reality model. */

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { Guid, GuidString, Logger } from "@bentley/bentleyjs-core";
+import { RealityDataProvider, RealityDataSourceContextShareKey, RealityDataSourceKey, RealityDataSourceProps, RealityDataSourceURLKey } from "@bentley/imodeljs-common";
+import { AccessToken } from "@bentley/itwin-client";
+import { RealityDataClient } from "@bentley/reality-data-client";
+import { FrontendLoggerCategory } from "./FrontendLoggerCategory";
+import { AuthorizedFrontendRequestContext } from "./FrontendRequestContext";
+import { IModelApp } from "./IModelApp";
+
+export function realityDataSourceKeyToString(rdSourceKey: RealityDataSourceKey): string {
+  const contextShareKey = rdSourceKey as RealityDataSourceContextShareKey;
+  if (contextShareKey) {
+    return `${contextShareKey.provider}:${contextShareKey.realityDataId}`;
+  }
+  const urlKey = rdSourceKey as RealityDataSourceURLKey;
+  if (urlKey) {
+    return `${urlKey.provider}:${urlKey.tilesetUrl}`;
+  }
+  return "undefined";
+}
+
+export class RealityDataSource {
+  public readonly rdSourceKey: RealityDataSourceKey;
+  /** The URL that supplies the 3d tiles for displaying the reality model. */
+  public tilesetUrl: string | undefined;
+  public isUrlResolved: boolean = false;
+
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  protected constructor(props: RealityDataSourceProps) {
+    this.rdSourceKey = props.sourceKey;
+    this.isUrlResolved=false;
+  }
+  public static createRealityDataSourceKeyFromUrl(tilesetUrl: string, inputProvider?: RealityDataProvider): RealityDataSourceKey {
+    if (tilesetUrl.includes("$CesiumIonAsset=")) {
+      const provider = inputProvider ? inputProvider : RealityDataProvider.CesiumIonAsset;
+      const cesiumIonAssetKey: RealityDataSourceURLKey = { provider, tilesetUrl };
+      return cesiumIonAssetKey;
+    }
+
+    // Try to extract realityDataId from URL and if not possible, use the url as the key
+    let attUrl: URL;
+    try {
+      attUrl = new URL(tilesetUrl);
+    } catch (e) {
+      // Not a valid URL and not equal, probably $cesiumAsset
+      const invalidUrlKey: RealityDataSourceURLKey = { provider: RealityDataProvider.TilesetUrl, tilesetUrl };
+      return invalidUrlKey;
+    }
+    // detect if it is a RDS url
+    const formattedUrl1 = attUrl.pathname.replace(/~2F/g, "/").replace(/\\/g, "/");
+    const urlParts1 = formattedUrl1.split("/").map((entry: string) => entry.replace(/%2D/g, "-"));
+    let partOffset1: number = 0;
+    urlParts1.find((value, index) => {
+      if (value === "Repositories") {
+        partOffset1 = index;
+        return true;
+      }
+      return false;
+    });
+    const isOPC = attUrl.pathname.match(".opc*") !== null;
+    const isRDSUrl = (urlParts1[partOffset1] === "Repositories") && (urlParts1[partOffset1 + 1].match("S3MXECPlugin--*") !== null) && (urlParts1[partOffset1 + 2] === "S3MX");
+    // Make sure the url to compare are REALITYMESH3DTILES url, otherwise, compare the url directly
+    if (isRDSUrl || isOPC) {
+      // Make sure the reality data id are the same
+      const guid1 = urlParts1.find(Guid.isGuid);
+      if (guid1 !== undefined) {
+        const provider = inputProvider ? inputProvider : isOPC ? RealityDataProvider.ContextShareOrbitGt : RealityDataProvider.ContextShare;
+        const contextShareKey: RealityDataSourceContextShareKey = { provider, realityDataId: guid1 };
+        return contextShareKey;
+      }
+    }
+    // default to tileSetUrl
+    const provider2 = inputProvider ? inputProvider : RealityDataProvider.TilesetUrl;
+    const urlKey: RealityDataSourceURLKey = { provider: provider2, tilesetUrl };
+    return urlKey;
+  }
+  public static createFromBlobUrl(blobUrl: string, inputProvider?: RealityDataProvider): RealityDataSourceKey {
+    const url = new URL(blobUrl);
+
+    // If we cannot interpret that url pass in parameter we just fallback to old implementation
+    if(!url.pathname)
+      return { provider: RealityDataProvider.TilesetUrl, tilesetUrl: blobUrl };
+
+    // const accountName   = url.hostname.split(".")[0];
+    const pathSplit     = url.pathname.split("/");
+    const containerName = pathSplit[1];
+    // const blobFileName  = `/${pathSplit[2]}`;
+    // const sasToken      = url.search.substr(1);
+    const isOPC = url.pathname.match(".opc*") !== null;
+    const provider = inputProvider ? inputProvider : isOPC ? RealityDataProvider.ContextShareOrbitGt : RealityDataProvider.ContextShare;
+    const contextShareKey: RealityDataSourceContextShareKey = { provider, realityDataId: containerName };
+    return contextShareKey;
+  }
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  public static fromProps(props: RealityDataSourceProps): RealityDataSource {
+    return new RealityDataSource(props);
+  }
+  /** Construct a new reality data source.
+   * @param props JSON representation of the reality data source
+   */
+  public static fromUrl(url: string): RealityDataSource {
+    const sourceKey = RealityDataSource.createRealityDataSourceKeyFromUrl(url);
+    const props: RealityDataSourceProps = {
+      sourceKey,
+    };
+    return new RealityDataSource(props);
+  }
+  public get isContextShare() {
+    return (this.rdSourceKey.provider === RealityDataProvider.ContextShare ||
+            this.rdSourceKey.provider === RealityDataProvider.ContextShareOrbitGt);
+  }
+  public get realityDataId(): string | undefined {
+    const sourceKey = this.rdSourceKey as RealityDataSourceContextShareKey;
+    return sourceKey.realityDataId;
+  }
+  public async getAccessToken(): Promise<AccessToken | undefined> {
+    if (!IModelApp.authorizationClient || !IModelApp.authorizationClient.hasSignedIn)
+      return undefined; // Not signed in
+    let accessToken: AccessToken;
+    try {
+      accessToken = await IModelApp.authorizationClient.getAccessToken();
+    } catch (error) {
+      return undefined;
+    }
+    return accessToken;
+  }
+  /**
+   * This method returns the URL to access the actual 3d tiles from the service provider.
+   * @returns string containing the URL to reality data.
+   */
+  public async getServiceUrl(iTwinId: GuidString | undefined): Promise<string | undefined> {
+    // If url was not resolved - resolve it
+    if (this.isContextShare && !this.isUrlResolved) {
+      const rdSourceKey = this.rdSourceKey as RealityDataSourceContextShareKey;
+      // we need to resolve tilesetURl from realityDataId and iTwinId
+      const client = new RealityDataClient();
+      try {
+        const accessToken = await this.getAccessToken();
+        if (accessToken) {
+          const authRequestContext = new AuthorizedFrontendRequestContext(accessToken);
+          authRequestContext.enter();
+
+          this.tilesetUrl = await client.getRealityDataUrl(authRequestContext, iTwinId, rdSourceKey.realityDataId);
+          this.isUrlResolved=true;
+        }
+      } catch (e) {
+        const errMsg = `Error getting URL from ContextShare using realityDataId=${rdSourceKey.realityDataId} and iTwinId=${iTwinId}`;
+        Logger.logError(FrontendLoggerCategory.RealityData, errMsg);
+      }
+    } else if (this.rdSourceKey.provider === RealityDataProvider.TilesetUrl || this.rdSourceKey.provider === RealityDataProvider.CesiumIonAsset) {
+      const rdSourceKey = this.rdSourceKey as RealityDataSourceURLKey;
+      this.tilesetUrl = rdSourceKey.tilesetUrl;
+    }
+    return this.tilesetUrl;
+  }
+}

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -28,10 +28,11 @@ export class RealityDataSource {
     this.rdSourceKey = props.sourceKey;
     this.isUrlResolved=false;
   }
-  public static createRealityDataSourceKeyFromUrl(tilesetUrl: string, inputProvider?: RealityDataProvider): RealityDataSourceKey {
+  public static createRealityDataSourceKeyFromUrl(tilesetUrl: string, inputProvider?: RealityDataProvider, inputFormat?: RealityDataFormat): RealityDataSourceKey {
+    let format = inputFormat ? inputFormat : RealityDataFormat.ThreeDTile;
     if (tilesetUrl.includes("$CesiumIonAsset=")) {
       const provider = inputProvider ? inputProvider : RealityDataProvider.CesiumIonAsset;
-      const cesiumIonAssetKey: RealityDataSourceKey = { provider, format:RealityDataFormat.ThreeDTile, id: tilesetUrl };
+      const cesiumIonAssetKey: RealityDataSourceKey = { provider, format, id: tilesetUrl };
       return cesiumIonAssetKey;
     }
 
@@ -41,7 +42,7 @@ export class RealityDataSource {
       attUrl = new URL(tilesetUrl);
     } catch (e) {
       // Not a valid URL and not equal, probably $cesiumAsset
-      const invalidUrlKey: RealityDataSourceKey = { provider: RealityDataProvider.TilesetUrl,  format: RealityDataFormat.ThreeDTile, id: tilesetUrl };
+      const invalidUrlKey: RealityDataSourceKey = { provider: RealityDataProvider.TilesetUrl,  format, id: tilesetUrl };
       return invalidUrlKey;
     }
     // detect if it is a RDS url
@@ -64,22 +65,23 @@ export class RealityDataSource {
       const guid1 = urlParts1.find(Guid.isGuid);
       if (guid1 !== undefined) {
         const provider = inputProvider ? inputProvider : RealityDataProvider.ContextShare;
-        const format = isOPC ? RealityDataFormat.OPC : RealityDataFormat.ThreeDTile;
+        format = inputFormat ? inputFormat : isOPC ? RealityDataFormat.OPC : RealityDataFormat.ThreeDTile;
         const contextShareKey: RealityDataSourceKey = { provider, format, id: guid1, iTwinId: projectId };
         return contextShareKey;
       }
     }
     // default to tileSetUrl
     const provider2 = inputProvider ? inputProvider : RealityDataProvider.TilesetUrl;
-    const urlKey: RealityDataSourceKey = { provider: provider2, format: RealityDataFormat.ThreeDTile, id: tilesetUrl };
+    const urlKey: RealityDataSourceKey = { provider: provider2, format, id: tilesetUrl };
     return urlKey;
   }
-  public static createFromBlobUrl(blobUrl: string, inputProvider?: RealityDataProvider): RealityDataSourceKey {
+  public static createFromBlobUrl(blobUrl: string, inputProvider?: RealityDataProvider, inputFormat?: RealityDataFormat): RealityDataSourceKey {
+    let format = inputFormat ? inputFormat : RealityDataFormat.ThreeDTile;
     const url = new URL(blobUrl);
 
     // If we cannot interpret that url pass in parameter we just fallback to old implementation
     if(!url.pathname)
-      return { provider: RealityDataProvider.TilesetUrl, format: RealityDataFormat.ThreeDTile, id: blobUrl };
+      return { provider: RealityDataProvider.TilesetUrl, format, id: blobUrl };
 
     // const accountName   = url.hostname.split(".")[0];
     const pathSplit     = url.pathname.split("/");
@@ -88,7 +90,7 @@ export class RealityDataSource {
     // const sasToken      = url.search.substr(1);
     const isOPC = url.pathname.match(".opc*") !== null;
     const provider = inputProvider ? inputProvider : RealityDataProvider.ContextShare;
-    const format = isOPC ? RealityDataFormat.OPC : RealityDataFormat.ThreeDTile;
+    format = isOPC ? RealityDataFormat.OPC : RealityDataFormat.ThreeDTile;
     const contextShareKey: RealityDataSourceKey = { provider, format, id: containerName };
     return contextShareKey;
   }
@@ -96,16 +98,6 @@ export class RealityDataSource {
    * @param props JSON representation of the reality data source
    */
   public static fromProps(props: RealityDataSourceProps): RealityDataSource {
-    return new RealityDataSource(props);
-  }
-  /** Construct a new reality data source.
-   * @param props JSON representation of the reality data source
-   */
-  public static fromUrl(url: string): RealityDataSource {
-    const sourceKey = RealityDataSource.createRealityDataSourceKeyFromUrl(url);
-    const props: RealityDataSourceProps = {
-      sourceKey,
-    };
     return new RealityDataSource(props);
   }
   public get isContextShare() {

--- a/core/frontend/src/imodeljs-frontend.ts
+++ b/core/frontend/src/imodeljs-frontend.ts
@@ -127,6 +127,7 @@ export * from "./BackgroundMapGeometry";
 export * from "./ViewCreator2d";
 export * from "./ViewCreator3d";
 export * from "./LocalhostIpcApp";
+export * from "./RealityDataSource";
 export * from "./RealityDataConnection";
 
 /** @docs-package-description

--- a/core/frontend/src/imodeljs-frontend.ts
+++ b/core/frontend/src/imodeljs-frontend.ts
@@ -127,6 +127,7 @@ export * from "./BackgroundMapGeometry";
 export * from "./ViewCreator2d";
 export * from "./ViewCreator3d";
 export * from "./LocalhostIpcApp";
+export * from "./RealityDataConnection";
 
 /** @docs-package-description
  * The imodeljs-frontend package always runs in a web browser. It contains classes for [querying iModels and showing views]($docs/learning/frontend/index.md).

--- a/core/frontend/src/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/tile/OrbitGtTileTree.ts
@@ -35,7 +35,7 @@ import { ViewingSpace } from "../ViewingSpace";
 import { Viewport } from "../Viewport";
 import {
   RealityModelTileTree, Tile, TileContent,
-  TileDrawArgs, TileLoadPriority, TileParams, TileRequest, TileTree, TileTreeOwner, TileTreeParams, TileTreeSupplier
+  TileDrawArgs, TileLoadPriority, TileParams, TileRequest, TileTree, TileTreeOwner, TileTreeParams, TileTreeSupplier,
 } from "./internal";
 import { TileUsageMarker } from "./TileUsageMarker";
 

--- a/core/frontend/src/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/tile/OrbitGtTileTree.ts
@@ -65,8 +65,6 @@ class OrbitGtTreeSupplier implements TileTreeSupplier {
     let cmp: number = 0;
     if (lhsSourceKey && rhsSourceKey) {
       cmp = compareStringsOrUndefined(lhsSourceKey.realityDataId, rhsSourceKey.realityDataId);
-      if (0 === cmp)
-        cmp = compareStringsOrUndefined(lhsSourceKey.iTwinId, rhsSourceKey.iTwinId);
     } else if (lhsSourceURLKey && rhsSourceURLKey) {
       cmp = compareStringsOrUndefined(lhsSourceURLKey.tilesetUrl, rhsSourceURLKey.tilesetUrl);
     }
@@ -463,7 +461,7 @@ export namespace OrbitGtTileTree {
         props.rdsUrl = await rdClient.getRealityDataUrl(authRequestContext, iModel.contextId, props.containerName);
       }
     } else {
-      props.rdsUrl = await rdConnection.getServiceUrl();
+      props.rdsUrl = await rdConnection.getServiceUrl(iModel.contextId);
     }
 
     // If props are now valid, return OK
@@ -475,7 +473,7 @@ export namespace OrbitGtTileTree {
   }
 
   export async function createOrbitGtTileTree(props: OrbitGtBlobProps, rdSourceKey: RealityDataSourceKey, iModel: IModelConnection, modelId: Id64String): Promise<TileTree | undefined> {
-    const rdConnection = await RealityDataConnection.createFromSourceKey(rdSourceKey);
+    const rdConnection = await RealityDataConnection.createFromSourceKey(rdSourceKey, iModel.contextId);
 
     if (await initializeOrbitGtBlobProps(props, rdConnection, iModel) === false)
       return undefined;

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -99,8 +99,6 @@ class RealityTreeSupplier implements TileTreeSupplier {
     let cmp: number = 0;
     if (lhsSourceKey && rhsSourceKey) {
       cmp = compareStringsOrUndefined(lhsSourceKey.realityDataId, rhsSourceKey.realityDataId);
-      if (0 === cmp)
-        cmp = compareStringsOrUndefined(lhsSourceKey.iTwinId, rhsSourceKey.iTwinId);
     } else if (lhsSourceURLKey && rhsSourceURLKey) {
       cmp = compareStringsOrUndefined(lhsSourceURLKey.tilesetUrl, rhsSourceURLKey.tilesetUrl);
     }
@@ -627,10 +625,10 @@ export namespace RealityModelTileTree {
   }
 
   export async function createRealityModelTileTree(rdSourceKey: RealityDataSourceKey, iModel: IModelConnection, modelId: Id64String, tilesetToDb: Transform | undefined): Promise<TileTree | undefined> {
-    const rdConnection = await RealityDataConnection.createFromSourceKey(rdSourceKey);
+    const rdConnection = await RealityDataConnection.createFromSourceKey(rdSourceKey, iModel.contextId);
     // If we can get a valid connection from sourceKey, returns the tile tree
     if (rdConnection) {
-      const url = await rdConnection.getServiceUrl();
+      const url = await rdConnection.getServiceUrl(iModel.contextId);
       if (url === undefined)
         return undefined;
       const props = await getTileTreeProps(url, tilesetToDb, iModel);


### PR DESCRIPTION
Generalize the way to attach a reality data by adding a RealityDataSourceKey to ContextRealityModelProps.
We will then resolve at runtime tilesetUrl from this key instead of using tilesetUrl/orbitGtBlob harcoded value for which the host and protocole could have changed after the attachment creation in iModel.
This can be use to attach OPC (intead of using orbitGtBlob) or any other reality data that was using tilesetUrl property.
This is a non-breaking change as the new property is optional but will take precedence over tilesetUrl and orbitGtBlob if present.
This is only an API change for now but might result into an iModel schema change if prove useful.


